### PR TITLE
feat: add AI SDK package tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ regxa fills that gap. One `fetchPackage` call, same response shape, regardless o
 pnpm add regxa
 ```
 
+For the AI SDK tool (`regxa/ai` subpath), also install `ai` and `zod`:
+
+```bash
+pnpm add ai zod
+```
+
 ## Quick start
 
 ### API
@@ -68,6 +74,31 @@ regxa deps alpm/aur/paru
 ```
 
 Add `--json` for machine-readable output, `--no-cache` to skip the cache.
+
+### AI SDK tool
+
+`regxa/ai` exports a ready-made tool for AI SDK apps:
+
+```ts
+import { generateText } from 'ai'
+import { packageTool } from 'regxa/ai'
+
+const { text } = await generateText({
+  model: yourModel,
+  tools: { packageRegistry: packageTool },
+  prompt: 'Show me the latest metadata for pkg:npm/lodash and then list its maintainers.',
+})
+```
+
+The tool supports these operations through one input schema:
+
+```ts
+// { operation: 'package', purl: 'pkg:npm/lodash' }
+// { operation: 'versions', purl: 'pkg:cargo/serde' }
+// { operation: 'dependencies', purl: 'pkg:pypi/flask@3.1.1' }
+// { operation: 'maintainers', purl: 'pkg:gem/rails' }
+// { operation: 'bulk-packages', purls: ['pkg:npm/lodash', 'pkg:cargo/serde'], concurrency?: number }
+```
 
 ## Registries
 

