### PR TITLE
feat(cli): show docs link in info output

### DIFF
--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -1,6 +1,37 @@
+import type { Package, Registry } from '../core/types.ts'
 import { defineCommand } from 'citty'
 import consola from 'consola'
+import { resolveDocsUrl } from '../helpers.ts'
 import { sharedArgs, resolvePURL, withErrorHandling } from './shared.ts'
+
+export function outputPackageInfo(pkg: Package, name: string, reg: Registry): void {
+  const urls = reg.urls()
+  const registryUrl = urls.registry(name)
+  const docsUrl = resolveDocsUrl(pkg, urls, pkg.latestVersion || undefined)
+  const showDocs = Boolean(docsUrl)
+    && docsUrl !== pkg.homepage
+    && docsUrl !== pkg.repository
+    && docsUrl !== registryUrl
+
+  consola.log('')
+  consola.log(`  \x1b[1m\x1b[36m${pkg.name}\x1b[0m${pkg.latestVersion ? `\x1b[90m@${pkg.latestVersion}\x1b[0m` : ''}`)
+  if (pkg.description) {
+    consola.log(`  ${pkg.description}`)
+  }
+  consola.log('')
+
+  if (pkg.licenses) consola.log(`  \x1b[90mLicense:\x1b[0m    ${pkg.licenses}`)
+  if (pkg.repository) consola.log(`  \x1b[90mRepository:\x1b[0m ${pkg.repository}`)
+  if (pkg.homepage) consola.log(`  \x1b[90mHomepage:\x1b[0m   ${pkg.homepage}`)
+  if (showDocs) consola.log(`  \x1b[90mDocs:\x1b[0m       ${docsUrl}`)
+  consola.log(`  \x1b[90mRegistry:\x1b[0m   ${registryUrl}`)
+  if (pkg.keywords.length > 0) {
+    consola.log(`  \x1b[90mKeywords:\x1b[0m   ${pkg.keywords.join(', ')}`)
+  }
+  if (pkg.namespace) consola.log(`  \x1b[90mNamespace:\x1b[0m  ${pkg.namespace}`)
+  consola.log(`  \x1b[90mEcosystem:\x1b[0m  ${reg.ecosystem()}`)
+  consola.log('')
+}
 
 export default defineCommand({
   meta: {
@@ -25,25 +56,7 @@ export default defineCommand({
         return
       }
 
-      const urls = reg.urls()
-
-      consola.log('')
-      consola.log(`  \x1b[1m\x1b[36m${pkg.name}\x1b[0m${pkg.latestVersion ? `\x1b[90m@${pkg.latestVersion}\x1b[0m` : ''}`)
-      if (pkg.description) {
-        consola.log(`  ${pkg.description}`)
-      }
-      consola.log('')
-
-      if (pkg.licenses) consola.log(`  \x1b[90mLicense:\x1b[0m    ${pkg.licenses}`)
-      if (pkg.repository) consola.log(`  \x1b[90mRepository:\x1b[0m ${pkg.repository}`)
-      if (pkg.homepage) consola.log(`  \x1b[90mHomepage:\x1b[0m   ${pkg.homepage}`)
-      consola.log(`  \x1b[90mRegistry:\x1b[0m   ${urls.registry(name)}`)
-      if (pkg.keywords.length > 0) {
-        consola.log(`  \x1b[90mKeywords:\x1b[0m   ${pkg.keywords.join(', ')}`)
-      }
-      if (pkg.namespace) consola.log(`  \x1b[90mNamespace:\x1b[0m  ${pkg.namespace}`)
-      consola.log(`  \x1b[90mEcosystem:\x1b[0m  ${reg.ecosystem()}`)
-      consola.log('')
+      outputPackageInfo(pkg, name, reg)
     })
   },
 })

--- a/test/unit/info-command.test.ts
+++ b/test/unit/info-command.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import consola from 'consola'
+import type { Package, Registry } from '../../src/core/types.ts'
+import { outputPackageInfo } from '../../src/commands/info.ts'
+
+function createPackage(overrides: Partial<Package> = {}): Package {
+  return {
+    name: 'serde',
+    description: 'Serialization framework',
+    homepage: '',
+    documentation: '',
+    repository: '',
+    licenses: 'MIT OR Apache-2.0',
+    keywords: [],
+    namespace: '',
+    latestVersion: '1.0.220',
+    metadata: {},
+    ...overrides,
+  }
+}
+
+function createRegistry(registryUrl: string, docsUrl: string): Registry {
+  return {
+    ecosystem: () => 'cargo',
+    fetchPackage: async () => createPackage(),
+    fetchVersions: async () => [],
+    fetchDependencies: async () => [],
+    fetchMaintainers: async () => [],
+    urls: () => ({
+      registry: () => registryUrl,
+      download: () => '',
+      documentation: () => docsUrl,
+      readme: () => '',
+      purl: () => '',
+    }),
+  }
+}
+
+function loggedLines(log: ReturnType<typeof vi.spyOn>): string[] {
+  return log.mock.calls.map(([message]) => String(message))
+}
+
+describe('outputPackageInfo', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('prints docs when documentation url adds new information', () => {
+    const log = vi.spyOn(consola, 'log').mockImplementation(() => undefined)
+    const pkg = createPackage({
+      homepage: 'https://serde.rs',
+      documentation: 'https://docs.rs/serde',
+      repository: 'https://github.com/serde-rs/serde',
+    })
+
+    outputPackageInfo(pkg, 'serde', createRegistry('https://crates.io/crates/serde', 'https://docs.rs/serde/1.0.220'))
+
+    expect(loggedLines(log)).toContain('  \x1b[90mDocs:\x1b[0m       https://docs.rs/serde')
+  })
+
+  it('skips docs when the resolved url falls back to homepage', () => {
+    const log = vi.spyOn(consola, 'log').mockImplementation(() => undefined)
+    const pkg = createPackage({
+      name: 'requests',
+      homepage: 'https://requests.readthedocs.io',
+      latestVersion: '2.32.0',
+    })
+
+    outputPackageInfo(pkg, 'requests', createRegistry('https://pypi.org/project/requests', 'https://pypi.org/project/requests'))
+
+    expect(loggedLines(log).some(line => line.includes('Docs:'))).toBe(false)
+  })
+
+  it('skips docs when the fallback matches the registry page', () => {
+    const log = vi.spyOn(consola, 'log').mockImplementation(() => undefined)
+    const pkg = createPackage({
+      name: 'lodash',
+      latestVersion: '4.17.21',
+      licenses: 'MIT',
+    })
+
+    outputPackageInfo(pkg, 'lodash', createRegistry('https://www.npmjs.com/package/lodash', 'https://www.npmjs.com/package/lodash'))
+
+    expect(loggedLines(log).some(line => line.includes('Docs:'))).toBe(false)
+  })
+
+  it('skips docs when documentation matches repository', () => {
+    const log = vi.spyOn(consola, 'log').mockImplementation(() => undefined)
+    const pkg = createPackage({
+      documentation: 'https://github.com/serde-rs/serde',
+      repository: 'https://github.com/serde-rs/serde',
+    })
+
+    outputPackageInfo(pkg, 'serde', createRegistry('https://crates.io/crates/serde', 'https://docs.rs/serde/1.0.220'))
+
+    expect(loggedLines(log).some(line => line.includes('Docs:'))).toBe(false)
+  })
+})


### PR DESCRIPTION
`regxa info` wasn't showing the docs link when it pointed somewhere different from homepage, repo, or registry. Hooked it up to the existing `resolveDocsUrl()` helper so the CLI uses the same fallback logic as the library API.

Added tests for the deduplication - docs only shows when it's actually a distinct URL.

Verification: `pnpm vitest run test/unit/info-command.test.ts`, `pnpm test:run`, `pnpm typecheck`, `pnpm build`