### PR TITLE
fix(errors): use typed PURL errors

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,6 +1,7 @@
 import type { Package, Version, Dependency, Maintainer, URLBuilder } from './core/types.ts'
 import type { Client } from './core/client.ts'
 import { createFromPURL } from './core/purl.ts'
+import { InvalidPURLError } from './core/errors.ts'
 
 /** Fetch normalized package metadata from a PURL. */
 export async function fetchPackageFromPURL(purl: string, signal?: AbortSignal, client?: Client): Promise<Package> {
@@ -18,7 +19,7 @@ export async function fetchVersionsFromPURL(purl: string, signal?: AbortSignal, 
 export async function fetchDependenciesFromPURL(purl: string, signal?: AbortSignal, client?: Client): Promise<Dependency[]> {
   const [reg, name, version] = createFromPURL(purl, client)
   if (!version) {
-    throw new Error(`PURL must include a version for dependency lookup: ${purl}`)
+    throw new InvalidPURLError(purl, 'must include a version for dependency lookup')
   }
   return reg.fetchDependencies(name, version, signal)
 }

--- a/src/registries/packagist.ts
+++ b/src/registries/packagist.ts
@@ -9,7 +9,7 @@ import type {
   Version,
 } from '../core/types.ts'
 import { register } from '../core/registry.ts'
-import { HTTPError, NotFoundError } from '../core/errors.ts'
+import { HTTPError, NotFoundError, InvalidPURLError } from '../core/errors.ts'
 import { combineLicenses } from '../core/license.ts'
 import { normalizeRepositoryURL } from '../core/repository.ts'
 
@@ -263,7 +263,7 @@ class PackagistRegistry implements Registry {
   private parseName(name: string): [string, string] {
     const parts = name.split('/')
     if (parts.length !== 2) {
-      throw new Error(`Invalid Composer package name: ${name}`)
+      throw new InvalidPURLError(name, 'invalid Composer package name, expected "vendor/package" format')
     }
     return [parts[0]!, parts[1]!]
   }

--- a/src/registries/packagist.ts
+++ b/src/registries/packagist.ts
@@ -262,8 +262,8 @@ class PackagistRegistry implements Registry {
   /** Parse "vendor/package" format. */
   private parseName(name: string): [string, string] {
     const parts = name.split('/')
-    if (parts.length !== 2) {
-      throw new InvalidPURLError(name, 'invalid Composer package name, expected "vendor/package" format')
+    if (parts.length !== 2 || !parts[0] || !parts[1]) {
+      throw new InvalidPURLError(`pkg:composer/${name}`, 'invalid Composer package name, expected "vendor/package" format')
     }
     return [parts[0]!, parts[1]!]
   }

--- a/test/unit/helpers.test.ts
+++ b/test/unit/helpers.test.ts
@@ -1,5 +1,7 @@
 import type { Package, Version, URLBuilder } from '../../src/core/types.ts'
-import { selectVersion, resolveDocsUrl, resolveReadmeUrl } from '../../src/helpers.ts'
+import { selectVersion, resolveDocsUrl, resolveReadmeUrl, fetchDependenciesFromPURL } from '../../src/helpers.ts'
+import { InvalidPURLError } from '../../src/core/errors.ts'
+import '../../src/registries/index.ts'
 
 function version(num: string, status: '' | 'yanked' | 'deprecated' | 'retracted' = '', date = '2024-01-01T00:00:00Z'): Version {
   return {
@@ -151,5 +153,17 @@ describe('resolveReadmeUrl', () => {
   it('uses package name for URL construction', () => {
     const p = pkg({ name: 'serde' })
     expect(resolveReadmeUrl(p, stubUrls, '1.0.220')).toBe('https://readme.example.com/serde/1.0.220')
+  })
+})
+
+describe('fetchDependenciesFromPURL', () => {
+  it('throws InvalidPURLError when PURL has no version', async () => {
+    await expect(fetchDependenciesFromPURL('pkg:npm/lodash')).rejects.toThrow(InvalidPURLError)
+  })
+
+  it('includes PURL string in InvalidPURLError', async () => {
+    await expect(fetchDependenciesFromPURL('pkg:npm/lodash')).rejects.toThrow(
+      /must include a version/
+    )
   })
 })

--- a/test/unit/helpers.test.ts
+++ b/test/unit/helpers.test.ts
@@ -162,8 +162,7 @@ describe('fetchDependenciesFromPURL', () => {
   })
 
   it('includes PURL string in InvalidPURLError', async () => {
-    await expect(fetchDependenciesFromPURL('pkg:npm/lodash')).rejects.toThrow(
-      /must include a version/
-    )
+    const purl = 'pkg:npm/lodash'
+    await expect(fetchDependenciesFromPURL(purl)).rejects.toThrow(purl)
   })
 })


### PR DESCRIPTION
`fetchDependenciesFromPURL` and Packagist's `parseName` were throwing plain `new Error()` instead of `InvalidPURLError`. The CLI catches `InvalidPURLError` specifically to show a helpful message with examples, so these two just printed a raw stack trace.

- `src/helpers.ts` - throw `InvalidPURLError` when PURL has no version
- `src/registries/packagist.ts` - throw `InvalidPURLError` for malformed Composer names
- `test/unit/helpers.test.ts` - two tests for the version-missing case

252/252 pass, typecheck clean.

Closes #7