--- a/build.config.ts
+++ b/build.config.ts
@@ -6,6 +6,7 @@ export default defineBuildConfig({
       type: 'bundle',
       input: [
         './src/index.ts',
+        './src/ai.ts',
         './src/types.ts',
         './src/core/index.ts',
         './src/registries/index.ts',

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
       "types": "./dist/index.d.mts",
       "import": "./dist/index.mjs"
     },
+    "./ai": {
+      "types": "./dist/ai.d.mts",
+      "import": "./dist/ai.mjs"
+    },
     "./registries": {
       "types": "./dist/registries/index.d.mts",
       "import": "./dist/registries/index.mjs"
@@ -60,15 +64,29 @@
   ],
   "devDependencies": {
     "@types/node": "^25.3.0",
+    "ai": "^6.0.116",
     "changelogen": "^0.6.2",
     "obuild": "^0.4.31",
     "typescript": "^5.8.3",
-    "vitest": "^4.0.0"
+    "vitest": "^4.0.0",
+    "zod": "^4.3.6"
   },
   "dependencies": {
     "citty": "^0.2.1",
     "consola": "^3.4.2",
     "ofetch": "^1.5.1",
     "unstorage": "^1.17.4"
+  },
+  "peerDependencies": {
+    "ai": "^6.0.116",
+    "zod": "^4.3.6"
+  },
+  "peerDependenciesMeta": {
+    "ai": {
+      "optional": true
+    },
+    "zod": {
+      "optional": true
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@types/node':
         specifier: ^25.3.0
         version: 25.3.0
+      ai:
+        specifier: ^6.0.116
+        version: 6.0.116(zod@4.3.6)
       changelogen:
         specifier: ^0.6.2
         version: 0.6.2
@@ -35,9 +38,28 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.0
-        version: 4.0.18(@types/node@25.3.0)(jiti@2.6.1)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
 
 packages:
+
+  '@ai-sdk/gateway@3.0.66':
+    resolution: {integrity: sha512-SIQ0YY0iMuv+07HLsZ+bB990zUJ6S4ujORAh+Jv1V2KGNn73qQKnGO0JBk+w+Res8YqOFSycwDoWcFlQrVxS4A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.19':
+    resolution: {integrity: sha512-3eG55CrSWCu2SXlqq2QCsFjo3+E7+Gmg7i/oRVoSZzIodTuDSfLb3MRje67xE9RFea73Zao7Lm4mADIfUETKGg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@3.0.8':
+    resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
+    engines: {node: '>=18'}
 
   '@babel/generator@8.0.0-rc.1':
     resolution: {integrity: sha512-3ypWOOiC4AYHKr8vYRVtWtWmyvcoItHtVqF8paFax+ydpmUdPsJpLBkBBs5ItmhdrwC3a0ZSqqFAdzls4ODP3w==}
@@ -240,6 +262,10 @@ packages:
 
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
 
   '@oxc-project/types@0.114.0':
     resolution: {integrity: sha512-//nBfbzHQHvJs8oFIjv6coZ6uxQ4alLfiPe6D5vit6c4pmxATHHlVwgB1k+Hv4yoAMyncdxgRBF5K4BYWUCzvA==}
@@ -487,6 +513,10 @@ packages:
   '@types/node@25.3.0':
     resolution: {integrity: sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==}
 
+  '@vercel/oidc@3.1.0':
+    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
+    engines: {node: '>= 20'}
+
   '@vitest/expect@4.0.18':
     resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
 
@@ -515,6 +545,12 @@ packages:
 
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
+
+  ai@6.0.116:
+    resolution: {integrity: sha512-7yM+cTmyRLeNIXwt4Vj+mrrJgVQ9RMIW5WO0ydoLoYkewIvsMcvUmqS4j2RJTUXaF1HphwmSKUMQ/HypNRGOmA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
@@ -646,6 +682,10 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -702,6 +742,9 @@ packages:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
     hasBin: true
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
@@ -1063,7 +1106,28 @@ packages:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
 
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
 snapshots:
+
+  '@ai-sdk/gateway@3.0.66(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
+      '@vercel/oidc': 3.1.0
+      zod: 4.3.6
+
+  '@ai-sdk/provider-utils@4.0.19(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 4.3.6
+
+  '@ai-sdk/provider@3.0.8':
+    dependencies:
+      json-schema: 0.4.0
 
   '@babel/generator@8.0.0-rc.1':
     dependencies:
@@ -1201,6 +1265,8 @@ snapshots:
       '@emnapi/runtime': 1.8.1
       '@tybys/wasm-util': 0.10.1
     optional: true
+
+  '@opentelemetry/api@1.9.0': {}
 
   '@oxc-project/types@0.114.0': {}
 
@@ -1344,6 +1410,8 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
+  '@vercel/oidc@3.1.0': {}
+
   '@vitest/expect@4.0.18':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -1382,6 +1450,14 @@ snapshots:
     dependencies:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
+
+  ai@6.0.116(zod@4.3.6):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.66(zod@4.3.6)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.3.6
 
   anymatch@3.1.3:
     dependencies:
@@ -1529,6 +1605,8 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  eventsource-parser@3.0.6: {}
+
   expect-type@1.3.0: {}
 
   exsolve@1.0.8: {}
@@ -1580,6 +1658,8 @@ snapshots:
   jiti@2.6.1: {}
 
   jsesc@3.1.0: {}
+
+  json-schema@0.4.0: {}
 
   lodash@4.17.23: {}
 
@@ -1861,7 +1941,7 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
 
-  vitest@4.0.18(@types/node@25.3.0)(jiti@2.6.1):
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1))
@@ -1884,6 +1964,7 @@ snapshots:
       vite: 7.3.1(@types/node@25.3.0)(jiti@2.6.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.0
       '@types/node': 25.3.0
     transitivePeerDependencies:
       - jiti
@@ -1906,3 +1987,5 @@ snapshots:
   wsl-utils@0.1.0:
     dependencies:
       is-wsl: 3.1.1
+
+  zod@4.3.6: {}

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -1,0 +1,56 @@
+import { tool } from 'ai'
+import { z } from 'zod'
+import {
+  bulkFetchPackages,
+  fetchDependenciesFromPURL,
+  fetchMaintainersFromPURL,
+  fetchPackageFromPURL,
+  fetchVersionsFromPURL,
+} from './helpers.ts'
+import './registries/index.ts'
+
+export const packageTool = tool({
+  description: 'Query package metadata from npm, PyPI, crates.io, RubyGems, Packagist, and Arch Linux using PURLs. Supports package info, versions, dependencies, maintainers, and bulk package metadata lookups.',
+  inputSchema: z.discriminatedUnion('operation', [
+    z.object({
+      operation: z.literal('package'),
+      purl: z.string().describe('Package PURL, for example pkg:npm/lodash or pkg:cargo/serde'),
+    }),
+    z.object({
+      operation: z.literal('versions'),
+      purl: z.string().describe('Package PURL, for example pkg:npm/lodash or pkg:cargo/serde'),
+    }),
+    z.object({
+      operation: z.literal('dependencies'),
+      purl: z.string().describe('Package PURL including a version, for example pkg:pypi/flask@3.1.1'),
+    }),
+    z.object({
+      operation: z.literal('maintainers'),
+      purl: z.string().describe('Package PURL, for example pkg:gem/rails or pkg:composer/laravel/framework'),
+    }),
+    z.object({
+      operation: z.literal('bulk-packages'),
+      purls: z.array(z.string()).min(1).max(50).describe('List of package PURLs to fetch in bulk.'),
+      concurrency: z.number().int().min(1).max(50).optional().describe('Maximum concurrent lookups. Defaults to 15.'),
+    }),
+  ]),
+  execute: async (input, { abortSignal }) => {
+    switch (input.operation) {
+      case 'package':
+        return fetchPackageFromPURL(input.purl, abortSignal)
+      case 'versions':
+        return fetchVersionsFromPURL(input.purl, abortSignal)
+      case 'dependencies':
+        return fetchDependenciesFromPURL(input.purl, abortSignal)
+      case 'maintainers':
+        return fetchMaintainersFromPURL(input.purl, abortSignal)
+      case 'bulk-packages': {
+        const results = await bulkFetchPackages(input.purls, {
+          concurrency: input.concurrency,
+          signal: abortSignal,
+        })
+        return Object.fromEntries(results)
+      }
+    }
+  },
+})

--- a/test/unit/ai-tool.test.ts
+++ b/test/unit/ai-tool.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const {
+  mockFetchPackageFromPURL,
+  mockFetchVersionsFromPURL,
+  mockFetchDependenciesFromPURL,
+  mockFetchMaintainersFromPURL,
+  mockBulkFetchPackages,
+} = vi.hoisted(() => ({
+  mockFetchPackageFromPURL: vi.fn(),
+  mockFetchVersionsFromPURL: vi.fn(),
+  mockFetchDependenciesFromPURL: vi.fn(),
+  mockFetchMaintainersFromPURL: vi.fn(),
+  mockBulkFetchPackages: vi.fn(),
+}))
+
+vi.mock('../../src/helpers.ts', () => ({
+  fetchPackageFromPURL: mockFetchPackageFromPURL,
+  fetchVersionsFromPURL: mockFetchVersionsFromPURL,
+  fetchDependenciesFromPURL: mockFetchDependenciesFromPURL,
+  fetchMaintainersFromPURL: mockFetchMaintainersFromPURL,
+  bulkFetchPackages: mockBulkFetchPackages,
+}))
+
+import { packageTool } from '../../src/ai.ts'
+
+describe('packageTool', () => {
+  it('has description and input schema', () => {
+    expect(packageTool.description).toBeTypeOf('string')
+    expect(packageTool.inputSchema).toBeDefined()
+    expect(packageTool.execute).toBeTypeOf('function')
+  })
+
+  it('fetches package metadata', async () => {
+    mockFetchPackageFromPURL.mockResolvedValueOnce({ name: 'lodash', latestVersion: '4.17.21' })
+
+    const result = await packageTool.execute!(
+      { operation: 'package', purl: 'pkg:npm/lodash' },
+      { toolCallId: 'call-1', messages: [] },
+    )
+
+    expect(mockFetchPackageFromPURL).toHaveBeenCalledWith('pkg:npm/lodash', undefined)
+    expect(result).toEqual({ name: 'lodash', latestVersion: '4.17.21' })
+  })
+
+  it('fetches versions', async () => {
+    mockFetchVersionsFromPURL.mockResolvedValueOnce([{ number: '1.0.0' }, { number: '2.0.0' }])
+
+    const result = await packageTool.execute!(
+      { operation: 'versions', purl: 'pkg:cargo/serde' },
+      { toolCallId: 'call-2', messages: [] },
+    )
+
+    expect(mockFetchVersionsFromPURL).toHaveBeenCalledWith('pkg:cargo/serde', undefined)
+    expect(result).toEqual([{ number: '1.0.0' }, { number: '2.0.0' }])
+  })
+
+  it('fetches dependencies', async () => {
+    mockFetchDependenciesFromPURL.mockResolvedValueOnce([{ name: 'click', requirements: '>=8.0' }])
+
+    const result = await packageTool.execute!(
+      { operation: 'dependencies', purl: 'pkg:pypi/flask@3.1.1' },
+      { toolCallId: 'call-3', messages: [] },
+    )
+
+    expect(mockFetchDependenciesFromPURL).toHaveBeenCalledWith('pkg:pypi/flask@3.1.1', undefined)
+    expect(result).toEqual([{ name: 'click', requirements: '>=8.0' }])
+  })
+
+  it('fetches maintainers', async () => {
+    mockFetchMaintainersFromPURL.mockResolvedValueOnce([{ login: 'dhh', role: 'author' }])
+
+    const result = await packageTool.execute!(
+      { operation: 'maintainers', purl: 'pkg:gem/rails' },
+      { toolCallId: 'call-4', messages: [] },
+    )
+
+    expect(mockFetchMaintainersFromPURL).toHaveBeenCalledWith('pkg:gem/rails', undefined)
+    expect(result).toEqual([{ login: 'dhh', role: 'author' }])
+  })
+
+  it('fetches bulk package metadata and serializes the map', async () => {
+    mockBulkFetchPackages.mockResolvedValueOnce(new Map([
+      ['pkg:npm/lodash', { name: 'lodash' }],
+      ['pkg:cargo/serde', { name: 'serde' }],
+    ]))
+
+    const result = await packageTool.execute!(
+      {
+        operation: 'bulk-packages',
+        purls: ['pkg:npm/lodash', 'pkg:cargo/serde'],
+        concurrency: 4,
+      },
+      { toolCallId: 'call-5', messages: [] },
+    )
+
+    expect(mockBulkFetchPackages).toHaveBeenCalledWith(
+      ['pkg:npm/lodash', 'pkg:cargo/serde'],
+      { concurrency: 4, signal: undefined },
+    )
+    expect(result).toEqual({
+      'pkg:npm/lodash': { name: 'lodash' },
+      'pkg:cargo/serde': { name: 'serde' },
+    })
+  })
+})


### PR DESCRIPTION
Right now if you want to use regxa from an AI agent, you end up wrapping the helpers yourself. This adds a `regxa/ai` export with a single `packageTool` that handles package info, versions, deps, maintainers, and bulk lookups through the existing helper layer.

README updated with AI usage docs, tests cover the operation routing.

Closes #12