### PR TITLE
chore: add oxlint, oxfmt and editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.{js,ts}]
+indent_style = space
+indent_size = 2
+
+[{package.json,*.yml,*.cjson}]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ permissions:
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 jobs:
   release:

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://unpkg.com/oxfmt/configuration_schema.json",
+  "ignorePatterns": []
+}

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://unpkg.com/oxlint/configuration_schema.json",
+  "plugins": ["unicorn", "typescript", "oxc"],
+  "rules": {},
+  "ignorePatterns": []
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,10 +5,12 @@
 **Branch:** main
 
 ## OVERVIEW
+
 regxa is an ESM-only TypeScript library + CLI that normalizes package metadata across npm, PyPI, crates.io, RubyGems, and Packagist using PURL-first APIs.
 The architecture is layered: `core` abstractions, per-ecosystem `registries`, optional `cache` decorator, and CLI `commands`.
 
 ## STRUCTURE
+
 ```text
 pkio/
 |- src/                # source modules and entrypoints
@@ -24,29 +26,32 @@ pkio/
 ```
 
 ## WHERE TO LOOK
-| Task | Location | Notes |
-|------|----------|-------|
-| Public API changes | `src/index.ts` | Main export surface used by package root `.` |
-| Add ecosystem support | `src/registries/*.ts` | Implement `Registry`, then register via side-effect import |
-| PURL behavior | `src/core/purl.ts` | Validation, normalization, parser/builder |
-| HTTP/retry behavior | `src/core/client.ts` | Retry status handling and timeout defaults |
-| Cache semantics | `src/cache/lockfile.ts` | TTL + integrity freshness gates |
-| CLI command behavior | `src/commands/*.ts`, `src/cli.ts` | Dynamic subcommand loading through citty |
-| Test updates | `test/unit/*.test.ts`, `test/e2e/smoke.test.ts` | Unit first; e2e for live registry checks |
-| Build/export wiring | `build.config.ts`, `package.json` | Entry points, exports, bin wiring |
+
+| Task                  | Location                                        | Notes                                                      |
+| --------------------- | ----------------------------------------------- | ---------------------------------------------------------- |
+| Public API changes    | `src/index.ts`                                  | Main export surface used by package root `.`               |
+| Add ecosystem support | `src/registries/*.ts`                           | Implement `Registry`, then register via side-effect import |
+| PURL behavior         | `src/core/purl.ts`                              | Validation, normalization, parser/builder                  |
+| HTTP/retry behavior   | `src/core/client.ts`                            | Retry status handling and timeout defaults                 |
+| Cache semantics       | `src/cache/lockfile.ts`                         | TTL + integrity freshness gates                            |
+| CLI command behavior  | `src/commands/*.ts`, `src/cli.ts`               | Dynamic subcommand loading through citty                   |
+| Test updates          | `test/unit/*.test.ts`, `test/e2e/smoke.test.ts` | Unit first; e2e for live registry checks                   |
+| Build/export wiring   | `build.config.ts`, `package.json`               | Entry points, exports, bin wiring                          |
 
 ## CODE MAP
-| Symbol | Type | Location | Refs | Role |
-|--------|------|----------|------|------|
-| `create` | function | `src/core/registry.ts` | high | Registry factory from ecosystem key |
-| `createCached` | function | `src/cache/index.ts` | medium | Decorates a registry with cache + lockfile |
-| `parsePURL` | function | `src/core/purl.ts` | high | Canonical parser for all PURL input |
-| `Client` | class | `src/core/client.ts` | high | Central HTTP behavior, retry, timeout |
-| `CachedRegistry` | class | `src/cache/cached-registry.ts` | medium | Cache wrapper implementing `Registry` |
-| `main` | constant command | `src/cli.ts` | medium | CLI root with subcommand routing |
-| `DEFAULT_TTL` | constant | `src/cache/lockfile.ts` | medium | Project-wide cache freshness policy |
+
+| Symbol           | Type             | Location                       | Refs   | Role                                       |
+| ---------------- | ---------------- | ------------------------------ | ------ | ------------------------------------------ |
+| `create`         | function         | `src/core/registry.ts`         | high   | Registry factory from ecosystem key        |
+| `createCached`   | function         | `src/cache/index.ts`           | medium | Decorates a registry with cache + lockfile |
+| `parsePURL`      | function         | `src/core/purl.ts`             | high   | Canonical parser for all PURL input        |
+| `Client`         | class            | `src/core/client.ts`           | high   | Central HTTP behavior, retry, timeout      |
+| `CachedRegistry` | class            | `src/cache/cached-registry.ts` | medium | Cache wrapper implementing `Registry`      |
+| `main`           | constant command | `src/cli.ts`                   | medium | CLI root with subcommand routing           |
+| `DEFAULT_TTL`    | constant         | `src/cache/lockfile.ts`        | medium | Project-wide cache freshness policy        |
 
 ## CONVENTIONS
+
 - ESM-only; TypeScript imports keep `.ts` extension style in source.
 - `tsc` is typecheck-only (`noEmit`); build artifacts come from `obuild`.
 - Public API is export-barrel-driven; avoid hidden side-channel exports.
@@ -54,6 +59,7 @@ pkio/
 - Tests use Vitest globals with `test/unit` and `test/e2e` split.
 
 ## ANTI-PATTERNS (THIS PROJECT)
+
 - Do not parse PURLs outside `src/core/purl.ts`; call `createFromPURL`/`parsePURL`.
 - Do not bypass `Client` for direct fetch logic in registries.
 - Do not duplicate retry/backoff constants outside `src/core/client.ts`.
@@ -61,11 +67,13 @@ pkio/
 - Do not add CommonJS output or `require` paths; package is ESM-first.
 
 ## UNIQUE STYLES
+
 - Side-effect ecosystem registration is intentional (`import 'regxa/registries'`).
 - `cache` is an optional decorator layer, not mandatory in core flows.
 - Bulk fetch helpers intentionally skip failed packages instead of failing all.
 
 ## COMMANDS
+
 ```bash
 pnpm typecheck
 pnpm build
@@ -75,6 +83,7 @@ pnpm release
 ```
 
 ## NOTES
+
 - Release workflow triggers on tags `v*` and publishes with `pnpm publish --no-git-checks`.
 - Node runtime floor is `>=22.6.0`; respect modern syntax assumptions.
 - Unit tests are broad; e2e smoke tests can be network-sensitive.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # Changelog
 
-
 ## v0.1.4
 
 [compare changes](https://github.com/oritwoen/regxa/compare/v0.1.2...v0.1.4)
@@ -25,24 +24,19 @@
 
 ## v0.1.2
 
-
 ### 🩹 Fixes
 
 - Fix npm publish — re-release under new version (0.1.1 burned by npm registry ghost)
-
 
 ### ❤️ Contributors
 
 - Oritwoen ([@oritwoen](https://github.com/oritwoen))
 
-
 ## v0.1.1
-
 
 ### 🏡 Chore
 
 - Init ([da6269f](https://github.com/oritwoen/regxa/commit/da6269f))
-
 
 ### ❤️ Contributors
 

--- a/README.md
+++ b/README.md
@@ -42,24 +42,24 @@ pnpm add ai zod
 ### API
 
 ```ts
-import { fetchPackageFromPURL } from 'regxa'
+import { fetchPackageFromPURL } from "regxa";
 
-const pkg = await fetchPackageFromPURL('pkg:npm/lodash')
+const pkg = await fetchPackageFromPURL("pkg:npm/lodash");
 
-console.log(pkg.name)          // "lodash"
-console.log(pkg.latestVersion) // "4.17.23"
-console.log(pkg.licenses)      // "MIT"
-console.log(pkg.repository)    // "https://github.com/lodash/lodash"
+console.log(pkg.name); // "lodash"
+console.log(pkg.latestVersion); // "4.17.23"
+console.log(pkg.licenses); // "MIT"
+console.log(pkg.repository); // "https://github.com/lodash/lodash"
 ```
 
 Works the same for any supported registry:
 
 ```ts
-await fetchPackageFromPURL('pkg:cargo/serde')
-await fetchPackageFromPURL('pkg:pypi/flask')
-await fetchPackageFromPURL('pkg:gem/rails')
-await fetchPackageFromPURL('pkg:composer/laravel/framework')
-await fetchPackageFromPURL('pkg:alpm/arch/pacman')
+await fetchPackageFromPURL("pkg:cargo/serde");
+await fetchPackageFromPURL("pkg:pypi/flask");
+await fetchPackageFromPURL("pkg:gem/rails");
+await fetchPackageFromPURL("pkg:composer/laravel/framework");
+await fetchPackageFromPURL("pkg:alpm/arch/pacman");
 ```
 
 ### CLI
@@ -81,14 +81,14 @@ Add `--json` for machine-readable output, `--no-cache` to skip the cache.
 `regxa/ai` exports a ready-made tool for AI SDK apps:
 
 ```ts
-import { generateText } from 'ai'
-import { packageTool } from 'regxa/ai'
+import { generateText } from "ai";
+import { packageTool } from "regxa/ai";
 
 const { text } = await generateText({
   model: yourModel,
   tools: { packageRegistry: packageTool },
-  prompt: 'Show me the latest metadata for pkg:npm/lodash and then list its maintainers.',
-})
+  prompt: "Show me the latest metadata for pkg:npm/lodash and then list its maintainers.",
+});
 ```
 
 The tool supports these operations through one input schema:
@@ -103,14 +103,14 @@ The tool supports these operations through one input schema:
 
 ## Registries
 
-| Ecosystem | PURL type | Registry |
-|-----------|-----------|----------|
-| npm | `pkg:npm/...` | registry.npmjs.org |
-| Cargo | `pkg:cargo/...` | crates.io |
-| PyPI | `pkg:pypi/...` | pypi.org |
-| RubyGems | `pkg:gem/...` | rubygems.org |
-| Packagist | `pkg:composer/...` | packagist.org |
-| Arch Linux | `pkg:alpm/...` | archlinux.org, aur.archlinux.org |
+| Ecosystem  | PURL type          | Registry                         |
+| ---------- | ------------------ | -------------------------------- |
+| npm        | `pkg:npm/...`      | registry.npmjs.org               |
+| Cargo      | `pkg:cargo/...`    | crates.io                        |
+| PyPI       | `pkg:pypi/...`     | pypi.org                         |
+| RubyGems   | `pkg:gem/...`      | rubygems.org                     |
+| Packagist  | `pkg:composer/...` | packagist.org                    |
+| Arch Linux | `pkg:alpm/...`     | archlinux.org, aur.archlinux.org |
 
 Scoped packages work as expected: `pkg:npm/%40vue/core` or `npm/@vue/core` in the CLI.
 
@@ -121,20 +121,22 @@ Arch Linux packages use a namespace: `pkg:alpm/arch/pacman` (or just `pkg:alpm/p
 ### PURL helpers
 
 ```ts
-import { fetchPackageFromPURL, fetchVersionsFromPURL, fetchDependenciesFromPURL, fetchMaintainersFromPURL, bulkFetchPackages } from 'regxa'
+import {
+  fetchPackageFromPURL,
+  fetchVersionsFromPURL,
+  fetchDependenciesFromPURL,
+  fetchMaintainersFromPURL,
+  bulkFetchPackages,
+} from "regxa";
 
 // Single lookups
-const pkg = await fetchPackageFromPURL('pkg:npm/lodash')
-const versions = await fetchVersionsFromPURL('pkg:cargo/serde')
-const deps = await fetchDependenciesFromPURL('pkg:pypi/flask@3.1.1')
-const maintainers = await fetchMaintainersFromPURL('pkg:gem/rails')
+const pkg = await fetchPackageFromPURL("pkg:npm/lodash");
+const versions = await fetchVersionsFromPURL("pkg:cargo/serde");
+const deps = await fetchDependenciesFromPURL("pkg:pypi/flask@3.1.1");
+const maintainers = await fetchMaintainersFromPURL("pkg:gem/rails");
 
 // Bulk - fetches up to 15 packages concurrently
-const packages = await bulkFetchPackages([
-  'pkg:npm/lodash',
-  'pkg:cargo/serde',
-  'pkg:pypi/flask',
-])
+const packages = await bulkFetchPackages(["pkg:npm/lodash", "pkg:cargo/serde", "pkg:pypi/flask"]);
 ```
 
 ### Direct registry access
@@ -142,13 +144,13 @@ const packages = await bulkFetchPackages([
 For more control, create a registry instance directly:
 
 ```ts
-import { create } from 'regxa'
-import 'regxa/registries' // registers all built-in ecosystems
+import { create } from "regxa";
+import "regxa/registries"; // registers all built-in ecosystems
 
-const npm = create('npm')
-const pkg = await npm.fetchPackage('lodash')
-const versions = await npm.fetchVersions('lodash')
-const deps = await npm.fetchDependencies('lodash', '4.17.21')
+const npm = create("npm");
+const pkg = await npm.fetchPackage("lodash");
+const versions = await npm.fetchVersions("lodash");
+const deps = await npm.fetchDependencies("lodash", "4.17.21");
 ```
 
 ### Cached registry
@@ -156,16 +158,16 @@ const deps = await npm.fetchDependencies('lodash', '4.17.21')
 Wrap any registry with caching:
 
 ```ts
-import { createCached } from 'regxa'
-import 'regxa/registries'
+import { createCached } from "regxa";
+import "regxa/registries";
 
-const npm = createCached('npm')
+const npm = createCached("npm");
 
 // First call hits the network and writes to cache
-const pkg = await npm.fetchPackage('lodash')
+const pkg = await npm.fetchPackage("lodash");
 
 // Second call reads from cache (if TTL hasn't expired)
-const same = await npm.fetchPackage('lodash')
+const same = await npm.fetchPackage("lodash");
 ```
 
 By default, regxa uses filesystem storage and follows platform cache conventions: `~/.cache/regxa` on Linux (XDG), `~/Library/Caches/regxa` on macOS, `%LOCALAPPDATA%\regxa\cache` on Windows. Override with `REGXA_CACHE_DIR` env var.
@@ -173,37 +175,39 @@ By default, regxa uses filesystem storage and follows platform cache conventions
 For edge/serverless runtimes, configure a custom unstorage driver (example: Cloudflare KV binding):
 
 ```ts
-import { configureStorage, createCached } from 'regxa'
-import { createStorage } from 'unstorage'
-import cloudflareKVBindingDriver from 'unstorage/drivers/cloudflare-kv-binding'
-import 'regxa/registries'
+import { configureStorage, createCached } from "regxa";
+import { createStorage } from "unstorage";
+import cloudflareKVBindingDriver from "unstorage/drivers/cloudflare-kv-binding";
+import "regxa/registries";
 
-configureStorage(createStorage({
-  driver: cloudflareKVBindingDriver({ binding: 'REGXA_CACHE' }),
-}))
+configureStorage(
+  createStorage({
+    driver: cloudflareKVBindingDriver({ binding: "REGXA_CACHE" }),
+  }),
+);
 
-const npm = createCached('npm')
-const pkg = await npm.fetchPackage('lodash')
+const npm = createCached("npm");
+const pkg = await npm.fetchPackage("lodash");
 ```
 
 ### PURL parsing
 
 ```ts
-import { parsePURL, buildPURL, fullName } from 'regxa'
+import { parsePURL, buildPURL, fullName } from "regxa";
 
-const parsed = parsePURL('pkg:npm/%40vue/core@3.5.0')
+const parsed = parsePURL("pkg:npm/%40vue/core@3.5.0");
 // { type: 'npm', namespace: '@vue', name: 'core', version: '3.5.0', qualifiers: {}, subpath: '' }
 
-fullName(parsed) // "@vue/core"
+fullName(parsed); // "@vue/core"
 
-buildPURL({ type: 'cargo', name: 'serde', version: '1.0.0' })
+buildPURL({ type: "cargo", name: "serde", version: "1.0.0" });
 // "pkg:cargo/serde@1.0.0"
 ```
 
 ### Types
 
 ```ts
-import type { Package, Version, Dependency, Maintainer, Registry, ParsedPURL } from 'regxa'
+import type { Package, Version, Dependency, Maintainer, Registry, ParsedPURL } from "regxa";
 ```
 
 ## CLI
@@ -212,34 +216,34 @@ import type { Package, Version, Dependency, Maintainer, Registry, ParsedPURL } f
 regxa <command> [options]
 ```
 
-| Command | Description |
-|---------|-------------|
-| `regxa info <purl>` | Package metadata (name, license, repo, latest version) |
-| `regxa versions <purl>` | List all published versions |
-| `regxa deps <purl>` | Dependencies for a specific version |
-| `regxa maintainers <purl>` | Package maintainers / authors |
-| `regxa cache status` | Show cache stats (entries, freshness) |
-| `regxa cache path` | Print cache directory path |
-| `regxa cache clear` | Remove all cached data |
-| `regxa cache prune` | Remove stale entries |
+| Command                    | Description                                            |
+| -------------------------- | ------------------------------------------------------ |
+| `regxa info <purl>`        | Package metadata (name, license, repo, latest version) |
+| `regxa versions <purl>`    | List all published versions                            |
+| `regxa deps <purl>`        | Dependencies for a specific version                    |
+| `regxa maintainers <purl>` | Package maintainers / authors                          |
+| `regxa cache status`       | Show cache stats (entries, freshness)                  |
+| `regxa cache path`         | Print cache directory path                             |
+| `regxa cache clear`        | Remove all cached data                                 |
+| `regxa cache prune`        | Remove stale entries                                   |
 
 ### Options
 
-| Flag | Description |
-|------|-------------|
-| `--json` | Output as JSON |
+| Flag         | Description                              |
+| ------------ | ---------------------------------------- |
+| `--json`     | Output as JSON                           |
 | `--no-cache` | Bypass cache, always fetch from registry |
 
 ## Caching
 
 regxa stores fetched data and freshness metadata in unstorage. Default TTLs:
 
-| Data type | TTL |
-|-----------|-----|
-| Package metadata | 1 hour |
-| Version list | 30 minutes |
-| Dependencies | 24 hours |
-| Maintainers | 24 hours |
+| Data type        | TTL        |
+| ---------------- | ---------- |
+| Package metadata | 1 hour     |
+| Version list     | 30 minutes |
+| Dependencies     | 24 hours   |
+| Maintainers      | 24 hours   |
 
 Each cached entry has a sha256 integrity hash. If the stored data doesn't match the hash, regxa refetches automatically.
 
@@ -249,41 +253,41 @@ Every registry returns the same normalized types:
 
 ```ts
 interface Package {
-  name: string
-  description: string
-  homepage: string
-  documentation: string  // docs URL (docs.rs, readthedocs, rubydoc, etc.)
-  repository: string
-  licenses: string       // SPDX-normalized
-  keywords: string[]
-  namespace: string      // e.g. "@vue" for npm scoped packages
-  latestVersion: string
-  metadata: Record<string, unknown>
+  name: string;
+  description: string;
+  homepage: string;
+  documentation: string; // docs URL (docs.rs, readthedocs, rubydoc, etc.)
+  repository: string;
+  licenses: string; // SPDX-normalized
+  keywords: string[];
+  namespace: string; // e.g. "@vue" for npm scoped packages
+  latestVersion: string;
+  metadata: Record<string, unknown>;
 }
 
 interface Version {
-  number: string
-  publishedAt: Date | null
-  licenses: string
-  integrity: string
-  status: '' | 'yanked' | 'deprecated' | 'retracted'
-  metadata: Record<string, unknown>
+  number: string;
+  publishedAt: Date | null;
+  licenses: string;
+  integrity: string;
+  status: "" | "yanked" | "deprecated" | "retracted";
+  metadata: Record<string, unknown>;
 }
 
 interface Dependency {
-  name: string
-  requirements: string   // version constraint
-  scope: 'runtime' | 'development' | 'test' | 'build' | 'optional'
-  optional: boolean
+  name: string;
+  requirements: string; // version constraint
+  scope: "runtime" | "development" | "test" | "build" | "optional";
+  optional: boolean;
 }
 
 interface Maintainer {
-  uuid: string
-  login: string
-  name: string
-  email: string
-  url: string
-  role: string
+  uuid: string;
+  login: string;
+  name: string;
+  email: string;
+  url: string;
+  role: string;
 }
 ```
 

--- a/build.config.ts
+++ b/build.config.ts
@@ -1,33 +1,33 @@
-import { defineBuildConfig } from 'obuild/config'
+import { defineBuildConfig } from "obuild/config";
 
 export default defineBuildConfig({
   entries: [
     {
-      type: 'bundle',
+      type: "bundle",
       input: [
-        './src/index.ts',
-        './src/ai.ts',
-        './src/types.ts',
-        './src/core/index.ts',
-        './src/registries/index.ts',
-        './src/cli.ts',
-        './src/commands/shared.ts',
-        './src/commands/info.ts',
-        './src/commands/versions.ts',
-        './src/commands/deps.ts',
-        './src/commands/maintainers.ts',
-        './src/commands/cache.ts',
- 
-        './src/cache/index.ts',
- 
-        './src/cache/paths.ts',
- 
-        './src/cache/lockfile.ts',
- 
-        './src/cache/storage.ts',
- 
-        './src/cache/cached-registry.ts',
+        "./src/index.ts",
+        "./src/ai.ts",
+        "./src/types.ts",
+        "./src/core/index.ts",
+        "./src/registries/index.ts",
+        "./src/cli.ts",
+        "./src/commands/shared.ts",
+        "./src/commands/info.ts",
+        "./src/commands/versions.ts",
+        "./src/commands/deps.ts",
+        "./src/commands/maintainers.ts",
+        "./src/commands/cache.ts",
+
+        "./src/cache/index.ts",
+
+        "./src/cache/paths.ts",
+
+        "./src/cache/lockfile.ts",
+
+        "./src/cache/storage.ts",
+
+        "./src/cache/cached-registry.ts",
       ],
     },
   ],
-})
+});

--- a/package.json
+++ b/package.json
@@ -2,16 +2,35 @@
   "name": "regxa",
   "version": "0.1.4",
   "description": "Universal package registry client. Query npm, PyPI, crates.io, RubyGems, Packagist and more with a single PURL-native API.",
-  "type": "module",
+  "keywords": [
+    "crates",
+    "metadata",
+    "npm",
+    "package-registry",
+    "packagist",
+    "purl",
+    "pypi",
+    "rubygems",
+    "universal"
+  ],
+  "homepage": "https://github.com/oritwoen/regxa#readme",
+  "bugs": "https://github.com/oritwoen/regxa/issues",
   "license": "MIT",
-  "sideEffects": false,
   "author": "oritwoen (https://github.com/oritwoen)",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/oritwoen/regxa.git"
   },
-  "homepage": "https://github.com/oritwoen/regxa#readme",
-  "bugs": "https://github.com/oritwoen/regxa/issues",
+  "bin": {
+    "regxa": "./dist/cli.mjs"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
   "exports": {
     ".": {
       "types": "./dist/index.d.mts",
@@ -30,52 +49,33 @@
       "import": "./dist/cache/index.mjs"
     }
   },
-  "main": "./dist/index.mjs",
-  "types": "./dist/index.d.mts",
-  "bin": {
-    "regxa": "./dist/cli.mjs"
-  },
-  "files": [
-    "dist"
-  ],
-  "engines": {
-    "node": ">=22.6.0"
-  },
-  "packageManager": "pnpm@10.30.3",
   "scripts": {
     "build": "obuild",
     "dev:prepare": "obuild --stub",
+    "fmt": "oxlint . --fix && oxfmt .",
+    "lint": "oxlint . && oxfmt --check .",
     "typecheck": "tsc --noEmit",
     "test": "vitest",
     "test:run": "vitest run",
     "prepack": "pnpm run build",
     "release": "pnpm test:run && pnpm build && changelogen --release --push"
   },
-  "keywords": [
-    "package-registry",
-    "purl",
-    "npm",
-    "pypi",
-    "crates",
-    "rubygems",
-    "packagist",
-    "universal",
-    "metadata"
-  ],
-  "devDependencies": {
-    "@types/node": "^25.3.0",
-    "ai": "^6.0.116",
-    "changelogen": "^0.6.2",
-    "obuild": "^0.4.31",
-    "typescript": "^5.8.3",
-    "vitest": "^4.0.0",
-    "zod": "^4.3.6"
-  },
   "dependencies": {
     "citty": "^0.2.1",
     "consola": "^3.4.2",
     "ofetch": "^1.5.1",
     "unstorage": "^1.17.4"
+  },
+  "devDependencies": {
+    "@types/node": "^25.3.0",
+    "ai": "^6.0.116",
+    "changelogen": "^0.6.2",
+    "obuild": "^0.4.31",
+    "oxfmt": "^0.36.0",
+    "oxlint": "^1.51.0",
+    "typescript": "^5.8.3",
+    "vitest": "^4.0.0",
+    "zod": "^4.3.6"
   },
   "peerDependencies": {
     "ai": "^6.0.116",
@@ -88,5 +88,9 @@
     "zod": {
       "optional": true
     }
-  }
+  },
+  "engines": {
+    "node": ">=22.6.0"
+  },
+  "packageManager": "pnpm@10.30.3"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,12 @@ importers:
       obuild:
         specifier: ^0.4.31
         version: 0.4.31(chokidar@5.0.0)(dotenv@17.3.1)(giget@2.0.0)(jiti@2.6.1)(picomatch@4.0.3)(rollup@4.59.0)(typescript@5.9.3)
+      oxfmt:
+        specifier: latest
+        version: 0.36.0
+      oxlint:
+        specifier: latest
+        version: 1.51.0
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
@@ -269,6 +275,250 @@ packages:
 
   '@oxc-project/types@0.114.0':
     resolution: {integrity: sha512-//nBfbzHQHvJs8oFIjv6coZ6uxQ4alLfiPe6D5vit6c4pmxATHHlVwgB1k+Hv4yoAMyncdxgRBF5K4BYWUCzvA==}
+
+  '@oxfmt/binding-android-arm-eabi@0.36.0':
+    resolution: {integrity: sha512-Z4yVHJWx/swHHjtr0dXrBZb6LxS+qNz1qdza222mWwPTUK4L790+5i3LTgjx3KYGBzcYpjaiZBw4vOx94dH7MQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxfmt/binding-android-arm64@0.36.0':
+    resolution: {integrity: sha512-3ElCJRFNPQl7jexf2CAa9XmAm8eC5JPrIDSjc9jSchkVSFTEqyL0NtZinBB2h1a4i4JgP1oGl/5G5n8YR4FN8Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxfmt/binding-darwin-arm64@0.36.0':
+    resolution: {integrity: sha512-nak4znWCqIExKhYSY/mz/lWsqWIpdsS7o0+SRzXR1Q0m7GrMcG1UrF1pS7TLGZhhkf7nTfEF7q6oZzJiodRDuw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxfmt/binding-darwin-x64@0.36.0':
+    resolution: {integrity: sha512-V4GP96thDnpKx6ADnMDnhIXNdtV+Ql9D4HUU+a37VTeVbs5qQSF/s6hhUP1b3xUqU7iRcwh72jUU2Y12rtGHAw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxfmt/binding-freebsd-x64@0.36.0':
+    resolution: {integrity: sha512-/xapWCADfI5wrhxpEUjhI9fnw7MV5BUZizVa8e24n3VSK6A3Y1TB/ClOP1tfxNspykFKXp4NBWl6NtDJP3osqQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.36.0':
+    resolution: {integrity: sha512-1lOmv61XMFIH5uNm27620kRRzWt/RK6tdn250BRDoG9W7OXGOQ5UyI1HVT+SFkoOoKztBiinWgi68+NA1MjBVQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.36.0':
+    resolution: {integrity: sha512-vMH23AskdR1ujUS9sPck2Df9rBVoZUnCVY86jisILzIQ/QQ/yKUTi7tgnIvydPx7TyB/48wsQ5QMr5Knq5p/aw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-gnu@0.36.0':
+    resolution: {integrity: sha512-Hy1V+zOBHpBiENRx77qrUTt5aPDHeCASRc8K5KwwAHkX2AKP0nV89eL17hsZrE9GmnXFjsNmd80lyf7aRTXsbw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-arm64-musl@0.36.0':
+    resolution: {integrity: sha512-SPGLJkOIHSIC6ABUQ5V8NqJpvYhMJueJv26NYqfCnwi/Mn6A61amkpJJ9Suy0Nmvs+OWESJpcebrBUbXPGZyQQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.36.0':
+    resolution: {integrity: sha512-3EuoyB8x9x8ysYJjbEO/M9fkSk72zQKnXCvpZMDHXlnY36/1qMp55Nm0PrCwjGO/1pen5hdOVkz9WmP3nAp2IQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.36.0':
+    resolution: {integrity: sha512-MpY3itLwpGh8dnywtrZtaZ604T1m715SydCKy0+qTxetv+IHzuA+aO/AGzrlzUNYZZmtWtmDBrChZGibvZxbRQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-musl@0.36.0':
+    resolution: {integrity: sha512-mmDhe4Vtx+XwQPRPn/V25+APnkApYgZ23q+6GVsNYY98pf3aU0aI3Me96pbRs/AfJ1jIiGC+/6q71FEu8dHcHw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-s390x-gnu@0.36.0':
+    resolution: {integrity: sha512-AYXhU+DmNWLSnvVwkHM92fuYhogtVHab7UQrPNaDf1sxadugg9gWVmcgJDlIwxJdpk5CVW/TFvwUKwI432zhhA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-gnu@0.36.0':
+    resolution: {integrity: sha512-H16QhhQ3usoakMleiAAQ2mg0NsBDAdyE9agUgfC8IHHh3jZEbr0rIKwjEqwbOHK5M0EmfhJmr+aGO/MgZPsneA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-musl@0.36.0':
+    resolution: {integrity: sha512-EFFGkixA39BcmHiCe2ECdrq02D6FCve5ka6ObbvrheXl4V+R0U/E+/uLyVx1X65LW8TA8QQHdnbdDallRekohw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-openharmony-arm64@0.36.0':
+    resolution: {integrity: sha512-zr/t369wZWFOj1qf06Z5gGNjFymfUNDrxKMmr7FKiDRVI1sNsdKRCuRL4XVjtcptKQ+ao3FfxLN1vrynivmCYg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxfmt/binding-win32-arm64-msvc@0.36.0':
+    resolution: {integrity: sha512-FxO7UksTv8h4olzACgrqAXNF6BP329+H322323iDrMB5V/+a1kcAw07fsOsUmqNrb9iJBsCQgH/zqcqp5903ag==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxfmt/binding-win32-ia32-msvc@0.36.0':
+    resolution: {integrity: sha512-OjoMQ89H01M0oLMfr/CPNH1zi48ZIwxAKObUl57oh7ssUBNDp/2Vjf7E1TQ8M4oj4VFQ/byxl2SmcPNaI2YNDg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxfmt/binding-win32-x64-msvc@0.36.0':
+    resolution: {integrity: sha512-MoyeQ9S36ZTz/4bDhOKJgOBIDROd4dQ5AkT9iezhEaUBxAPdNX9Oq0jD8OSnCj3G4wam/XNxVWKMA52kmzmPtQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxlint/binding-android-arm-eabi@1.51.0':
+    resolution: {integrity: sha512-jJYIqbx4sX+suIxWstc4P7SzhEwb4ArWA2KVrmEuu9vH2i0qM6QIHz/ehmbGE4/2fZbpuMuBzTl7UkfNoqiSgw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxlint/binding-android-arm64@1.51.0':
+    resolution: {integrity: sha512-GtXyBCcH4ti98YdiMNCrpBNGitx87EjEWxevnyhcBK12k/Vu4EzSB45rzSC4fGFUD6sQgeaxItRCEEWeVwPafw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxlint/binding-darwin-arm64@1.51.0':
+    resolution: {integrity: sha512-3QJbeYaMHn6Bh2XeBXuITSsbnIctyTjvHf5nRjKYrT9pPeErNIpp5VDEeAXC0CZSwSVTsc8WOSDwgrAI24JolQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint/binding-darwin-x64@1.51.0':
+    resolution: {integrity: sha512-NzErhMaTEN1cY0E8C5APy74lw5VwsNfJfVPBMWPVQLqAbO0k4FFLjvHURvkUL+Y18Wu+8Vs1kbqPh2hjXYA4pg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint/binding-freebsd-x64@1.51.0':
+    resolution: {integrity: sha512-msAIh3vPAoKoHlOE/oe6Q5C/n9umypv/k81lED82ibrJotn+3YG2Qp1kiR8o/Dg5iOEU97c6tl0utxcyFenpFw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.51.0':
+    resolution: {integrity: sha512-CqQPcvqYyMe9ZBot2stjGogEzk1z8gGAngIX7srSzrzexmXixwVxBdFZyxTVM0CjGfDeV+Ru0w25/WNjlMM2Hw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm-musleabihf@1.51.0':
+    resolution: {integrity: sha512-dstrlYQgZMnyOssxSbolGCge/sDbko12N/35RBNuqLpoPbft2aeBidBAb0dvQlyBd9RJ6u8D4o4Eh8Un6iTgyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-gnu@1.51.0':
+    resolution: {integrity: sha512-QEjUpXO7d35rP1/raLGGbAsBLLGZIzV3ZbeSjqWlD3oRnxpRIZ6iL4o51XQHkconn3uKssc+1VKdtHJ81BBhDA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-arm64-musl@1.51.0':
+    resolution: {integrity: sha512-YSJua5irtG4DoMAjUapDTPhkQLHhBIY0G9JqlZS6/SZPzqDkPku/1GdWs0D6h/wyx0Iz31lNCfIaWKBQhzP0wQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-ppc64-gnu@1.51.0':
+    resolution: {integrity: sha512-7L4Wj2IEUNDETKssB9IDYt16T6WlF+X2jgC/hBq3diGHda9vJLpAgb09+D3quFq7TdkFtI7hwz/jmuQmQFPc1Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-gnu@1.51.0':
+    resolution: {integrity: sha512-cBUHqtOXy76G41lOB401qpFoKx1xq17qYkhWrLSM7eEjiHM9sOtYqpr6ZdqCnN9s6ZpzudX4EkeHOFH2E9q0vA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-musl@1.51.0':
+    resolution: {integrity: sha512-WKbg8CysgZcHfZX0ixQFBRSBvFZUHa3SBnEjHY2FVYt2nbNJEjzTxA3ZR5wMU0NOCNKIAFUFvAh5/XJKPRJuJg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-s390x-gnu@1.51.0':
+    resolution: {integrity: sha512-N1QRUvJTxqXNSu35YOufdjsAVmKVx5bkrggOWAhTWBc3J4qjcBwr1IfyLh/6YCg8sYRSR1GraldS9jUgJL/U4A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-gnu@1.51.0':
+    resolution: {integrity: sha512-e0Mz0DizsCoqNIjeOg6OUKe8JKJWZ5zZlwsd05Bmr51Jo3AOL4UJnPvwKumr4BBtBrDZkCmOLhCvDGm95nJM2g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-musl@1.51.0':
+    resolution: {integrity: sha512-wD8HGTWhYBKXvRDvoBVB1y+fEYV01samhWQSy1Zkxq2vpezvMnjaFKRuiP6tBNITLGuffbNDEXOwcAhJ3gI5Ug==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-openharmony-arm64@1.51.0':
+    resolution: {integrity: sha512-5NSwQ2hDEJ0GPXqikjWtwzgAQCsS7P9aLMNenjjKa+gknN3lTCwwwERsT6lKXSirfU3jLjexA2XQvQALh5h27w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxlint/binding-win32-arm64-msvc@1.51.0':
+    resolution: {integrity: sha512-JEZyah1M0RHMw8d+jjSSJmSmO8sABA1J1RtrHYujGPeCkYg1NeH0TGuClpe2h5QtioRTaF57y/TZfn/2IFV6fA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint/binding-win32-ia32-msvc@1.51.0':
+    resolution: {integrity: sha512-q3cEoKH6kwjz/WRyHwSf0nlD2F5Qw536kCXvmlSu+kaShzgrA0ojmh45CA81qL+7udfCaZL2SdKCZlLiGBVFlg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxlint/binding-win32-x64-msvc@1.51.0':
+    resolution: {integrity: sha512-Q14+fOGb9T28nWF/0EUsYqERiRA7cl1oy4TJrGmLaqhm+aO2cV+JttboHI3CbdeMCAyDI1+NoSlrM7Melhp/cw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
 
   '@rolldown/binding-android-arm64@1.0.0-rc.5':
     resolution: {integrity: sha512-zCEmUrt1bggwgBgeKLxNj217J1OrChrp3jJt24VK9jAharSTeVaHODNL+LpcQVhRz+FktYWfT9cjo5oZ99ZLpg==}
@@ -800,6 +1050,21 @@ packages:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
 
+  oxfmt@0.36.0:
+    resolution: {integrity: sha512-/ejJ+KoSW6J9bcNT9a9UtJSJNWhJ3yOLSBLbkoFHJs/8CZjmaZVZAJe4YgO1KMJlKpNQasrn/G9JQUEZI3p0EQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  oxlint@1.51.0:
+    resolution: {integrity: sha512-g6DNPaV9/WI9MoX2XllafxQuxwY1TV++j7hP8fTJByVBuCoVtm3dy9f/2vtH/HU40JztcgWF4G7ua+gkainklQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=0.15.0'
+    peerDependenciesMeta:
+      oxlint-tsgolint:
+        optional: true
+
   package-name-regex@2.0.6:
     resolution: {integrity: sha512-gFL35q7kbE/zBaPA3UKhp2vSzcPYx2ecbYuwv1ucE9Il6IIgBDweBlH8D68UFGZic2MkllKa2KHCfC1IQBQUYA==}
     engines: {node: '>=12'}
@@ -939,6 +1204,10 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@2.1.0:
+    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   tinyrainbow@3.0.3:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
@@ -1269,6 +1538,120 @@ snapshots:
   '@opentelemetry/api@1.9.0': {}
 
   '@oxc-project/types@0.114.0': {}
+
+  '@oxfmt/binding-android-arm-eabi@0.36.0':
+    optional: true
+
+  '@oxfmt/binding-android-arm64@0.36.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-arm64@0.36.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-x64@0.36.0':
+    optional: true
+
+  '@oxfmt/binding-freebsd-x64@0.36.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.36.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.36.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-gnu@0.36.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-musl@0.36.0':
+    optional: true
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.36.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.36.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-musl@0.36.0':
+    optional: true
+
+  '@oxfmt/binding-linux-s390x-gnu@0.36.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-gnu@0.36.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-musl@0.36.0':
+    optional: true
+
+  '@oxfmt/binding-openharmony-arm64@0.36.0':
+    optional: true
+
+  '@oxfmt/binding-win32-arm64-msvc@0.36.0':
+    optional: true
+
+  '@oxfmt/binding-win32-ia32-msvc@0.36.0':
+    optional: true
+
+  '@oxfmt/binding-win32-x64-msvc@0.36.0':
+    optional: true
+
+  '@oxlint/binding-android-arm-eabi@1.51.0':
+    optional: true
+
+  '@oxlint/binding-android-arm64@1.51.0':
+    optional: true
+
+  '@oxlint/binding-darwin-arm64@1.51.0':
+    optional: true
+
+  '@oxlint/binding-darwin-x64@1.51.0':
+    optional: true
+
+  '@oxlint/binding-freebsd-x64@1.51.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.51.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-musleabihf@1.51.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-gnu@1.51.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-musl@1.51.0':
+    optional: true
+
+  '@oxlint/binding-linux-ppc64-gnu@1.51.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-gnu@1.51.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-musl@1.51.0':
+    optional: true
+
+  '@oxlint/binding-linux-s390x-gnu@1.51.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-gnu@1.51.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-musl@1.51.0':
+    optional: true
+
+  '@oxlint/binding-openharmony-arm64@1.51.0':
+    optional: true
+
+  '@oxlint/binding-win32-arm64-msvc@1.51.0':
+    optional: true
+
+  '@oxlint/binding-win32-ia32-msvc@1.51.0':
+    optional: true
+
+  '@oxlint/binding-win32-x64-msvc@1.51.0':
+    optional: true
 
   '@rolldown/binding-android-arm64@1.0.0-rc.5':
     optional: true
@@ -1731,6 +2114,52 @@ snapshots:
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
 
+  oxfmt@0.36.0:
+    dependencies:
+      tinypool: 2.1.0
+    optionalDependencies:
+      '@oxfmt/binding-android-arm-eabi': 0.36.0
+      '@oxfmt/binding-android-arm64': 0.36.0
+      '@oxfmt/binding-darwin-arm64': 0.36.0
+      '@oxfmt/binding-darwin-x64': 0.36.0
+      '@oxfmt/binding-freebsd-x64': 0.36.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.36.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.36.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.36.0
+      '@oxfmt/binding-linux-arm64-musl': 0.36.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.36.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.36.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.36.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.36.0
+      '@oxfmt/binding-linux-x64-gnu': 0.36.0
+      '@oxfmt/binding-linux-x64-musl': 0.36.0
+      '@oxfmt/binding-openharmony-arm64': 0.36.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.36.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.36.0
+      '@oxfmt/binding-win32-x64-msvc': 0.36.0
+
+  oxlint@1.51.0:
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.51.0
+      '@oxlint/binding-android-arm64': 1.51.0
+      '@oxlint/binding-darwin-arm64': 1.51.0
+      '@oxlint/binding-darwin-x64': 1.51.0
+      '@oxlint/binding-freebsd-x64': 1.51.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.51.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.51.0
+      '@oxlint/binding-linux-arm64-gnu': 1.51.0
+      '@oxlint/binding-linux-arm64-musl': 1.51.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.51.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.51.0
+      '@oxlint/binding-linux-riscv64-musl': 1.51.0
+      '@oxlint/binding-linux-s390x-gnu': 1.51.0
+      '@oxlint/binding-linux-x64-gnu': 1.51.0
+      '@oxlint/binding-linux-x64-musl': 1.51.0
+      '@oxlint/binding-openharmony-arm64': 1.51.0
+      '@oxlint/binding-win32-arm64-msvc': 1.51.0
+      '@oxlint/binding-win32-ia32-msvc': 1.51.0
+      '@oxlint/binding-win32-x64-msvc': 1.51.0
+
   package-name-regex@2.0.6: {}
 
   pathe@2.0.3: {}
@@ -1903,6 +2332,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinypool@2.1.0: {}
 
   tinyrainbow@3.0.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,10 +34,10 @@ importers:
         specifier: ^0.4.31
         version: 0.4.31(chokidar@5.0.0)(dotenv@17.3.1)(giget@2.0.0)(jiti@2.6.1)(picomatch@4.0.3)(rollup@4.59.0)(typescript@5.9.3)
       oxfmt:
-        specifier: latest
+        specifier: ^0.36.0
         version: 0.36.0
       oxlint:
-        specifier: latest
+        specifier: ^1.51.0
         version: 1.51.0
       typescript:
         specifier: ^5.8.3

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,9 +1,11 @@
 # SOURCE GUIDE
 
 ## OVERVIEW
+
 `src/` is the implementation boundary: core contracts, ecosystem adapters, cache decorator, CLI commands, and top-level export barrels.
 
 ## STRUCTURE
+
 ```text
 src/
 |- core/        # primitives and shared contracts
@@ -17,20 +19,23 @@ src/
 ```
 
 ## WHERE TO LOOK
-| Task | Location | Notes |
-|------|----------|-------|
-| Extend public exports | `src/index.ts` | Keep grouping order stable (Core, Errors, Helpers, Types, Cache) |
-| Add convenience API | `src/helpers.ts` | Wrap `createFromPURL`; preserve normalization path |
-| Add CLI command | `src/commands/*.ts` + `src/cli.ts` | Command file + dynamic import wiring |
-| Add ecosystem adapter | `src/registries/*.ts` | Register through factory + side-effect import hub |
-| Change shared models | `src/core/types.ts` | Impacts all registries and helpers |
+
+| Task                  | Location                           | Notes                                                            |
+| --------------------- | ---------------------------------- | ---------------------------------------------------------------- |
+| Extend public exports | `src/index.ts`                     | Keep grouping order stable (Core, Errors, Helpers, Types, Cache) |
+| Add convenience API   | `src/helpers.ts`                   | Wrap `createFromPURL`; preserve normalization path               |
+| Add CLI command       | `src/commands/*.ts` + `src/cli.ts` | Command file + dynamic import wiring                             |
+| Add ecosystem adapter | `src/registries/*.ts`              | Register through factory + side-effect import hub                |
+| Change shared models  | `src/core/types.ts`                | Impacts all registries and helpers                               |
 
 ## CONVENTIONS
+
 - Direction is inward: commands/registries/cache depend on `core`, not the reverse.
 - Use `.ts` import suffixes consistently.
 - Keep barrels (`src/index.ts`, `src/core/index.ts`, `src/cache/index.ts`) as canonical export surfaces.
 
 ## ANTI-PATTERNS
+
 - Do not duplicate parsing logic in commands/helpers; route through `createFromPURL`.
 - Do not implement fetch/retry behavior outside `src/core/client.ts`.
 - Do not make cache mandatory for base registry usage.

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -1,56 +1,67 @@
-import { tool } from 'ai'
-import { z } from 'zod'
+import { tool } from "ai";
+import { z } from "zod";
 import {
   bulkFetchPackages,
   fetchDependenciesFromPURL,
   fetchMaintainersFromPURL,
   fetchPackageFromPURL,
   fetchVersionsFromPURL,
-} from './helpers.ts'
-import './registries/index.ts'
+} from "./helpers.ts";
+import "./registries/index.ts";
 
 export const packageTool = tool({
-  description: 'Query package metadata from npm, PyPI, crates.io, RubyGems, Packagist, and Arch Linux using PURLs. Supports package info, versions, dependencies, maintainers, and bulk package metadata lookups.',
-  inputSchema: z.discriminatedUnion('operation', [
+  description:
+    "Query package metadata from npm, PyPI, crates.io, RubyGems, Packagist, and Arch Linux using PURLs. Supports package info, versions, dependencies, maintainers, and bulk package metadata lookups.",
+  inputSchema: z.discriminatedUnion("operation", [
     z.object({
-      operation: z.literal('package'),
-      purl: z.string().describe('Package PURL, for example pkg:npm/lodash or pkg:cargo/serde'),
+      operation: z.literal("package"),
+      purl: z.string().describe("Package PURL, for example pkg:npm/lodash or pkg:cargo/serde"),
     }),
     z.object({
-      operation: z.literal('versions'),
-      purl: z.string().describe('Package PURL, for example pkg:npm/lodash or pkg:cargo/serde'),
+      operation: z.literal("versions"),
+      purl: z.string().describe("Package PURL, for example pkg:npm/lodash or pkg:cargo/serde"),
     }),
     z.object({
-      operation: z.literal('dependencies'),
-      purl: z.string().describe('Package PURL including a version, for example pkg:pypi/flask@3.1.1'),
+      operation: z.literal("dependencies"),
+      purl: z
+        .string()
+        .describe("Package PURL including a version, for example pkg:pypi/flask@3.1.1"),
     }),
     z.object({
-      operation: z.literal('maintainers'),
-      purl: z.string().describe('Package PURL, for example pkg:gem/rails or pkg:composer/laravel/framework'),
+      operation: z.literal("maintainers"),
+      purl: z
+        .string()
+        .describe("Package PURL, for example pkg:gem/rails or pkg:composer/laravel/framework"),
     }),
     z.object({
-      operation: z.literal('bulk-packages'),
-      purls: z.array(z.string()).min(1).max(50).describe('List of package PURLs to fetch in bulk.'),
-      concurrency: z.number().int().min(1).max(50).optional().describe('Maximum concurrent lookups. Defaults to 15.'),
+      operation: z.literal("bulk-packages"),
+      purls: z.array(z.string()).min(1).max(50).describe("List of package PURLs to fetch in bulk."),
+      concurrency: z
+        .number()
+        .int()
+        .min(1)
+        .max(50)
+        .optional()
+        .describe("Maximum concurrent lookups. Defaults to 15."),
     }),
   ]),
   execute: async (input, { abortSignal }) => {
     switch (input.operation) {
-      case 'package':
-        return fetchPackageFromPURL(input.purl, abortSignal)
-      case 'versions':
-        return fetchVersionsFromPURL(input.purl, abortSignal)
-      case 'dependencies':
-        return fetchDependenciesFromPURL(input.purl, abortSignal)
-      case 'maintainers':
-        return fetchMaintainersFromPURL(input.purl, abortSignal)
-      case 'bulk-packages': {
+      case "package":
+        return fetchPackageFromPURL(input.purl, abortSignal);
+      case "versions":
+        return fetchVersionsFromPURL(input.purl, abortSignal);
+      case "dependencies":
+        return fetchDependenciesFromPURL(input.purl, abortSignal);
+      case "maintainers":
+        return fetchMaintainersFromPURL(input.purl, abortSignal);
+      case "bulk-packages": {
         const results = await bulkFetchPackages(input.purls, {
           concurrency: input.concurrency,
           signal: abortSignal,
-        })
-        return Object.fromEntries(results)
+        });
+        return Object.fromEntries(results);
       }
     }
   },
-})
+});

--- a/src/cache/AGENTS.md
+++ b/src/cache/AGENTS.md
@@ -1,9 +1,11 @@
 # CACHE GUIDE
 
 ## OVERVIEW
+
 `src/cache` is an optional decorator subsystem that adds storage-backed reads and lockfile freshness checks around registry operations.
 
 ## STRUCTURE
+
 ```text
 src/cache/
 |- cached-registry.ts  # registry decorator with cache read/write flow
@@ -14,24 +16,28 @@ src/cache/
 ```
 
 ## WHERE TO LOOK
-| Task | Location | Notes |
-|------|----------|-------|
-| Cache wrapper behavior | `src/cache/cached-registry.ts` | Read-through/write-through wrapper for `Registry` |
-| Freshness and TTL policy | `src/cache/lockfile.ts` | `DEFAULT_TTL`, integrity, stale pruning |
-| Storage lifecycle | `src/cache/storage.ts` | Global storage config + disposal/clear hooks |
-| Platform path behavior | `src/cache/paths.ts` | Linux/macOS/Windows cache directory rules |
-| Public cache entry points | `src/cache/index.ts` | Exports + `createCached` convenience API |
+
+| Task                      | Location                       | Notes                                             |
+| ------------------------- | ------------------------------ | ------------------------------------------------- |
+| Cache wrapper behavior    | `src/cache/cached-registry.ts` | Read-through/write-through wrapper for `Registry` |
+| Freshness and TTL policy  | `src/cache/lockfile.ts`        | `DEFAULT_TTL`, integrity, stale pruning           |
+| Storage lifecycle         | `src/cache/storage.ts`         | Global storage config + disposal/clear hooks      |
+| Platform path behavior    | `src/cache/paths.ts`           | Linux/macOS/Windows cache directory rules         |
+| Public cache entry points | `src/cache/index.ts`           | Exports + `createCached` convenience API          |
 
 ## CONVENTIONS
+
 - Cache is optional; uncached path must remain first-class.
 - Lockfile integrity hash gates cache reuse.
 - `createCached` composes core registry creation with `CachedRegistry`.
 
 ## ANTI-PATTERNS
+
 - Do not hardcode TTL values outside `lockfile.ts`.
 - Do not bypass lockfile freshness checks for cached reads.
 - Do not assume filesystem-only storage; keep `unstorage` driver compatibility.
 
 ## NOTES
+
 - Corrupt or stale entries fail soft and trigger network fallback.
 - Keep cache-key format stable; lockfile compatibility depends on it.

--- a/src/cache/cached-registry.ts
+++ b/src/cache/cached-registry.ts
@@ -1,5 +1,12 @@
-import type { Dependency, Maintainer, Package, Registry, URLBuilder, Version } from '../core/types.ts'
-import { getEcosystemStorage, getStorage, computeIntegrity } from './storage.ts'
+import type {
+  Dependency,
+  Maintainer,
+  Package,
+  Registry,
+  URLBuilder,
+  Version,
+} from "../core/types.ts";
+import { getEcosystemStorage, getStorage, computeIntegrity } from "./storage.ts";
 import {
   readLockfile,
   writeLockfile,
@@ -7,9 +14,9 @@ import {
   getFreshEntry,
   setEntry,
   DEFAULT_TTL,
-} from './lockfile.ts'
-import type { EntryType, LockfileEntry } from './lockfile.ts'
-import type { Storage } from 'unstorage'
+} from "./lockfile.ts";
+import type { EntryType, LockfileEntry } from "./lockfile.ts";
+import type { Storage } from "unstorage";
 
 /**
  * CachedRegistry wraps any Registry and adds caching backed by unstorage
@@ -19,59 +26,54 @@ import type { Storage } from 'unstorage'
  * If omitted, uses the globally configured storage (see `configureStorage()`).
  */
 export class CachedRegistry implements Registry {
-  readonly inner: Registry
-  readonly storage: Storage
-  private readonly lockfileStorage: Storage
+  readonly inner: Registry;
+  readonly storage: Storage;
+  private readonly lockfileStorage: Storage;
 
   constructor(inner: Registry, storage?: Storage) {
-    this.inner = inner
-    this.storage = storage ?? getEcosystemStorage(inner.ecosystem())
-    this.lockfileStorage = storage ?? getStorage()
+    this.inner = inner;
+    this.storage = storage ?? getEcosystemStorage(inner.ecosystem());
+    this.lockfileStorage = storage ?? getStorage();
   }
 
   ecosystem(): string {
-    return this.inner.ecosystem()
+    return this.inner.ecosystem();
   }
 
   urls(): URLBuilder {
-    return this.inner.urls()
+    return this.inner.urls();
   }
 
   async fetchPackage(name: string, signal?: AbortSignal): Promise<Package> {
     return this.cached<Package>(
       name,
-      'package',
+      "package",
       undefined,
       () => this.inner.fetchPackage(name, signal),
       (value) => ({ latestVersion: value.latestVersion }),
-    )
+    );
   }
 
   async fetchVersions(name: string, signal?: AbortSignal): Promise<Version[]> {
-    return this.cached<Version[]>(
-      name,
-      'versions',
-      undefined,
-      () => this.inner.fetchVersions(name, signal),
-    )
+    return this.cached<Version[]>(name, "versions", undefined, () =>
+      this.inner.fetchVersions(name, signal),
+    );
   }
 
-  async fetchDependencies(name: string, version: string, signal?: AbortSignal): Promise<Dependency[]> {
-    return this.cached<Dependency[]>(
-      name,
-      'dependencies',
-      version,
-      () => this.inner.fetchDependencies(name, version, signal),
-    )
+  async fetchDependencies(
+    name: string,
+    version: string,
+    signal?: AbortSignal,
+  ): Promise<Dependency[]> {
+    return this.cached<Dependency[]>(name, "dependencies", version, () =>
+      this.inner.fetchDependencies(name, version, signal),
+    );
   }
 
   async fetchMaintainers(name: string, signal?: AbortSignal): Promise<Maintainer[]> {
-    return this.cached<Maintainer[]>(
-      name,
-      'maintainers',
-      undefined,
-      () => this.inner.fetchMaintainers(name, signal),
-    )
+    return this.cached<Maintainer[]>(name, "maintainers", undefined, () =>
+      this.inner.fetchMaintainers(name, signal),
+    );
   }
 
   /**
@@ -87,46 +89,46 @@ export class CachedRegistry implements Registry {
     fetcher: () => Promise<T>,
     extraMeta?: (value: T) => Record<string, unknown>,
   ): Promise<T> {
-    const eco = this.inner.ecosystem()
-    const key = cacheKey(eco, name, type, version)
-    const storageKey = version ? `${name}:${type}:${version}` : `${name}:${type}`
+    const eco = this.inner.ecosystem();
+    const key = cacheKey(eco, name, type, version);
+    const storageKey = version ? `${name}:${type}:${version}` : `${name}:${type}`;
 
     // 1. Check lockfile
-    const lockfile = await readLockfile(this.lockfileStorage)
-    const entry = getFreshEntry(lockfile, key)
+    const lockfile = await readLockfile(this.lockfileStorage);
+    const entry = getFreshEntry(lockfile, key);
 
     if (entry) {
       // 2. Read from storage
-      const cached = await this.storage.getItem<T>(storageKey)
+      const cached = await this.storage.getItem<T>(storageKey);
       if (cached !== null) {
         // Verify integrity
-        const currentHash = computeIntegrity(cached)
+        const currentHash = computeIntegrity(cached);
         if (currentHash === entry.integrity) {
-          return cached
+          return cached;
         }
         // Integrity mismatch — refetch
       }
     }
 
     // 3. Fetch fresh data
-    const value = await fetcher()
+    const value = await fetcher();
 
     // Store to storage
-    await this.storage.setItem(storageKey, value as Record<string, unknown>)
+    await this.storage.setItem(storageKey, value as Record<string, unknown>);
 
     // Update lockfile entry
-    const meta = extraMeta ? extraMeta(value) : {}
+    const meta = extraMeta ? extraMeta(value) : {};
     const newEntry: LockfileEntry = {
       key,
       type,
       fetchedAt: Date.now(),
       ttl: DEFAULT_TTL[type],
       integrity: computeIntegrity(value),
-      ...('latestVersion' in meta ? { latestVersion: meta['latestVersion'] as string } : {}),
-    }
-    setEntry(lockfile, newEntry)
-    await writeLockfile(lockfile, this.lockfileStorage)
+      ...("latestVersion" in meta ? { latestVersion: meta["latestVersion"] as string } : {}),
+    };
+    setEntry(lockfile, newEntry);
+    await writeLockfile(lockfile, this.lockfileStorage);
 
-    return value
+    return value;
   }
 }

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -1,7 +1,14 @@
 // Cache
-export { getCacheDir } from './paths.ts'
-export { getStorage, getEcosystemStorage, computeIntegrity, disposeStorage, clearStorage, configureStorage } from './storage.ts'
-export { CachedRegistry } from './cached-registry.ts'
+export { getCacheDir } from "./paths.ts";
+export {
+  getStorage,
+  getEcosystemStorage,
+  computeIntegrity,
+  disposeStorage,
+  clearStorage,
+  configureStorage,
+} from "./storage.ts";
+export { CachedRegistry } from "./cached-registry.ts";
 export {
   readLockfile,
   writeLockfile,
@@ -12,28 +19,28 @@ export {
   removeEntry,
   pruneStale,
   DEFAULT_TTL,
-} from './lockfile.ts'
-export type { Lockfile, LockfileEntry, EntryType } from './lockfile.ts'
+} from "./lockfile.ts";
+export type { Lockfile, LockfileEntry, EntryType } from "./lockfile.ts";
 
 // Convenience
-import type { Storage } from 'unstorage'
-import type { Registry } from '../core/types.ts'
-import type { Client } from '../core/client.ts'
-import { create } from '../core/registry.ts'
-import { CachedRegistry } from './cached-registry.ts'
+import type { Storage } from "unstorage";
+import type { Registry } from "../core/types.ts";
+import type { Client } from "../core/client.ts";
+import { create } from "../core/registry.ts";
+import { CachedRegistry } from "./cached-registry.ts";
 
 /** Options for creating a cached registry. */
 export interface CreateCachedOptions {
   /** Custom base URL for the registry API. */
-  baseURL?: string
+  baseURL?: string;
   /** Custom HTTP client. */
-  client?: Client
+  client?: Client;
   /** Custom unstorage instance. Overrides the globally configured storage. */
-  storage?: Storage
+  storage?: Storage;
 }
 
 /** Create a registry instance with caching + lockfile tracking. */
 export function createCached(ecosystem: string, options?: CreateCachedOptions): Registry {
-  const inner = create(ecosystem, options?.baseURL, options?.client)
-  return new CachedRegistry(inner, options?.storage)
+  const inner = create(ecosystem, options?.baseURL, options?.client);
+  return new CachedRegistry(inner, options?.storage);
 }

--- a/src/cache/lockfile.ts
+++ b/src/cache/lockfile.ts
@@ -1,102 +1,106 @@
-import type { Storage } from 'unstorage'
-import { getStorage } from './storage.ts'
+import type { Storage } from "unstorage";
+import { getStorage } from "./storage.ts";
 
-const LOCKFILE_VERSION = 1
-const LOCKFILE_KEY = '__lockfile__'
+const LOCKFILE_VERSION = 1;
+const LOCKFILE_KEY = "__lockfile__";
 
 /** Default TTL per data type (seconds). */
 export const DEFAULT_TTL = {
-  package: 3600,       // 1 hour — package metadata changes rarely
-  versions: 1800,      // 30 min — new versions published more often
+  package: 3600, // 1 hour — package metadata changes rarely
+  versions: 1800, // 30 min — new versions published more often
   dependencies: 86400, // 24 hours — deps of a specific version never change
-  maintainers: 86400,  // 24 hours
-} as const
+  maintainers: 86400, // 24 hours
+} as const;
 
-export type EntryType = keyof typeof DEFAULT_TTL
+export type EntryType = keyof typeof DEFAULT_TTL;
 
 /** A single cached entry tracked in the lockfile. */
 export interface LockfileEntry {
   /** PURL-style key: 'npm:lodash', 'cargo:serde' */
-  key: string
+  key: string;
   /** What kind of data: package, versions, dependencies, maintainers */
-  type: EntryType
+  type: EntryType;
   /** Unix timestamp (ms) when fetched */
-  fetchedAt: number
+  fetchedAt: number;
   /** TTL in seconds */
-  ttl: number
+  ttl: number;
   /** Latest version at time of caching (for package entries) */
-  latestVersion?: string
+  latestVersion?: string;
   /** Content hash (sha256 of JSON-serialized value) for integrity */
-  integrity: string
+  integrity: string;
 }
 
 /** The full lockfile structure. */
 export interface Lockfile {
-  version: number
-  entries: Record<string, LockfileEntry>
+  version: number;
+  entries: Record<string, LockfileEntry>;
 }
 
 function emptyLockfile(): Lockfile {
-  return { version: LOCKFILE_VERSION, entries: {} }
+  return { version: LOCKFILE_VERSION, entries: {} };
 }
 
 /** Read the lockfile from storage. Returns empty lockfile if not found or invalid. */
 export async function readLockfile(storage?: Storage): Promise<Lockfile> {
-  const s = storage ?? getStorage()
+  const s = storage ?? getStorage();
   try {
-    const data = await s.getItem<Lockfile>(LOCKFILE_KEY)
-    if (!data || data.version !== LOCKFILE_VERSION) return emptyLockfile()
-    return data
-  }
-  catch {
-    return emptyLockfile()
+    const data = await s.getItem<Lockfile>(LOCKFILE_KEY);
+    if (!data || data.version !== LOCKFILE_VERSION) return emptyLockfile();
+    return data;
+  } catch {
+    return emptyLockfile();
   }
 }
 
 /** Write the lockfile to storage. */
 export async function writeLockfile(lockfile: Lockfile, storage?: Storage): Promise<void> {
-  const s = storage ?? getStorage()
-  await s.setItem(LOCKFILE_KEY, lockfile)
+  const s = storage ?? getStorage();
+  await s.setItem(LOCKFILE_KEY, lockfile);
 }
 
 /** Build a cache key from ecosystem + name + type + optional version. */
-export function cacheKey(ecosystem: string, name: string, type: EntryType, version?: string): string {
-  const base = `${ecosystem}:${name}:${type}`
-  return version ? `${base}:${version}` : base
+export function cacheKey(
+  ecosystem: string,
+  name: string,
+  type: EntryType,
+  version?: string,
+): string {
+  const base = `${ecosystem}:${name}:${type}`;
+  return version ? `${base}:${version}` : base;
 }
 
 /** Check if a lockfile entry is still fresh. */
 export function isFresh(entry: LockfileEntry): boolean {
-  const expiresAt = entry.fetchedAt + (entry.ttl * 1000)
-  return Date.now() < expiresAt
+  const expiresAt = entry.fetchedAt + entry.ttl * 1000;
+  return Date.now() < expiresAt;
 }
 
 /** Get a lockfile entry if it exists and is fresh. Returns null otherwise. */
 export function getFreshEntry(lockfile: Lockfile, key: string): LockfileEntry | null {
-  const entry = lockfile.entries[key]
-  if (!entry) return null
-  if (!isFresh(entry)) return null
-  return entry
+  const entry = lockfile.entries[key];
+  if (!entry) return null;
+  if (!isFresh(entry)) return null;
+  return entry;
 }
 
 /** Upsert an entry in the lockfile. Does NOT persist — call writeLockfile() after. */
 export function setEntry(lockfile: Lockfile, entry: LockfileEntry): void {
-  lockfile.entries[entry.key] = entry
+  lockfile.entries[entry.key] = entry;
 }
 
 /** Remove an entry from the lockfile. */
 export function removeEntry(lockfile: Lockfile, key: string): void {
-  delete lockfile.entries[key]
+  delete lockfile.entries[key];
 }
 
 /** Remove all stale entries from the lockfile. Returns count of removed entries. */
 export function pruneStale(lockfile: Lockfile): number {
-  let removed = 0
+  let removed = 0;
   for (const key of Object.keys(lockfile.entries)) {
     if (!isFresh(lockfile.entries[key]!)) {
-      delete lockfile.entries[key]
-      removed++
+      delete lockfile.entries[key];
+      removed++;
     }
   }
-  return removed
+  return removed;
 }

--- a/src/cache/paths.ts
+++ b/src/cache/paths.ts
@@ -1,7 +1,7 @@
-import { homedir, platform } from 'node:os'
-import { join } from 'node:path'
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
 
-const APP_NAME = 'regxa'
+const APP_NAME = "regxa";
 
 /**
  * Resolve the cache directory following platform conventions:
@@ -11,23 +11,23 @@ const APP_NAME = 'regxa'
  */
 export function getCacheDir(): string {
   // Explicit override always wins
-  const envOverride = process.env['REGXA_CACHE_DIR']
-  if (envOverride) return envOverride
+  const envOverride = process.env["REGXA_CACHE_DIR"];
+  if (envOverride) return envOverride;
 
-  const os = platform()
+  const os = platform();
 
-  if (os === 'darwin') {
-    return join(homedir(), 'Library', 'Caches', APP_NAME)
+  if (os === "darwin") {
+    return join(homedir(), "Library", "Caches", APP_NAME);
   }
 
-  if (os === 'win32') {
-    const localAppData = process.env['LOCALAPPDATA']
-    if (localAppData) return join(localAppData, APP_NAME, 'cache')
-    return join(homedir(), 'AppData', 'Local', APP_NAME, 'cache')
+  if (os === "win32") {
+    const localAppData = process.env["LOCALAPPDATA"];
+    if (localAppData) return join(localAppData, APP_NAME, "cache");
+    return join(homedir(), "AppData", "Local", APP_NAME, "cache");
   }
 
   // Linux / FreeBSD / other — XDG Base Directory
-  const xdgCache = process.env['XDG_CACHE_HOME']
-  if (xdgCache) return join(xdgCache, APP_NAME)
-  return join(homedir(), '.cache', APP_NAME)
+  const xdgCache = process.env["XDG_CACHE_HOME"];
+  if (xdgCache) return join(xdgCache, APP_NAME);
+  return join(homedir(), ".cache", APP_NAME);
 }

--- a/src/cache/storage.ts
+++ b/src/cache/storage.ts
@@ -1,10 +1,10 @@
-import { createStorage, prefixStorage } from 'unstorage'
-import fsDriver from 'unstorage/drivers/fs'
-import type { Storage } from 'unstorage'
-import { getCacheDir } from './paths.ts'
-import { hash } from 'node:crypto'
+import { createStorage, prefixStorage } from "unstorage";
+import fsDriver from "unstorage/drivers/fs";
+import type { Storage } from "unstorage";
+import { getCacheDir } from "./paths.ts";
+import { hash } from "node:crypto";
 
-let _storage: Storage | undefined
+let _storage: Storage | undefined;
 
 /**
  * Configure a custom unstorage instance for regxa.
@@ -12,7 +12,7 @@ let _storage: Storage | undefined
  * (e.g. Cloudflare KV, Redis, memory).
  */
 export function configureStorage(storage: Storage): void {
-  _storage = storage
+  _storage = storage;
 }
 
 /** Get or create the shared storage instance. Uses configured storage or falls back to fs driver. */
@@ -20,30 +20,30 @@ export function getStorage(): Storage {
   if (!_storage) {
     _storage = createStorage({
       driver: fsDriver({ base: getCacheDir() }),
-    })
+    });
   }
-  return _storage
+  return _storage;
 }
 
 /** Get a namespaced storage for a specific ecosystem (e.g. 'npm', 'cargo'). */
 export function getEcosystemStorage(ecosystem: string): Storage {
-  return prefixStorage(getStorage(), ecosystem)
+  return prefixStorage(getStorage(), ecosystem);
 }
 
 /** Compute a sha256 integrity hash of a JSON-serializable value. */
 export function computeIntegrity(value: unknown): string {
-  return `sha256-${hash('sha256', JSON.stringify(value), 'hex')}`
+  return `sha256-${hash("sha256", JSON.stringify(value), "hex")}`;
 }
 
 /** Dispose the storage instance. Call on process exit. */
 export async function disposeStorage(): Promise<void> {
   if (_storage) {
-    await _storage.dispose()
-    _storage = undefined
+    await _storage.dispose();
+    _storage = undefined;
   }
 }
 
 /** Clear all cached data. */
 export async function clearStorage(): Promise<void> {
-  await getStorage().clear()
+  await getStorage().clear();
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,19 +1,20 @@
 #!/usr/bin/env node
-import { defineCommand, runMain } from 'citty'
+import { defineCommand, runMain } from "citty";
 
 const main = defineCommand({
   meta: {
-    name: 'regxa',
-    version: '0.1.0',
-    description: 'Universal package registry client — query npm, PyPI, crates.io, RubyGems, Packagist with a single PURL-native API.',
+    name: "regxa",
+    version: "0.1.0",
+    description:
+      "Universal package registry client — query npm, PyPI, crates.io, RubyGems, Packagist with a single PURL-native API.",
   },
   subCommands: {
-    info: () => import('./commands/info.ts').then(m => m.default),
-    versions: () => import('./commands/versions.ts').then(m => m.default),
-    deps: () => import('./commands/deps.ts').then(m => m.default),
-    maintainers: () => import('./commands/maintainers.ts').then(m => m.default),
-    cache: () => import('./commands/cache.ts').then(m => m.default),
+    info: () => import("./commands/info.ts").then((m) => m.default),
+    versions: () => import("./commands/versions.ts").then((m) => m.default),
+    deps: () => import("./commands/deps.ts").then((m) => m.default),
+    maintainers: () => import("./commands/maintainers.ts").then((m) => m.default),
+    cache: () => import("./commands/cache.ts").then((m) => m.default),
   },
-})
+});
 
-runMain(main)
+runMain(main);

--- a/src/commands/AGENTS.md
+++ b/src/commands/AGENTS.md
@@ -1,9 +1,11 @@
 # COMMANDS GUIDE
 
 ## OVERVIEW
+
 `src/commands` defines CLI subcommands and shared command utilities on top of core/helpers/cache layers.
 
 ## STRUCTURE
+
 ```text
 src/commands/
 |- shared.ts       # shared args, PURL resolver, error wrapper
@@ -15,26 +17,30 @@ src/commands/
 ```
 
 ## WHERE TO LOOK
-| Task | Location | Notes |
-|------|----------|-------|
-| Shared argument flags | `src/commands/shared.ts` | `--json` and `--no-cache` handling |
-| PURL input resolution | `src/commands/shared.ts` | Optional `pkg:` prefix normalization |
-| `info` output flow | `src/commands/info.ts` | Package metadata command |
-| `versions` output flow | `src/commands/versions.ts` | Version list command |
-| `deps` output flow | `src/commands/deps.ts` | Version-specific dependency command |
-| `maintainers` output flow | `src/commands/maintainers.ts` | Maintainer listing command |
-| Cache maintenance commands | `src/commands/cache.ts` | status/path/clear/prune subcommands |
+
+| Task                       | Location                      | Notes                                |
+| -------------------------- | ----------------------------- | ------------------------------------ |
+| Shared argument flags      | `src/commands/shared.ts`      | `--json` and `--no-cache` handling   |
+| PURL input resolution      | `src/commands/shared.ts`      | Optional `pkg:` prefix normalization |
+| `info` output flow         | `src/commands/info.ts`        | Package metadata command             |
+| `versions` output flow     | `src/commands/versions.ts`    | Version list command                 |
+| `deps` output flow         | `src/commands/deps.ts`        | Version-specific dependency command  |
+| `maintainers` output flow  | `src/commands/maintainers.ts` | Maintainer listing command           |
+| Cache maintenance commands | `src/commands/cache.ts`       | status/path/clear/prune subcommands  |
 
 ## CONVENTIONS
+
 - Commands are thin orchestration layers; domain logic stays in core/cache/helpers.
 - Wrap command bodies with shared error handling helpers.
 - Keep output dual-mode (`human` + `--json`).
 
 ## ANTI-PATTERNS
+
 - Do not reimplement PURL parsing in individual command files.
 - Do not mutate cache internals directly from commands; use cache API.
 - Do not bypass shared argument definitions for common flags.
 
 ## NOTES
+
 - `src/cli.ts` owns subcommand registration; keep command files focused on execution.
 - For new command output, maintain parity between human-readable and `--json` branches.

--- a/src/commands/cache.ts
+++ b/src/commands/cache.ts
@@ -1,80 +1,82 @@
-import { defineCommand } from 'citty'
-import consola from 'consola'
-import { getCacheDir } from '../cache/paths.ts'
-import { clearStorage } from '../cache/storage.ts'
-import { readLockfile, writeLockfile, pruneStale } from '../cache/lockfile.ts'
+import { defineCommand } from "citty";
+import consola from "consola";
+import { getCacheDir } from "../cache/paths.ts";
+import { clearStorage } from "../cache/storage.ts";
+import { readLockfile, writeLockfile, pruneStale } from "../cache/lockfile.ts";
 
 export default defineCommand({
   meta: {
-    name: 'cache',
-    description: 'Manage the regxa cache',
+    name: "cache",
+    description: "Manage the regxa cache",
   },
   subCommands: {
     clear: defineCommand({
       meta: {
-        name: 'clear',
-        description: 'Remove all cached data',
+        name: "clear",
+        description: "Remove all cached data",
       },
       async run() {
-        await clearStorage()
-        await writeLockfile({ version: 1, entries: {} })
-        consola.success('Cache cleared')
+        await clearStorage();
+        await writeLockfile({ version: 1, entries: {} });
+        consola.success("Cache cleared");
       },
     }),
     path: defineCommand({
       meta: {
-        name: 'path',
-        description: 'Show cache directory path',
+        name: "path",
+        description: "Show cache directory path",
       },
       run() {
-        console.log(getCacheDir())
+        console.log(getCacheDir());
       },
     }),
     status: defineCommand({
       meta: {
-        name: 'status',
-        description: 'Show cache status and entry count',
+        name: "status",
+        description: "Show cache status and entry count",
       },
       async run() {
-        const lockfile = await readLockfile()
-        const entries = Object.values(lockfile.entries)
-        const fresh = entries.filter(e => {
-          const expiresAt = e.fetchedAt + (e.ttl * 1000)
-          return Date.now() < expiresAt
-        })
-        const stale = entries.length - fresh.length
+        const lockfile = await readLockfile();
+        const entries = Object.values(lockfile.entries);
+        const fresh = entries.filter((e) => {
+          const expiresAt = e.fetchedAt + e.ttl * 1000;
+          return Date.now() < expiresAt;
+        });
+        const stale = entries.length - fresh.length;
 
-        consola.log('')
-        consola.log(`  \x1b[1mCache status\x1b[0m`)
-        consola.log(`  \x1b[90mDirectory:\x1b[0m  ${getCacheDir()}`)
-        consola.log(`  \x1b[90mEntries:\x1b[0m    ${entries.length} total, ${fresh.length} fresh, ${stale} stale`)
-        consola.log('')
+        consola.log("");
+        consola.log(`  \x1b[1mCache status\x1b[0m`);
+        consola.log(`  \x1b[90mDirectory:\x1b[0m  ${getCacheDir()}`);
+        consola.log(
+          `  \x1b[90mEntries:\x1b[0m    ${entries.length} total, ${fresh.length} fresh, ${stale} stale`,
+        );
+        consola.log("");
 
         if (fresh.length > 0) {
           // Group by ecosystem
-          const byEco = new Map<string, number>()
+          const byEco = new Map<string, number>();
           for (const e of fresh) {
-            const eco = e.key.split(':')[0]!
-            byEco.set(eco, (byEco.get(eco) ?? 0) + 1)
+            const eco = e.key.split(":")[0]!;
+            byEco.set(eco, (byEco.get(eco) ?? 0) + 1);
           }
           for (const [eco, count] of byEco) {
-            consola.log(`  \x1b[36m${eco}\x1b[0m: ${count} cached`)
+            consola.log(`  \x1b[36m${eco}\x1b[0m: ${count} cached`);
           }
-          consola.log('')
+          consola.log("");
         }
       },
     }),
     prune: defineCommand({
       meta: {
-        name: 'prune',
-        description: 'Remove stale cache entries',
+        name: "prune",
+        description: "Remove stale cache entries",
       },
       async run() {
-        const lockfile = await readLockfile()
-        const removed = pruneStale(lockfile)
-        await writeLockfile(lockfile)
-        consola.success(`Pruned ${removed} stale entries`)
+        const lockfile = await readLockfile();
+        const removed = pruneStale(lockfile);
+        await writeLockfile(lockfile);
+        consola.success(`Pruned ${removed} stale entries`);
       },
     }),
   },
-})
+});

--- a/src/commands/deps.ts
+++ b/src/commands/deps.ts
@@ -1,78 +1,82 @@
-import { defineCommand } from 'citty'
-import consola from 'consola'
-import { sharedArgs, resolvePURL, withErrorHandling } from './shared.ts'
+import { defineCommand } from "citty";
+import consola from "consola";
+import { sharedArgs, resolvePURL, withErrorHandling } from "./shared.ts";
 
 export default defineCommand({
   meta: {
-    name: 'deps',
-    description: 'List package dependencies',
+    name: "deps",
+    description: "List package dependencies",
   },
   args: {
     ...sharedArgs,
     purl: {
-      type: 'positional',
-      description: 'Package PURL with version (e.g. pkg:npm/lodash@4.17.21, cargo/serde@1.0)',
+      type: "positional",
+      description: "Package PURL with version (e.g. pkg:npm/lodash@4.17.21, cargo/serde@1.0)",
       required: true,
     },
   },
   async run({ args }) {
     await withErrorHandling(async () => {
-      const [reg, name, version] = resolvePURL(args.purl, !args['no-cache'])
+      const [reg, name, version] = resolvePURL(args.purl, !args["no-cache"]);
 
       if (!version) {
         // Try to resolve latest version
-        const pkg = await reg.fetchPackage(name)
+        const pkg = await reg.fetchPackage(name);
         if (!pkg.latestVersion) {
-          consola.error('PURL must include a version for dependency lookup, and no latest version found.')
-          consola.info('Example: pkg:npm/lodash@4.17.21')
-          process.exit(1)
+          consola.error(
+            "PURL must include a version for dependency lookup, and no latest version found.",
+          );
+          consola.info("Example: pkg:npm/lodash@4.17.21");
+          process.exit(1);
         }
-        consola.info(`No version specified, using latest: ${pkg.latestVersion}`)
-        const deps = await reg.fetchDependencies(name, pkg.latestVersion)
-        outputDeps(name, pkg.latestVersion, deps, args.json)
-        return
+        consola.info(`No version specified, using latest: ${pkg.latestVersion}`);
+        const deps = await reg.fetchDependencies(name, pkg.latestVersion);
+        outputDeps(name, pkg.latestVersion, deps, args.json);
+        return;
       }
 
-      const deps = await reg.fetchDependencies(name, version)
-      outputDeps(name, version, deps, args.json)
-    })
+      const deps = await reg.fetchDependencies(name, version);
+      outputDeps(name, version, deps, args.json);
+    });
   },
-})
+});
 
-import type { Dependency } from '../core/types.ts'
+import type { Dependency } from "../core/types.ts";
 
 function outputDeps(name: string, version: string, deps: Dependency[], json: boolean): void {
   if (json) {
-    console.log(JSON.stringify(deps, null, 2))
-    return
+    console.log(JSON.stringify(deps, null, 2));
+    return;
   }
 
-  consola.log('')
-  consola.log(`  \x1b[1m${name}@${version}\x1b[0m — ${deps.length} dependenc${deps.length === 1 ? 'y' : 'ies'}`)
-  consola.log('')
+  consola.log("");
+  consola.log(
+    `  \x1b[1m${name}@${version}\x1b[0m — ${deps.length} dependenc${deps.length === 1 ? "y" : "ies"}`,
+  );
+  consola.log("");
 
-  const byScope = new Map<string, Dependency[]>()
+  const byScope = new Map<string, Dependency[]>();
   for (const dep of deps) {
-    const scope = dep.scope || 'runtime'
-    if (!byScope.has(scope)) byScope.set(scope, [])
-    byScope.get(scope)!.push(dep)
+    const scope = dep.scope || "runtime";
+    if (!byScope.has(scope)) byScope.set(scope, []);
+    byScope.get(scope)!.push(dep);
   }
 
   const scopeColors: Record<string, string> = {
-    runtime: '\x1b[32m',
-    development: '\x1b[33m',
-    build: '\x1b[35m',
-    test: '\x1b[36m',
-    optional: '\x1b[90m',
-  }
+    runtime: "\x1b[32m",
+    development: "\x1b[33m",
+    build: "\x1b[35m",
+    test: "\x1b[36m",
+    optional: "\x1b[90m",
+  };
 
   for (const [scope, scopeDeps] of byScope) {
-    const color = scopeColors[scope] ?? '\x1b[0m'
-    consola.log(`  ${color}${scope}\x1b[0m (${scopeDeps.length})`)
+    const color = scopeColors[scope] ?? "\x1b[0m";
+    consola.log(`  ${color}${scope}\x1b[0m (${scopeDeps.length})`);
     for (const dep of scopeDeps) {
-      const opt = dep.optional ? ' \x1b[90m(optional)\x1b[0m' : ''
-      consola.log(`    ${dep.name} \x1b[90m${dep.requirements}\x1b[0m${opt}`)
+      const opt = dep.optional ? " \x1b[90m(optional)\x1b[0m" : "";
+      consola.log(`    ${dep.name} \x1b[90m${dep.requirements}\x1b[0m${opt}`);
     }
-    consola.log('')
+    consola.log("");
   }
 }

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -1,62 +1,65 @@
-import type { Package, Registry } from '../core/types.ts'
-import { defineCommand } from 'citty'
-import consola from 'consola'
-import { resolveDocsUrl } from '../helpers.ts'
-import { sharedArgs, resolvePURL, withErrorHandling } from './shared.ts'
+import type { Package, Registry } from "../core/types.ts";
+import { defineCommand } from "citty";
+import consola from "consola";
+import { resolveDocsUrl } from "../helpers.ts";
+import { sharedArgs, resolvePURL, withErrorHandling } from "./shared.ts";
 
 export function outputPackageInfo(pkg: Package, name: string, reg: Registry): void {
-  const urls = reg.urls()
-  const registryUrl = urls.registry(name)
-  const docsUrl = resolveDocsUrl(pkg, urls, pkg.latestVersion || undefined)
-  const showDocs = Boolean(docsUrl)
-    && docsUrl !== pkg.homepage
-    && docsUrl !== pkg.repository
-    && docsUrl !== registryUrl
+  const urls = reg.urls();
+  const registryUrl = urls.registry(name);
+  const docsUrl = resolveDocsUrl(pkg, urls, pkg.latestVersion || undefined);
+  const showDocs =
+    Boolean(docsUrl) &&
+    docsUrl !== pkg.homepage &&
+    docsUrl !== pkg.repository &&
+    docsUrl !== registryUrl;
 
-  consola.log('')
-  consola.log(`  \x1b[1m\x1b[36m${pkg.name}\x1b[0m${pkg.latestVersion ? `\x1b[90m@${pkg.latestVersion}\x1b[0m` : ''}`)
+  consola.log("");
+  consola.log(
+    `  \x1b[1m\x1b[36m${pkg.name}\x1b[0m${pkg.latestVersion ? `\x1b[90m@${pkg.latestVersion}\x1b[0m` : ""}`,
+  );
   if (pkg.description) {
-    consola.log(`  ${pkg.description}`)
+    consola.log(`  ${pkg.description}`);
   }
-  consola.log('')
+  consola.log("");
 
-  if (pkg.licenses) consola.log(`  \x1b[90mLicense:\x1b[0m    ${pkg.licenses}`)
-  if (pkg.repository) consola.log(`  \x1b[90mRepository:\x1b[0m ${pkg.repository}`)
-  if (pkg.homepage) consola.log(`  \x1b[90mHomepage:\x1b[0m   ${pkg.homepage}`)
-  if (showDocs) consola.log(`  \x1b[90mDocs:\x1b[0m       ${docsUrl}`)
-  consola.log(`  \x1b[90mRegistry:\x1b[0m   ${registryUrl}`)
+  if (pkg.licenses) consola.log(`  \x1b[90mLicense:\x1b[0m    ${pkg.licenses}`);
+  if (pkg.repository) consola.log(`  \x1b[90mRepository:\x1b[0m ${pkg.repository}`);
+  if (pkg.homepage) consola.log(`  \x1b[90mHomepage:\x1b[0m   ${pkg.homepage}`);
+  if (showDocs) consola.log(`  \x1b[90mDocs:\x1b[0m       ${docsUrl}`);
+  consola.log(`  \x1b[90mRegistry:\x1b[0m   ${registryUrl}`);
   if (pkg.keywords.length > 0) {
-    consola.log(`  \x1b[90mKeywords:\x1b[0m   ${pkg.keywords.join(', ')}`)
+    consola.log(`  \x1b[90mKeywords:\x1b[0m   ${pkg.keywords.join(", ")}`);
   }
-  if (pkg.namespace) consola.log(`  \x1b[90mNamespace:\x1b[0m  ${pkg.namespace}`)
-  consola.log(`  \x1b[90mEcosystem:\x1b[0m  ${reg.ecosystem()}`)
-  consola.log('')
+  if (pkg.namespace) consola.log(`  \x1b[90mNamespace:\x1b[0m  ${pkg.namespace}`);
+  consola.log(`  \x1b[90mEcosystem:\x1b[0m  ${reg.ecosystem()}`);
+  consola.log("");
 }
 
 export default defineCommand({
   meta: {
-    name: 'info',
-    description: 'Show package metadata',
+    name: "info",
+    description: "Show package metadata",
   },
   args: {
     ...sharedArgs,
     purl: {
-      type: 'positional',
-      description: 'Package PURL (e.g. pkg:npm/lodash, cargo/serde@1.0)',
+      type: "positional",
+      description: "Package PURL (e.g. pkg:npm/lodash, cargo/serde@1.0)",
       required: true,
     },
   },
   async run({ args }) {
     await withErrorHandling(async () => {
-      const [reg, name] = resolvePURL(args.purl, !args['no-cache'])
-      const pkg = await reg.fetchPackage(name)
+      const [reg, name] = resolvePURL(args.purl, !args["no-cache"]);
+      const pkg = await reg.fetchPackage(name);
 
       if (args.json) {
-        console.log(JSON.stringify(pkg, null, 2))
-        return
+        console.log(JSON.stringify(pkg, null, 2));
+        return;
       }
 
-      outputPackageInfo(pkg, name, reg)
-    })
+      outputPackageInfo(pkg, name, reg);
+    });
   },
-})
+});

--- a/src/commands/maintainers.ts
+++ b/src/commands/maintainers.ts
@@ -1,44 +1,46 @@
-import { defineCommand } from 'citty'
-import consola from 'consola'
-import { sharedArgs, resolvePURL, withErrorHandling } from './shared.ts'
+import { defineCommand } from "citty";
+import consola from "consola";
+import { sharedArgs, resolvePURL, withErrorHandling } from "./shared.ts";
 
 export default defineCommand({
   meta: {
-    name: 'maintainers',
-    description: 'List package maintainers',
+    name: "maintainers",
+    description: "List package maintainers",
   },
   args: {
     ...sharedArgs,
     purl: {
-      type: 'positional',
-      description: 'Package PURL (e.g. pkg:npm/lodash, gem/rails)',
+      type: "positional",
+      description: "Package PURL (e.g. pkg:npm/lodash, gem/rails)",
       required: true,
     },
   },
   async run({ args }) {
     await withErrorHandling(async () => {
-      const [reg, name] = resolvePURL(args.purl, !args['no-cache'])
-      const maintainers = await reg.fetchMaintainers(name)
+      const [reg, name] = resolvePURL(args.purl, !args["no-cache"]);
+      const maintainers = await reg.fetchMaintainers(name);
 
       if (args.json) {
-        console.log(JSON.stringify(maintainers, null, 2))
-        return
+        console.log(JSON.stringify(maintainers, null, 2));
+        return;
       }
 
-      consola.log('')
-      consola.log(`  \x1b[1m${name}\x1b[0m — ${maintainers.length} maintainer${maintainers.length === 1 ? '' : 's'}`)
-      consola.log('')
+      consola.log("");
+      consola.log(
+        `  \x1b[1m${name}\x1b[0m — ${maintainers.length} maintainer${maintainers.length === 1 ? "" : "s"}`,
+      );
+      consola.log("");
 
       for (const m of maintainers) {
-        const nameStr = m.name || m.login || 'unknown'
-        const parts: string[] = [nameStr]
-        if (m.login && m.login !== nameStr) parts.push(`\x1b[90m(${m.login})\x1b[0m`)
-        if (m.email) parts.push(`\x1b[90m<${m.email}>\x1b[0m`)
-        if (m.role) parts.push(`\x1b[36m[${m.role}]\x1b[0m`)
-        consola.log(`  ${parts.join(' ')}`)
-        if (m.url) consola.log(`    \x1b[90m${m.url}\x1b[0m`)
+        const nameStr = m.name || m.login || "unknown";
+        const parts: string[] = [nameStr];
+        if (m.login && m.login !== nameStr) parts.push(`\x1b[90m(${m.login})\x1b[0m`);
+        if (m.email) parts.push(`\x1b[90m<${m.email}>\x1b[0m`);
+        if (m.role) parts.push(`\x1b[36m[${m.role}]\x1b[0m`);
+        consola.log(`  ${parts.join(" ")}`);
+        if (m.url) consola.log(`    \x1b[90m${m.url}\x1b[0m`);
       }
-      consola.log('')
-    })
+      consola.log("");
+    });
   },
-})
+});

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -1,65 +1,66 @@
-import consola from 'consola'
-import type { Registry } from '../core/types.ts'
-import { createFromPURL, parsePURL, fullName } from '../core/purl.ts'
-import { create } from '../core/registry.ts'
-import { NotFoundError, UnknownEcosystemError, InvalidPURLError } from '../core/errors.ts'
-import { CachedRegistry } from '../cache/cached-registry.ts'
-import '../registries/index.ts'
+import consola from "consola";
+import type { Registry } from "../core/types.ts";
+import { createFromPURL, parsePURL, fullName } from "../core/purl.ts";
+import { create } from "../core/registry.ts";
+import { NotFoundError, UnknownEcosystemError, InvalidPURLError } from "../core/errors.ts";
+import { CachedRegistry } from "../cache/cached-registry.ts";
+import "../registries/index.ts";
 
 export const sharedArgs = {
   json: {
-    type: 'boolean' as const,
-    description: 'Output as JSON',
+    type: "boolean" as const,
+    description: "Output as JSON",
     default: false,
   },
-  'no-cache': {
-    type: 'boolean' as const,
-    description: 'Bypass cache, fetch fresh data',
+  "no-cache": {
+    type: "boolean" as const,
+    description: "Bypass cache, fetch fresh data",
     default: false,
   },
-} as const
+} as const;
 
 /**
  * Resolve a PURL string or shorthand into [registry, name, version].
  * Uses CachedRegistry unless --no-cache is set.
  */
 export function resolvePURL(input: string, useCache = true): [Registry, string, string] {
-  let purl = input
-  if (!purl.startsWith('pkg:')) {
-    purl = `pkg:${purl}`
+  let purl = input;
+  if (!purl.startsWith("pkg:")) {
+    purl = `pkg:${purl}`;
   }
 
   if (useCache) {
-    const parsed = parsePURL(purl)
-    const baseURL = parsed.qualifiers['repository_url'] ?? ''
-    const inner = create(parsed.type, baseURL || undefined)
-    const reg = new CachedRegistry(inner)
-    return [reg, fullName(parsed), parsed.version]
+    const parsed = parsePURL(purl);
+    const baseURL = parsed.qualifiers["repository_url"] ?? "";
+    const inner = create(parsed.type, baseURL || undefined);
+    const reg = new CachedRegistry(inner);
+    return [reg, fullName(parsed), parsed.version];
   }
 
-  return createFromPURL(purl)
+  return createFromPURL(purl);
 }
 
 /** Run a command with standard error handling. */
 export async function withErrorHandling(fn: () => Promise<void>): Promise<void> {
   try {
-    await fn()
-  }
-  catch (error) {
+    await fn();
+  } catch (error) {
     if (error instanceof NotFoundError) {
-      consola.error(`Package not found: ${error.ecosystem}/${error.packageName}${error.version ? `@${error.version}` : ''}`)
-      process.exit(1)
+      consola.error(
+        `Package not found: ${error.ecosystem}/${error.packageName}${error.version ? `@${error.version}` : ""}`,
+      );
+      process.exit(1);
     }
     if (error instanceof UnknownEcosystemError) {
-      consola.error(`Unknown ecosystem: ${error.ecosystem}`)
-      consola.info('Supported: npm, cargo, pypi, gem, composer')
-      process.exit(1)
+      consola.error(`Unknown ecosystem: ${error.ecosystem}`);
+      consola.info("Supported: npm, cargo, pypi, gem, composer");
+      process.exit(1);
     }
     if (error instanceof InvalidPURLError) {
-      consola.error(`Invalid PURL: ${error.purl}`)
-      consola.info('Examples: pkg:npm/lodash, npm/lodash@4.17.21, pkg:cargo/serde')
-      process.exit(1)
+      consola.error(`Invalid PURL: ${error.purl}`);
+      consola.info("Examples: pkg:npm/lodash, npm/lodash@4.17.21, pkg:cargo/serde");
+      process.exit(1);
     }
-    throw error
+    throw error;
   }
 }

--- a/src/commands/versions.ts
+++ b/src/commands/versions.ts
@@ -1,55 +1,59 @@
-import { defineCommand } from 'citty'
-import consola from 'consola'
-import { sharedArgs, resolvePURL, withErrorHandling } from './shared.ts'
+import { defineCommand } from "citty";
+import consola from "consola";
+import { sharedArgs, resolvePURL, withErrorHandling } from "./shared.ts";
 
 export default defineCommand({
   meta: {
-    name: 'versions',
-    description: 'List package versions',
+    name: "versions",
+    description: "List package versions",
   },
   args: {
     ...sharedArgs,
     purl: {
-      type: 'positional',
-      description: 'Package PURL (e.g. pkg:npm/lodash, cargo/serde)',
+      type: "positional",
+      description: "Package PURL (e.g. pkg:npm/lodash, cargo/serde)",
       required: true,
     },
     limit: {
-      type: 'string',
-      alias: 'l',
-      description: 'Max versions to show',
-      default: '20',
+      type: "string",
+      alias: "l",
+      description: "Max versions to show",
+      default: "20",
     },
   },
   async run({ args }) {
     await withErrorHandling(async () => {
-      const [reg, name] = resolvePURL(args.purl, !args['no-cache'])
-      const versions = await reg.fetchVersions(name)
-      const limit = Number.parseInt(args.limit, 10) || 20
+      const [reg, name] = resolvePURL(args.purl, !args["no-cache"]);
+      const versions = await reg.fetchVersions(name);
+      const limit = Number.parseInt(args.limit, 10) || 20;
 
       if (args.json) {
-        console.log(JSON.stringify(versions.slice(0, limit), null, 2))
-        return
+        console.log(JSON.stringify(versions.slice(0, limit), null, 2));
+        return;
       }
 
-      const shown = versions.slice(0, limit)
+      const shown = versions.slice(0, limit);
 
-      consola.log('')
-      consola.log(`  \x1b[1m${name}\x1b[0m — ${versions.length} version${versions.length === 1 ? '' : 's'}`)
-      consola.log('')
+      consola.log("");
+      consola.log(
+        `  \x1b[1m${name}\x1b[0m — ${versions.length} version${versions.length === 1 ? "" : "s"}`,
+      );
+      consola.log("");
 
       for (const v of shown) {
-        const status = v.status ? ` \x1b[33m[${v.status}]\x1b[0m` : ''
+        const status = v.status ? ` \x1b[33m[${v.status}]\x1b[0m` : "";
         const date = v.publishedAt
           ? `  \x1b[90m${v.publishedAt.toISOString().slice(0, 10)}\x1b[0m`
-          : ''
-        consola.log(`  ${v.number}${status}${date}`)
+          : "";
+        consola.log(`  ${v.number}${status}${date}`);
       }
 
       if (versions.length > limit) {
-        consola.log(`\n  \x1b[90m... and ${versions.length - limit} more (use --limit to show more)\x1b[0m`)
+        consola.log(
+          `\n  \x1b[90m... and ${versions.length - limit} more (use --limit to show more)\x1b[0m`,
+        );
       }
-      consola.log('')
-    })
+      consola.log("");
+    });
   },
-})
+});

--- a/src/core/AGENTS.md
+++ b/src/core/AGENTS.md
@@ -1,9 +1,11 @@
 # CORE GUIDE
 
 ## OVERVIEW
+
 `src/core` defines the stable contract layer: types, errors, PURL parser, registry factory, client behavior, and normalization helpers.
 
 ## STRUCTURE
+
 ```text
 src/core/
 |- client.ts      # HTTP, retries, timeout, rate limiter hook
@@ -17,25 +19,29 @@ src/core/
 ```
 
 ## WHERE TO LOOK
-| Task | Location | Notes |
-|------|----------|-------|
-| Registry creation flow | `src/core/registry.ts` | `register` + `create` map-based factory |
-| PURL parse/build behavior | `src/core/purl.ts` | Single source of truth for validation and normalization |
-| HTTP retries/timeouts | `src/core/client.ts` | Shared retry status list and backoff policy |
-| Type-level contract updates | `src/core/types.ts` | Changes cascade to all adapters and CLI |
-| Domain-specific errors | `src/core/errors.ts` | Throw these classes from adapters/helpers |
-| URL normalization | `src/core/repository.ts` | Canonical repository link cleanup |
+
+| Task                        | Location                 | Notes                                                   |
+| --------------------------- | ------------------------ | ------------------------------------------------------- |
+| Registry creation flow      | `src/core/registry.ts`   | `register` + `create` map-based factory                 |
+| PURL parse/build behavior   | `src/core/purl.ts`       | Single source of truth for validation and normalization |
+| HTTP retries/timeouts       | `src/core/client.ts`     | Shared retry status list and backoff policy             |
+| Type-level contract updates | `src/core/types.ts`      | Changes cascade to all adapters and CLI                 |
+| Domain-specific errors      | `src/core/errors.ts`     | Throw these classes from adapters/helpers               |
+| URL normalization           | `src/core/repository.ts` | Canonical repository link cleanup                       |
 
 ## CONVENTIONS
+
 - Throw typed errors (`InvalidPURLError`, `NotFoundError`, `RateLimitError`) instead of plain `Error` in core flows.
 - `Client` owns network behavior defaults (`maxRetries`, `timeout`, retry codes).
 - `VersionStatus` and `Scope` are closed unions; keep adapter outputs inside allowed values.
 
 ## ANTI-PATTERNS
+
 - No direct registry-specific assumptions in core modules.
 - No duplicate PURL parsing utilities outside `purl.ts`.
 - No hardcoded HTTP behavior in adapters when client defaults exist.
 
 ## NOTES
+
 - Keep core adapter-agnostic; keep ecosystem details in `src/registries`.
 - Assume changes to `types.ts` require updates in tests and multiple adapters.

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -1,86 +1,83 @@
-import { ofetch, FetchError } from 'ofetch'
-import type { $Fetch } from 'ofetch'
-import type { ClientOptions, RateLimiter } from './types.ts'
-import { HTTPError, RateLimitError } from './errors.ts'
+import { ofetch, FetchError } from "ofetch";
+import type { $Fetch } from "ofetch";
+import type { ClientOptions, RateLimiter } from "./types.ts";
+import { HTTPError, RateLimitError } from "./errors.ts";
 
-const DEFAULT_MAX_RETRIES = 5
-const DEFAULT_BASE_DELAY = 50
-const DEFAULT_TIMEOUT = 30_000
-const DEFAULT_USER_AGENT = 'regxa/0.1.0'
+const DEFAULT_MAX_RETRIES = 5;
+const DEFAULT_BASE_DELAY = 50;
+const DEFAULT_TIMEOUT = 30_000;
+const DEFAULT_USER_AGENT = "regxa/0.1.0";
 
 /** HTTP client with retry, backoff, rate limiting, and timeout. */
 export class Client {
-  readonly maxRetries: number
-  readonly baseDelay: number
-  readonly timeout: number
-  readonly userAgent: string
-  private readonly rateLimiter: RateLimiter | null
-  private readonly fetch: $Fetch
+  readonly maxRetries: number;
+  readonly baseDelay: number;
+  readonly timeout: number;
+  readonly userAgent: string;
+  private readonly rateLimiter: RateLimiter | null;
+  private readonly fetch: $Fetch;
 
   constructor(options: ClientOptions = {}) {
-    this.maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES
-    this.baseDelay = options.baseDelay ?? DEFAULT_BASE_DELAY
-    this.timeout = options.timeout ?? DEFAULT_TIMEOUT
-    this.userAgent = options.userAgent ?? DEFAULT_USER_AGENT
-    this.rateLimiter = options.rateLimiter ?? null
+    this.maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
+    this.baseDelay = options.baseDelay ?? DEFAULT_BASE_DELAY;
+    this.timeout = options.timeout ?? DEFAULT_TIMEOUT;
+    this.userAgent = options.userAgent ?? DEFAULT_USER_AGENT;
+    this.rateLimiter = options.rateLimiter ?? null;
 
-    const maxRetries = this.maxRetries
-    const baseDelay = this.baseDelay
+    const maxRetries = this.maxRetries;
+    const baseDelay = this.baseDelay;
 
     this.fetch = ofetch.create({
       retry: this.maxRetries,
       retryDelay(context) {
-        const remaining = typeof context.options.retry === 'number' ? context.options.retry : 0
-        const attempt = maxRetries - remaining
-        const delay = baseDelay * Math.pow(2, attempt - 1)
-        const jitter = delay * Math.random() * 0.1
-        return delay + jitter
+        const remaining = typeof context.options.retry === "number" ? context.options.retry : 0;
+        const attempt = maxRetries - remaining;
+        const delay = baseDelay * Math.pow(2, attempt - 1);
+        const jitter = delay * Math.random() * 0.1;
+        return delay + jitter;
       },
       retryStatusCodes: [408, 409, 425, 429, 500, 502, 503, 504],
       timeout: this.timeout,
       headers: {
-        'Accept': 'application/json',
-        'User-Agent': this.userAgent,
+        Accept: "application/json",
+        "User-Agent": this.userAgent,
       },
-    })
+    });
   }
 
   /** Fetch JSON from a URL with retry and rate limiting. */
   async getJSON<T>(url: string, signal?: AbortSignal): Promise<T> {
     if (this.rateLimiter) {
-      await this.rateLimiter.wait(signal)
+      await this.rateLimiter.wait(signal);
     }
 
     try {
-      return await this.fetch<T>(url, { signal })
-    }
-    catch (error) {
+      return await this.fetch<T>(url, { signal });
+    } catch (error) {
       if (error instanceof FetchError) {
         if (error.statusCode === 429) {
           const retryAfter = Number.parseInt(
-            error.response?.headers.get('Retry-After') ?? '60',
+            error.response?.headers.get("Retry-After") ?? "60",
             10,
-          )
-          throw new RateLimitError(retryAfter)
+          );
+          throw new RateLimitError(retryAfter);
         }
 
-        const body = typeof error.data === 'string'
-          ? error.data
-          : JSON.stringify(error.data ?? '')
+        const body = typeof error.data === "string" ? error.data : JSON.stringify(error.data ?? "");
 
-        throw new HTTPError(error.statusCode ?? 0, url, body)
+        throw new HTTPError(error.statusCode ?? 0, url, body);
       }
-      throw error
+      throw error;
     }
   }
 }
 
-let _defaultClient: Client | undefined
+let _defaultClient: Client | undefined;
 
 /** Get or create the shared default client. */
 export function defaultClient(): Client {
   if (!_defaultClient) {
-    _defaultClient = new Client()
+    _defaultClient = new Client();
   }
-  return _defaultClient
+  return _defaultClient;
 }

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -2,78 +2,78 @@
 
 export class PkioError extends Error {
   constructor(message: string, options?: ErrorOptions) {
-    super(message, options)
-    this.name = 'PkioError'
+    super(message, options);
+    this.name = "PkioError";
   }
 }
 
 export class HTTPError extends PkioError {
-  readonly statusCode: number
-  readonly url: string
-  readonly body: string
+  readonly statusCode: number;
+  readonly url: string;
+  readonly body: string;
 
   constructor(statusCode: number, url: string, body: string) {
-    super(`HTTP ${statusCode}: ${url}`)
-    this.name = 'HTTPError'
-    this.statusCode = statusCode
-    this.url = url
-    this.body = body
+    super(`HTTP ${statusCode}: ${url}`);
+    this.name = "HTTPError";
+    this.statusCode = statusCode;
+    this.url = url;
+    this.body = body;
   }
 
   isNotFound(): boolean {
-    return this.statusCode === 404
+    return this.statusCode === 404;
   }
 
   isRateLimit(): boolean {
-    return this.statusCode === 429
+    return this.statusCode === 429;
   }
 
   isServerError(): boolean {
-    return this.statusCode >= 500
+    return this.statusCode >= 500;
   }
 }
 
 export class NotFoundError extends PkioError {
-  readonly ecosystem: string
-  readonly packageName: string
-  readonly version: string
+  readonly ecosystem: string;
+  readonly packageName: string;
+  readonly version: string;
 
-  constructor(ecosystem: string, packageName: string, version = '') {
-    const versionSuffix = version ? `@${version}` : ''
-    super(`Package not found: ${ecosystem}/${packageName}${versionSuffix}`)
-    this.name = 'NotFoundError'
-    this.ecosystem = ecosystem
-    this.packageName = packageName
-    this.version = version
+  constructor(ecosystem: string, packageName: string, version = "") {
+    const versionSuffix = version ? `@${version}` : "";
+    super(`Package not found: ${ecosystem}/${packageName}${versionSuffix}`);
+    this.name = "NotFoundError";
+    this.ecosystem = ecosystem;
+    this.packageName = packageName;
+    this.version = version;
   }
 }
 
 export class RateLimitError extends PkioError {
-  readonly retryAfter: number
+  readonly retryAfter: number;
 
   constructor(retryAfter: number) {
-    super(`Rate limited. Retry after ${retryAfter}s`)
-    this.name = 'RateLimitError'
-    this.retryAfter = retryAfter
+    super(`Rate limited. Retry after ${retryAfter}s`);
+    this.name = "RateLimitError";
+    this.retryAfter = retryAfter;
   }
 }
 
 export class UnknownEcosystemError extends PkioError {
-  readonly ecosystem: string
+  readonly ecosystem: string;
 
   constructor(ecosystem: string) {
-    super(`Unknown ecosystem: ${ecosystem}`)
-    this.name = 'UnknownEcosystemError'
-    this.ecosystem = ecosystem
+    super(`Unknown ecosystem: ${ecosystem}`);
+    this.name = "UnknownEcosystemError";
+    this.ecosystem = ecosystem;
   }
 }
 
 export class InvalidPURLError extends PkioError {
-  readonly purl: string
+  readonly purl: string;
 
   constructor(purl: string, reason: string) {
-    super(`Invalid PURL "${purl}": ${reason}`)
-    this.name = 'InvalidPURLError'
-    this.purl = purl
+    super(`Invalid PURL "${purl}": ${reason}`);
+    this.name = "InvalidPURLError";
+    this.purl = purl;
   }
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,9 +1,9 @@
 // Core
-export { Client, defaultClient } from './client.ts'
-export { register, create, ecosystems, has } from './registry.ts'
-export { parsePURL, fullName, createFromPURL, buildPURL } from './purl.ts'
-export { normalizeLicense, combineLicenses } from './license.ts'
-export { normalizeRepositoryURL } from './repository.ts'
+export { Client, defaultClient } from "./client.ts";
+export { register, create, ecosystems, has } from "./registry.ts";
+export { parsePURL, fullName, createFromPURL, buildPURL } from "./purl.ts";
+export { normalizeLicense, combineLicenses } from "./license.ts";
+export { normalizeRepositoryURL } from "./repository.ts";
 
 // Errors
 export {
@@ -13,7 +13,7 @@ export {
   RateLimitError,
   UnknownEcosystemError,
   InvalidPURLError,
-} from './errors.ts'
+} from "./errors.ts";
 
 // Types
 export type {
@@ -29,4 +29,4 @@ export type {
   ClientOptions,
   RateLimiter,
   ParsedPURL,
-} from './types.ts'
+} from "./types.ts";

--- a/src/core/license.ts
+++ b/src/core/license.ts
@@ -5,65 +5,63 @@
  * Passes through already-valid SPDX identifiers unchanged.
  */
 export function normalizeLicense(raw: string | null | undefined): string {
-  if (!raw) return ''
+  if (!raw) return "";
 
-  const trimmed = raw.trim()
-  if (!trimmed) return ''
+  const trimmed = raw.trim();
+  if (!trimmed) return "";
 
   // Common mappings
-  const lower = trimmed.toLowerCase()
-  const known = LICENSE_MAP.get(lower)
-  if (known) return known
+  const lower = trimmed.toLowerCase();
+  const known = LICENSE_MAP.get(lower);
+  if (known) return known;
 
   // Already looks like SPDX — return as-is
-  return trimmed
+  return trimmed;
 }
 
 const LICENSE_MAP = new Map<string, string>([
-  ['mit license', 'MIT'],
-  ['mit', 'MIT'],
-  ['apache license 2.0', 'Apache-2.0'],
-  ['apache 2.0', 'Apache-2.0'],
-  ['apache-2.0', 'Apache-2.0'],
-  ['apache license, version 2.0', 'Apache-2.0'],
-  ['apache2', 'Apache-2.0'],
-  ['bsd-2-clause', 'BSD-2-Clause'],
-  ['bsd-3-clause', 'BSD-3-Clause'],
-  ['bsd 2-clause', 'BSD-2-Clause'],
-  ['bsd 3-clause', 'BSD-3-Clause'],
-  ['simplified bsd license', 'BSD-2-Clause'],
-  ['new bsd license', 'BSD-3-Clause'],
-  ['isc license', 'ISC'],
-  ['isc', 'ISC'],
-  ['gpl-2.0', 'GPL-2.0-only'],
-  ['gpl-3.0', 'GPL-3.0-only'],
-  ['gpl-2.0-only', 'GPL-2.0-only'],
-  ['gpl-3.0-only', 'GPL-3.0-only'],
-  ['lgpl-2.1', 'LGPL-2.1-only'],
-  ['lgpl-3.0', 'LGPL-3.0-only'],
-  ['mpl-2.0', 'MPL-2.0'],
-  ['mozilla public license 2.0', 'MPL-2.0'],
-  ['unlicense', 'Unlicense'],
-  ['the unlicense', 'Unlicense'],
-  ['cc0-1.0', 'CC0-1.0'],
-  ['cc0', 'CC0-1.0'],
-  ['public domain', 'Unlicense'],
-  ['zlib', 'Zlib'],
-  ['wtfpl', 'WTFPL'],
-  ['artistic-2.0', 'Artistic-2.0'],
-  ['boost software license 1.0', 'BSL-1.0'],
-  ['bsl-1.0', 'BSL-1.0'],
-])
+  ["mit license", "MIT"],
+  ["mit", "MIT"],
+  ["apache license 2.0", "Apache-2.0"],
+  ["apache 2.0", "Apache-2.0"],
+  ["apache-2.0", "Apache-2.0"],
+  ["apache license, version 2.0", "Apache-2.0"],
+  ["apache2", "Apache-2.0"],
+  ["bsd-2-clause", "BSD-2-Clause"],
+  ["bsd-3-clause", "BSD-3-Clause"],
+  ["bsd 2-clause", "BSD-2-Clause"],
+  ["bsd 3-clause", "BSD-3-Clause"],
+  ["simplified bsd license", "BSD-2-Clause"],
+  ["new bsd license", "BSD-3-Clause"],
+  ["isc license", "ISC"],
+  ["isc", "ISC"],
+  ["gpl-2.0", "GPL-2.0-only"],
+  ["gpl-3.0", "GPL-3.0-only"],
+  ["gpl-2.0-only", "GPL-2.0-only"],
+  ["gpl-3.0-only", "GPL-3.0-only"],
+  ["lgpl-2.1", "LGPL-2.1-only"],
+  ["lgpl-3.0", "LGPL-3.0-only"],
+  ["mpl-2.0", "MPL-2.0"],
+  ["mozilla public license 2.0", "MPL-2.0"],
+  ["unlicense", "Unlicense"],
+  ["the unlicense", "Unlicense"],
+  ["cc0-1.0", "CC0-1.0"],
+  ["cc0", "CC0-1.0"],
+  ["public domain", "Unlicense"],
+  ["zlib", "Zlib"],
+  ["wtfpl", "WTFPL"],
+  ["artistic-2.0", "Artistic-2.0"],
+  ["boost software license 1.0", "BSL-1.0"],
+  ["bsl-1.0", "BSL-1.0"],
+]);
 
 /**
  * Combine multiple license strings into a single SPDX expression.
  */
 export function combineLicenses(licenses: (string | null | undefined)[]): string {
-  const normalized = licenses
-    .map(l => normalizeLicense(l))
-    .filter(Boolean)
+  const normalized = licenses.map((l) => normalizeLicense(l)).filter(Boolean);
 
-  if (normalized.length === 0) return ''
-  if (normalized.length === 1) return normalized[0]!
-  return normalized.join(' AND ')
+  if (normalized.length === 0) return "";
+  if (normalized.length === 1) return normalized[0]!;
+  return normalized.join(" AND ");
 }

--- a/src/core/purl.ts
+++ b/src/core/purl.ts
@@ -1,7 +1,7 @@
-import type { ParsedPURL, Registry } from './types.ts'
-import type { Client } from './client.ts'
-import { create } from './registry.ts'
-import { InvalidPURLError } from './errors.ts'
+import type { ParsedPURL, Registry } from "./types.ts";
+import type { Client } from "./client.ts";
+import { create } from "./registry.ts";
+import { InvalidPURLError } from "./errors.ts";
 
 /**
  * Parse a PURL string into its components.
@@ -11,124 +11,139 @@ import { InvalidPURLError } from './errors.ts'
  * @see https://github.com/package-url/purl-spec (ECMA-427)
  */
 export function parsePURL(purlStr: string): ParsedPURL {
-  if (!purlStr.startsWith('pkg:')) {
-    throw new InvalidPURLError(purlStr, 'must start with "pkg:"')
+  if (!purlStr.startsWith("pkg:")) {
+    throw new InvalidPURLError(purlStr, 'must start with "pkg:"');
   }
 
-  let remainder = purlStr.slice(4) // strip 'pkg:'
+  let remainder = purlStr.slice(4); // strip 'pkg:'
 
   // Extract subpath
-  let subpath = ''
-  const hashIdx = remainder.indexOf('#')
+  let subpath = "";
+  const hashIdx = remainder.indexOf("#");
   if (hashIdx !== -1) {
-    subpath = remainder.slice(hashIdx + 1).split('/').map(s => decodeURIComponent(s)).join('/')
-    remainder = remainder.slice(0, hashIdx)
+    subpath = remainder
+      .slice(hashIdx + 1)
+      .split("/")
+      .map((s) => decodeURIComponent(s))
+      .join("/");
+    remainder = remainder.slice(0, hashIdx);
   }
 
   // Extract qualifiers
-  const qualifiers: Record<string, string> = {}
-  const queryIdx = remainder.indexOf('?')
+  const qualifiers: Record<string, string> = {};
+  const queryIdx = remainder.indexOf("?");
   if (queryIdx !== -1) {
-    const queryStr = remainder.slice(queryIdx + 1)
-    remainder = remainder.slice(0, queryIdx)
-    for (const pair of queryStr.split('&')) {
-      const eqIdx = pair.indexOf('=')
+    const queryStr = remainder.slice(queryIdx + 1);
+    remainder = remainder.slice(0, queryIdx);
+    for (const pair of queryStr.split("&")) {
+      const eqIdx = pair.indexOf("=");
       if (eqIdx !== -1) {
-        qualifiers[decodeURIComponent(pair.slice(0, eqIdx))] = decodeURIComponent(pair.slice(eqIdx + 1))
+        qualifiers[decodeURIComponent(pair.slice(0, eqIdx))] = decodeURIComponent(
+          pair.slice(eqIdx + 1),
+        );
       }
     }
   }
 
   // Extract version
-  let version = ''
-  const atIdx = remainder.indexOf('@')
+  let version = "";
+  const atIdx = remainder.indexOf("@");
   if (atIdx !== -1) {
-    version = decodeURIComponent(remainder.slice(atIdx + 1))
-    remainder = remainder.slice(0, atIdx)
+    version = decodeURIComponent(remainder.slice(atIdx + 1));
+    remainder = remainder.slice(0, atIdx);
   }
 
   // Extract type
-  const slashIdx = remainder.indexOf('/')
+  const slashIdx = remainder.indexOf("/");
   if (slashIdx === -1) {
-    throw new InvalidPURLError(purlStr, 'missing type/name separator')
+    throw new InvalidPURLError(purlStr, "missing type/name separator");
   }
 
-  const type = remainder.slice(0, slashIdx).toLowerCase()
+  const type = remainder.slice(0, slashIdx).toLowerCase();
   if (!type) {
-    throw new InvalidPURLError(purlStr, 'empty type')
+    throw new InvalidPURLError(purlStr, "empty type");
   }
 
-  const rest = remainder.slice(slashIdx + 1)
+  const rest = remainder.slice(slashIdx + 1);
   if (!rest) {
-    throw new InvalidPURLError(purlStr, 'empty name')
+    throw new InvalidPURLError(purlStr, "empty name");
   }
 
   // Extract namespace and name
-  const lastSlashIdx = rest.lastIndexOf('/')
-  let namespace = ''
-  let name: string
+  const lastSlashIdx = rest.lastIndexOf("/");
+  let namespace = "";
+  let name: string;
 
   if (lastSlashIdx !== -1) {
-    namespace = rest.slice(0, lastSlashIdx).split('/').map(s => decodeURIComponent(s)).join('/')
-    name = decodeURIComponent(rest.slice(lastSlashIdx + 1))
-  }
-  else {
-    name = decodeURIComponent(rest)
+    namespace = rest
+      .slice(0, lastSlashIdx)
+      .split("/")
+      .map((s) => decodeURIComponent(s))
+      .join("/");
+    name = decodeURIComponent(rest.slice(lastSlashIdx + 1));
+  } else {
+    name = decodeURIComponent(rest);
   }
 
   // Ecosystem-specific normalization per PURL spec
-  if (type === 'pypi') {
-    name = name.toLowerCase().replace(/_/g, '-')
+  if (type === "pypi") {
+    name = name.toLowerCase().replace(/_/g, "-");
   }
 
-  if (type === 'alpm') {
-    name = name.toLowerCase()
+  if (type === "alpm") {
+    name = name.toLowerCase();
   }
 
-  return { type, namespace, name, version, qualifiers, subpath }
+  return { type, namespace, name, version, qualifiers, subpath };
 }
 
 /** Build the full name from namespace + name (e.g., "@scope/pkg" for npm). */
 export function fullName(parsed: ParsedPURL): string {
   if (parsed.namespace) {
-    return `${parsed.namespace}/${parsed.name}`
+    return `${parsed.namespace}/${parsed.name}`;
   }
-  return parsed.name
+  return parsed.name;
 }
 
 /** Create a registry instance from a PURL, returning [registry, name, version]. */
 export function createFromPURL(purlStr: string, client?: Client): [Registry, string, string] {
-  const parsed = parsePURL(purlStr)
-  const baseURL = parsed.qualifiers['repository_url'] ?? ''
-  const reg = create(parsed.type, baseURL || undefined, client)
-  return [reg, fullName(parsed), parsed.version]
+  const parsed = parsePURL(purlStr);
+  const baseURL = parsed.qualifiers["repository_url"] ?? "";
+  const reg = create(parsed.type, baseURL || undefined, client);
+  return [reg, fullName(parsed), parsed.version];
 }
 
 /** Build a PURL string from components. Inverse of `parsePURL`. */
 export function buildPURL(parts: {
-  type: string
-  name: string
-  version?: string
-  namespace?: string
-  qualifiers?: Record<string, string>
-  subpath?: string
+  type: string;
+  name: string;
+  version?: string;
+  namespace?: string;
+  qualifiers?: Record<string, string>;
+  subpath?: string;
 }): string {
-  let purl = `pkg:${parts.type}/`
+  let purl = `pkg:${parts.type}/`;
   if (parts.namespace) {
-    purl += `${parts.namespace.split('/').map(s => encodeURIComponent(s)).join('/')}/`
+    purl += `${parts.namespace
+      .split("/")
+      .map((s) => encodeURIComponent(s))
+      .join("/")}/`;
   }
-  purl += encodeURIComponent(parts.name)
+  purl += encodeURIComponent(parts.name);
   if (parts.version) {
-    purl += `@${encodeURIComponent(parts.version)}`
+    purl += `@${encodeURIComponent(parts.version)}`;
   }
   if (parts.qualifiers && Object.keys(parts.qualifiers).length > 0) {
     const qs = Object.entries(parts.qualifiers)
       .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
-      .join('&')
-    purl += `?${qs}`
+      .join("&");
+    purl += `?${qs}`;
   }
   if (parts.subpath) {
-    purl += `#${parts.subpath.split('/').map(s => encodeURIComponent(s)).join('/')}`
+    purl += `#${parts.subpath
+      .split("/")
+      .map((s) => encodeURIComponent(s))
+      .join("/")}`;
   }
-  return purl
+  return purl;
 }

--- a/src/core/registry.ts
+++ b/src/core/registry.ts
@@ -1,33 +1,33 @@
-import type { Registry, RegistryFactory } from './types.ts'
-import type { Client } from './client.ts'
-import { defaultClient } from './client.ts'
-import { UnknownEcosystemError } from './errors.ts'
+import type { Registry, RegistryFactory } from "./types.ts";
+import type { Client } from "./client.ts";
+import { defaultClient } from "./client.ts";
+import { UnknownEcosystemError } from "./errors.ts";
 
-const factories = new Map<string, RegistryFactory>()
-const defaults = new Map<string, string>()
+const factories = new Map<string, RegistryFactory>();
+const defaults = new Map<string, string>();
 
 /** Register an ecosystem factory. Called by each registry module on import (side-effect). */
 export function register(ecosystem: string, defaultURL: string, factory: RegistryFactory): void {
-  factories.set(ecosystem, factory)
-  defaults.set(ecosystem, defaultURL)
+  factories.set(ecosystem, factory);
+  defaults.set(ecosystem, defaultURL);
 }
 
 /** Create a registry instance for the given ecosystem. */
 export function create(ecosystem: string, baseURL?: string, client?: Client): Registry {
-  const factory = factories.get(ecosystem)
+  const factory = factories.get(ecosystem);
   if (!factory) {
-    throw new UnknownEcosystemError(ecosystem)
+    throw new UnknownEcosystemError(ecosystem);
   }
-  const url = baseURL || defaults.get(ecosystem)!
-  return factory(url, client ?? defaultClient())
+  const url = baseURL || defaults.get(ecosystem)!;
+  return factory(url, client ?? defaultClient());
 }
 
 /** List all registered ecosystem names. */
 export function ecosystems(): string[] {
-  return [...factories.keys()]
+  return [...factories.keys()];
 }
 
 /** Check if an ecosystem is registered. */
 export function has(ecosystem: string): boolean {
-  return factories.has(ecosystem)
+  return factories.has(ecosystem);
 }

--- a/src/core/repository.ts
+++ b/src/core/repository.ts
@@ -9,74 +9,71 @@
  * - { url: "..." } → extracted and normalized
  */
 export function normalizeRepositoryURL(raw: unknown): string {
-  if (!raw) return ''
+  if (!raw) return "";
 
-  let url: string
+  let url: string;
 
-  if (typeof raw === 'string') {
-    url = raw
-  }
-  else if (typeof raw === 'object' && raw !== null) {
-    const obj = raw as Record<string, unknown>
-    if (typeof obj['url'] === 'string') {
-      url = obj['url']
+  if (typeof raw === "string") {
+    url = raw;
+  } else if (typeof raw === "object" && raw !== null) {
+    const obj = raw as Record<string, unknown>;
+    if (typeof obj["url"] === "string") {
+      url = obj["url"];
+    } else {
+      return "";
     }
-    else {
-      return ''
-    }
-  }
-  else {
-    return ''
+  } else {
+    return "";
   }
 
-  url = url.trim()
-  if (!url) return ''
+  url = url.trim();
+  if (!url) return "";
 
   // GitHub shorthand: "github:user/repo"
-  if (url.startsWith('github:')) {
-    return `https://github.com/${url.slice(7)}`
+  if (url.startsWith("github:")) {
+    return `https://github.com/${url.slice(7)}`;
   }
 
   // GitLab shorthand
-  if (url.startsWith('gitlab:')) {
-    return `https://gitlab.com/${url.slice(7)}`
+  if (url.startsWith("gitlab:")) {
+    return `https://gitlab.com/${url.slice(7)}`;
   }
 
   // Bitbucket shorthand
-  if (url.startsWith('bitbucket:')) {
-    return `https://bitbucket.org/${url.slice(10)}`
+  if (url.startsWith("bitbucket:")) {
+    return `https://bitbucket.org/${url.slice(10)}`;
   }
 
   // Strip "git+" prefix
-  if (url.startsWith('git+')) {
-    url = url.slice(4)
+  if (url.startsWith("git+")) {
+    url = url.slice(4);
   }
 
   // Convert git:// to https://
-  if (url.startsWith('git://')) {
-    url = 'https://' + url.slice(6)
+  if (url.startsWith("git://")) {
+    url = "https://" + url.slice(6);
   }
 
   // Convert ssh://git@host/... to https://host/...
-  if (url.startsWith('ssh://git@')) {
-    url = 'https://' + url.slice(10)
+  if (url.startsWith("ssh://git@")) {
+    url = "https://" + url.slice(10);
   }
 
   // Convert git@host:user/repo to https://host/user/repo
-  const sshMatch = url.match(/^git@([^:]+):(.+)$/)
+  const sshMatch = url.match(/^git@([^:]+):(.+)$/);
   if (sshMatch) {
-    url = `https://${sshMatch[1]}/${sshMatch[2]}`
+    url = `https://${sshMatch[1]}/${sshMatch[2]}`;
   }
 
   // Strip .git suffix
-  if (url.endsWith('.git')) {
-    url = url.slice(0, -4)
+  if (url.endsWith(".git")) {
+    url = url.slice(0, -4);
   }
 
   // Strip trailing slash
-  if (url.endsWith('/')) {
-    url = url.slice(0, -1)
+  if (url.endsWith("/")) {
+    url = url.slice(0, -1);
   }
 
-  return url
+  return url;
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,93 +1,92 @@
-import type { Client } from './client.ts'
+import type { Client } from "./client.ts";
 
 /** Normalized package metadata returned by any registry. */
 export interface Package {
-  name: string
-  description: string
-  homepage: string
-  documentation: string
-  repository: string
-  licenses: string
-  keywords: string[]
-  namespace: string
-  latestVersion: string
-  metadata: Record<string, unknown>
+  name: string;
+  description: string;
+  homepage: string;
+  documentation: string;
+  repository: string;
+  licenses: string;
+  keywords: string[];
+  namespace: string;
+  latestVersion: string;
+  metadata: Record<string, unknown>;
 }
 
 /** A single version entry of a package. */
 export interface Version {
-  number: string
-  publishedAt: Date | null
-  licenses: string
-  integrity: string
-  status: VersionStatus
-  metadata: Record<string, unknown>
+  number: string;
+  publishedAt: Date | null;
+  licenses: string;
+  integrity: string;
+  status: VersionStatus;
+  metadata: Record<string, unknown>;
 }
 
 /** Dependency of a package version. */
 export interface Dependency {
-  name: string
-  requirements: string
-  scope: Scope
-  optional: boolean
+  name: string;
+  requirements: string;
+  scope: Scope;
+  optional: boolean;
 }
 
 /** Maintainer / author of a package. */
 export interface Maintainer {
-  uuid: string
-  login: string
-  name: string
-  email: string
-  url: string
-  role: string
+  uuid: string;
+  login: string;
+  name: string;
+  email: string;
+  url: string;
+  role: string;
 }
 
-export type VersionStatus = '' | 'yanked' | 'deprecated' | 'retracted'
-export type Scope = 'runtime' | 'development' | 'test' | 'build' | 'optional'
+export type VersionStatus = "" | "yanked" | "deprecated" | "retracted";
+export type Scope = "runtime" | "development" | "test" | "build" | "optional";
 
 /** URL builder for a specific registry. */
 export interface URLBuilder {
-  registry(name: string, version?: string): string
-  download(name: string, version: string): string
-  documentation(name: string, version?: string): string
-  readme(name: string, version?: string): string
-  purl(name: string, version?: string): string
+  registry(name: string, version?: string): string;
+  download(name: string, version: string): string;
+  documentation(name: string, version?: string): string;
+  readme(name: string, version?: string): string;
+  purl(name: string, version?: string): string;
 }
 
 /** Common interface every registry must implement. */
 export interface Registry {
-  ecosystem(): string
-  fetchPackage(name: string, signal?: AbortSignal): Promise<Package>
-  fetchVersions(name: string, signal?: AbortSignal): Promise<Version[]>
-  fetchDependencies(name: string, version: string, signal?: AbortSignal): Promise<Dependency[]>
-  fetchMaintainers(name: string, signal?: AbortSignal): Promise<Maintainer[]>
-  urls(): URLBuilder
+  ecosystem(): string;
+  fetchPackage(name: string, signal?: AbortSignal): Promise<Package>;
+  fetchVersions(name: string, signal?: AbortSignal): Promise<Version[]>;
+  fetchDependencies(name: string, version: string, signal?: AbortSignal): Promise<Dependency[]>;
+  fetchMaintainers(name: string, signal?: AbortSignal): Promise<Maintainer[]>;
+  urls(): URLBuilder;
 }
 
 /** Factory function signature for creating registry instances. */
-export type RegistryFactory = (baseURL: string, client: Client) => Registry
+export type RegistryFactory = (baseURL: string, client: Client) => Registry;
 
 /** Options for the HTTP client. */
 export interface ClientOptions {
-  maxRetries?: number
-  baseDelay?: number
-  timeout?: number
-  rateLimiter?: RateLimiter
-  userAgent?: string
+  maxRetries?: number;
+  baseDelay?: number;
+  timeout?: number;
+  rateLimiter?: RateLimiter;
+  userAgent?: string;
 }
 
 /** Rate limiter interface — bring your own implementation. */
 export interface RateLimiter {
-  wait(signal?: AbortSignal): Promise<void>
+  wait(signal?: AbortSignal): Promise<void>;
 }
 
 /** Parsed PURL components. */
 export interface ParsedPURL {
-  type: string
-  namespace: string
-  name: string
-  version: string
-  qualifiers: Record<string, string>
-  subpath: string
+  type: string;
+  namespace: string;
+  name: string;
+  version: string;
+  qualifiers: Record<string, string>;
+  subpath: string;
 }
-

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,61 +1,76 @@
-import type { Package, Version, Dependency, Maintainer, URLBuilder } from './core/types.ts'
-import type { Client } from './core/client.ts'
-import { createFromPURL } from './core/purl.ts'
-import { InvalidPURLError } from './core/errors.ts'
+import type { Package, Version, Dependency, Maintainer, URLBuilder } from "./core/types.ts";
+import type { Client } from "./core/client.ts";
+import { createFromPURL } from "./core/purl.ts";
+import { InvalidPURLError } from "./core/errors.ts";
 
 /** Fetch normalized package metadata from a PURL. */
-export async function fetchPackageFromPURL(purl: string, signal?: AbortSignal, client?: Client): Promise<Package> {
-  const [reg, name] = createFromPURL(purl, client)
-  return reg.fetchPackage(name, signal)
+export async function fetchPackageFromPURL(
+  purl: string,
+  signal?: AbortSignal,
+  client?: Client,
+): Promise<Package> {
+  const [reg, name] = createFromPURL(purl, client);
+  return reg.fetchPackage(name, signal);
 }
 
 /** Fetch all versions from a PURL. */
-export async function fetchVersionsFromPURL(purl: string, signal?: AbortSignal, client?: Client): Promise<Version[]> {
-  const [reg, name] = createFromPURL(purl, client)
-  return reg.fetchVersions(name, signal)
+export async function fetchVersionsFromPURL(
+  purl: string,
+  signal?: AbortSignal,
+  client?: Client,
+): Promise<Version[]> {
+  const [reg, name] = createFromPURL(purl, client);
+  return reg.fetchVersions(name, signal);
 }
 
 /** Fetch dependencies for a specific version from a PURL. */
-export async function fetchDependenciesFromPURL(purl: string, signal?: AbortSignal, client?: Client): Promise<Dependency[]> {
-  const [reg, name, version] = createFromPURL(purl, client)
+export async function fetchDependenciesFromPURL(
+  purl: string,
+  signal?: AbortSignal,
+  client?: Client,
+): Promise<Dependency[]> {
+  const [reg, name, version] = createFromPURL(purl, client);
   if (!version) {
-    throw new InvalidPURLError(purl, 'must include a version for dependency lookup')
+    throw new InvalidPURLError(purl, "must include a version for dependency lookup");
   }
-  return reg.fetchDependencies(name, version, signal)
+  return reg.fetchDependencies(name, version, signal);
 }
 
 /** Fetch maintainers from a PURL. */
-export async function fetchMaintainersFromPURL(purl: string, signal?: AbortSignal, client?: Client): Promise<Maintainer[]> {
-  const [reg, name] = createFromPURL(purl, client)
-  return reg.fetchMaintainers(name, signal)
+export async function fetchMaintainersFromPURL(
+  purl: string,
+  signal?: AbortSignal,
+  client?: Client,
+): Promise<Maintainer[]> {
+  const [reg, name] = createFromPURL(purl, client);
+  return reg.fetchMaintainers(name, signal);
 }
 
-const DEFAULT_CONCURRENCY = 15
+const DEFAULT_CONCURRENCY = 15;
 
 /** Bulk fetch packages from multiple PURLs, with concurrency limit. */
 export async function bulkFetchPackages(
   purls: string[],
-  options?: { concurrency?: number, signal?: AbortSignal, client?: Client },
+  options?: { concurrency?: number; signal?: AbortSignal; client?: Client },
 ): Promise<Map<string, Package>> {
-  const concurrency = options?.concurrency ?? DEFAULT_CONCURRENCY
-  const results = new Map<string, Package>()
-  const queue = [...purls]
+  const concurrency = options?.concurrency ?? DEFAULT_CONCURRENCY;
+  const results = new Map<string, Package>();
+  const queue = [...purls];
 
   const workers = Array.from({ length: Math.min(concurrency, queue.length) }, async () => {
     while (queue.length > 0) {
-      const purl = queue.shift()!
+      const purl = queue.shift()!;
       try {
-        const pkg = await fetchPackageFromPURL(purl, options?.signal, options?.client)
-        results.set(purl, pkg)
-      }
-      catch {
+        const pkg = await fetchPackageFromPURL(purl, options?.signal, options?.client);
+        results.set(purl, pkg);
+      } catch {
         // Silently skip failed lookups — absent from results map
       }
     }
-  })
+  });
 
-  await Promise.all(workers)
-  return results
+  await Promise.all(workers);
+  return results;
 }
 
 /**
@@ -68,32 +83,35 @@ export async function bulkFetchPackages(
  *
  * Returns `null` when no usable version exists.
  */
-export function selectVersion(versions: Version[], options?: {
-  requested?: string
-  latest?: string
-}): Version | null {
-  const { requested, latest } = options ?? {}
+export function selectVersion(
+  versions: Version[],
+  options?: {
+    requested?: string;
+    latest?: string;
+  },
+): Version | null {
+  const { requested, latest } = options ?? {};
 
   if (requested) {
-    const exact = versions.find(v => v.number === requested && v.status === '')
-    if (exact) return exact
+    const exact = versions.find((v) => v.number === requested && v.status === "");
+    if (exact) return exact;
   }
 
   if (latest) {
-    const latestV = versions.find(v => v.number === latest && v.status === '')
-    if (latestV) return latestV
+    const latestV = versions.find((v) => v.number === latest && v.status === "");
+    if (latestV) return latestV;
   }
 
-  const usable = versions.filter(v => v.status === '')
-  if (usable.length === 0) return null
+  const usable = versions.filter((v) => v.status === "");
+  if (usable.length === 0) return null;
 
   usable.sort((a, b) => {
-    const at = a.publishedAt?.getTime() ?? 0
-    const bt = b.publishedAt?.getTime() ?? 0
-    return bt - at
-  })
+    const at = a.publishedAt?.getTime() ?? 0;
+    const bt = b.publishedAt?.getTime() ?? 0;
+    return bt - at;
+  });
 
-  return usable[0] ?? null
+  return usable[0] ?? null;
 }
 
 /**
@@ -105,7 +123,7 @@ export function selectVersion(versions: Version[], options?: {
  * 3. `urls.documentation()` (ecosystem default, e.g. docs.rs, rubydoc.info)
  */
 export function resolveDocsUrl(pkg: Package, urls: URLBuilder, version?: string): string {
-  return pkg.documentation || pkg.homepage || urls.documentation(pkg.name, version)
+  return pkg.documentation || pkg.homepage || urls.documentation(pkg.name, version);
 }
 
 /**
@@ -114,5 +132,5 @@ export function resolveDocsUrl(pkg: Package, urls: URLBuilder, version?: string)
  * Returns the ecosystem-specific URL where the package README can be fetched.
  */
 export function resolveReadmeUrl(pkg: Package, urls: URLBuilder, version?: string): string {
-  return urls.readme(pkg.name, version)
+  return urls.readme(pkg.name, version);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 // Core API
-export { Client, defaultClient } from './core/client.ts'
-export { register, create, ecosystems, has } from './core/registry.ts'
-export { parsePURL, fullName, createFromPURL, buildPURL } from './core/purl.ts'
-export { normalizeLicense, combineLicenses } from './core/license.ts'
-export { normalizeRepositoryURL } from './core/repository.ts'
+export { Client, defaultClient } from "./core/client.ts";
+export { register, create, ecosystems, has } from "./core/registry.ts";
+export { parsePURL, fullName, createFromPURL, buildPURL } from "./core/purl.ts";
+export { normalizeLicense, combineLicenses } from "./core/license.ts";
+export { normalizeRepositoryURL } from "./core/repository.ts";
 
 // Errors
 export {
@@ -13,7 +13,7 @@ export {
   RateLimitError,
   UnknownEcosystemError,
   InvalidPURLError,
-} from './core/errors.ts'
+} from "./core/errors.ts";
 
 // Helpers
 export {
@@ -25,7 +25,7 @@ export {
   selectVersion,
   resolveDocsUrl,
   resolveReadmeUrl,
-} from './helpers.ts'
+} from "./helpers.ts";
 
 // Types
 export type {
@@ -41,14 +41,21 @@ export type {
   ClientOptions,
   RateLimiter,
   ParsedPURL,
-} from './core/types.ts'
+} from "./core/types.ts";
 
 // Cache
-export { getCacheDir } from './cache/paths.ts'
-export { getStorage, getEcosystemStorage, computeIntegrity, disposeStorage, clearStorage, configureStorage } from './cache/storage.ts'
-export { CachedRegistry } from './cache/cached-registry.ts'
-export { createCached } from './cache/index.ts'
-export type { CreateCachedOptions } from './cache/index.ts'
+export { getCacheDir } from "./cache/paths.ts";
+export {
+  getStorage,
+  getEcosystemStorage,
+  computeIntegrity,
+  disposeStorage,
+  clearStorage,
+  configureStorage,
+} from "./cache/storage.ts";
+export { CachedRegistry } from "./cache/cached-registry.ts";
+export { createCached } from "./cache/index.ts";
+export type { CreateCachedOptions } from "./cache/index.ts";
 export {
   readLockfile,
   writeLockfile,
@@ -59,5 +66,5 @@ export {
   removeEntry,
   pruneStale,
   DEFAULT_TTL,
-} from './cache/lockfile.ts'
-export type { Lockfile, LockfileEntry, EntryType } from './cache/lockfile.ts'
+} from "./cache/lockfile.ts";
+export type { Lockfile, LockfileEntry, EntryType } from "./cache/lockfile.ts";

--- a/src/registries/AGENTS.md
+++ b/src/registries/AGENTS.md
@@ -1,9 +1,11 @@
 # REGISTRIES GUIDE
 
 ## OVERVIEW
+
 `src/registries` contains ecosystem adapters implementing a common `Registry` contract and normalizing foreign API payloads into shared core types.
 
 ## STRUCTURE
+
 ```text
 src/registries/
 |- index.ts       # side-effect registration hub
@@ -15,26 +17,30 @@ src/registries/
 ```
 
 ## WHERE TO LOOK
-| Task | Location | Notes |
-|------|----------|-------|
-| Register all ecosystems | `src/registries/index.ts` | Side-effect import hub |
-| npm adapter behavior | `src/registries/npm.ts` | Largest implementation; good pattern baseline |
-| Python package behavior | `src/registries/pypi.ts` | Name normalization and metadata mapping |
-| Cargo crate behavior | `src/registries/cargo.ts` | crates.io-specific dependency mapping |
-| RubyGems behavior | `src/registries/rubygems.ts` | Maintainer/license mapping nuances |
-| Packagist behavior | `src/registries/packagist.ts` | Composer ecosystem parsing |
+
+| Task                    | Location                      | Notes                                         |
+| ----------------------- | ----------------------------- | --------------------------------------------- |
+| Register all ecosystems | `src/registries/index.ts`     | Side-effect import hub                        |
+| npm adapter behavior    | `src/registries/npm.ts`       | Largest implementation; good pattern baseline |
+| Python package behavior | `src/registries/pypi.ts`      | Name normalization and metadata mapping       |
+| Cargo crate behavior    | `src/registries/cargo.ts`     | crates.io-specific dependency mapping         |
+| RubyGems behavior       | `src/registries/rubygems.ts`  | Maintainer/license mapping nuances            |
+| Packagist behavior      | `src/registries/packagist.ts` | Composer ecosystem parsing                    |
 
 ## CONVENTIONS
+
 - Each adapter exposes `ecosystem`, `fetchPackage`, `fetchVersions`, `fetchDependencies`, `fetchMaintainers`, `urls`.
 - Convert source-specific fields into core `Package`/`Version`/`Dependency`/`Maintainer` shapes.
 - Map remote API failures to core error classes.
 - Keep adapter internals self-contained; no adapter-to-adapter imports.
 
 ## ANTI-PATTERNS
+
 - Do not call `fetch` directly; use `Client`.
 - Do not return raw upstream payloads through public methods.
 - Do not skip registration wiring; new adapter must be imported in `index.ts`.
 
 ## NOTES
+
 - `npm.ts` is the largest adapter and a reliable local reference for new adapter patterns.
 - Keep per-registry quirks isolated to that file; normalize before returning shared types.

--- a/src/registries/alpm.ts
+++ b/src/registries/alpm.ts
@@ -1,4 +1,4 @@
-import type { Client } from '../core/client.ts'
+import type { Client } from "../core/client.ts";
 import type {
   Dependency,
   Maintainer,
@@ -7,117 +7,114 @@ import type {
   RegistryFactory,
   URLBuilder,
   Version,
-} from '../core/types.ts'
-import { register } from '../core/registry.ts'
-import { HTTPError, NotFoundError } from '../core/errors.ts'
-import { combineLicenses } from '../core/license.ts'
+} from "../core/types.ts";
+import { register } from "../core/registry.ts";
+import { HTTPError, NotFoundError } from "../core/errors.ts";
+import { combineLicenses } from "../core/license.ts";
 
-const AUR_BASE_URL = 'https://aur.archlinux.org'
+const AUR_BASE_URL = "https://aur.archlinux.org";
 
 /** Arch Linux official package search response. */
 interface ArchSearchResponse {
-  results: ArchPackageResult[]
+  results: ArchPackageResult[];
 }
 
 /** Arch Linux official package data from search/detail endpoints. */
 interface ArchPackageResult {
-  pkgname: string
-  pkgbase: string
-  repo: string
-  arch: string
-  pkgver: string
-  pkgrel: string
-  epoch: number
-  pkgdesc: string
-  url: string
-  filename: string
-  compressed_size: number
-  installed_size: number
-  build_date: string
-  last_update: string
-  flag_date: string | null
-  maintainers: string[]
-  packager: string
-  groups: string[]
-  licenses: string[]
-  conflicts: string[]
-  provides: string[]
-  replaces: string[]
-  depends: string[]
-  optdepends: string[]
-  makedepends: string[]
-  checkdepends: string[]
+  pkgname: string;
+  pkgbase: string;
+  repo: string;
+  arch: string;
+  pkgver: string;
+  pkgrel: string;
+  epoch: number;
+  pkgdesc: string;
+  url: string;
+  filename: string;
+  compressed_size: number;
+  installed_size: number;
+  build_date: string;
+  last_update: string;
+  flag_date: string | null;
+  maintainers: string[];
+  packager: string;
+  groups: string[];
+  licenses: string[];
+  conflicts: string[];
+  provides: string[];
+  replaces: string[];
+  depends: string[];
+  optdepends: string[];
+  makedepends: string[];
+  checkdepends: string[];
 }
 
 /** AUR RPC v5 response wrapper. */
 interface AurResponse {
-  resultcount: number
-  results: AurPackageResult[]
-  type: string
-  version: number
+  resultcount: number;
+  results: AurPackageResult[];
+  type: string;
+  version: number;
 }
 
 /** AUR package data. */
 interface AurPackageResult {
-  ID: number
-  Name: string
-  PackageBase: string
-  PackageBaseID: number
-  Version: string
-  Description: string
-  URL: string
-  NumVotes: number
-  Popularity: number
-  OutOfDate: number | null
-  Maintainer: string | null
-  FirstSubmitted: number
-  LastModified: number
-  URLPath: string
-  Depends?: string[]
-  OptDepends?: string[]
-  MakeDepends?: string[]
-  CheckDepends?: string[]
-  License?: string[]
-  Keywords?: string[]
+  ID: number;
+  Name: string;
+  PackageBase: string;
+  PackageBaseID: number;
+  Version: string;
+  Description: string;
+  URL: string;
+  NumVotes: number;
+  Popularity: number;
+  OutOfDate: number | null;
+  Maintainer: string | null;
+  FirstSubmitted: number;
+  LastModified: number;
+  URLPath: string;
+  Depends?: string[];
+  OptDepends?: string[];
+  MakeDepends?: string[];
+  CheckDepends?: string[];
+  License?: string[];
+  Keywords?: string[];
 }
 
 /** ALPM registry client — routes to Arch Linux official repos or AUR based on namespace. */
 class AlpmRegistry implements Registry {
-  constructor(
-    baseURL: string,
-    client: Client,
-  ) {
-    this.baseURL = baseURL
-    this.client = client
+  constructor(baseURL: string, client: Client) {
+    this.baseURL = baseURL;
+    this.client = client;
   }
 
-  readonly baseURL: string
-  readonly client: Client
+  readonly baseURL: string;
+  readonly client: Client;
 
   ecosystem(): string {
-    return 'alpm'
+    return "alpm";
   }
 
   async fetchPackage(name: string, signal?: AbortSignal): Promise<Package> {
-    const { namespace, pkgName } = this.parseName(name)
-    this.assertSupportedNamespace(namespace, name)
+    const { namespace, pkgName } = this.parseName(name);
+    this.assertSupportedNamespace(namespace, name);
 
-    if (namespace === 'aur') {
-      return this.fetchAurPackage(pkgName, signal)
+    if (namespace === "aur") {
+      return this.fetchAurPackage(pkgName, signal);
     }
 
-    return this.fetchOfficialPackage(pkgName, signal)
+    return this.fetchOfficialPackage(pkgName, signal);
   }
 
   async fetchVersions(name: string, signal?: AbortSignal): Promise<Version[]> {
-    const { namespace, pkgName } = this.parseName(name)
-    this.assertSupportedNamespace(namespace, name)
+    const { namespace, pkgName } = this.parseName(name);
+    this.assertSupportedNamespace(namespace, name);
 
-    if (namespace === 'aur') {
-      return this.fetchAurVersions(pkgName, signal)
+    if (namespace === "aur") {
+      return this.fetchAurVersions(pkgName, signal);
     }
 
-    return this.fetchOfficialVersions(pkgName, signal)
+    return this.fetchOfficialVersions(pkgName, signal);
   }
 
   async fetchDependencies(
@@ -125,76 +122,76 @@ class AlpmRegistry implements Registry {
     version: string,
     signal?: AbortSignal,
   ): Promise<Dependency[]> {
-    const { namespace, pkgName } = this.parseName(name)
-    this.assertSupportedNamespace(namespace, name)
+    const { namespace, pkgName } = this.parseName(name);
+    this.assertSupportedNamespace(namespace, name);
 
-    if (namespace === 'aur') {
-      return this.fetchAurDependencies(pkgName, version, signal)
+    if (namespace === "aur") {
+      return this.fetchAurDependencies(pkgName, version, signal);
     }
 
-    return this.fetchOfficialDependencies(pkgName, version, signal)
+    return this.fetchOfficialDependencies(pkgName, version, signal);
   }
 
   async fetchMaintainers(name: string, signal?: AbortSignal): Promise<Maintainer[]> {
-    const { namespace, pkgName } = this.parseName(name)
-    this.assertSupportedNamespace(namespace, name)
+    const { namespace, pkgName } = this.parseName(name);
+    this.assertSupportedNamespace(namespace, name);
 
-    if (namespace === 'aur') {
-      return this.fetchAurMaintainers(pkgName, signal)
+    if (namespace === "aur") {
+      return this.fetchAurMaintainers(pkgName, signal);
     }
 
-    return this.fetchOfficialMaintainers(pkgName, signal)
+    return this.fetchOfficialMaintainers(pkgName, signal);
   }
 
   urls(): URLBuilder {
     return {
       registry: (name: string, _version?: string) => {
-        const { namespace, pkgName } = this.parseName(name)
-        if (namespace === 'aur') {
-          return `https://aur.archlinux.org/packages/${pkgName}`
+        const { namespace, pkgName } = this.parseName(name);
+        if (namespace === "aur") {
+          return `https://aur.archlinux.org/packages/${pkgName}`;
         }
-        return `https://archlinux.org/packages/?name=${pkgName}`
+        return `https://archlinux.org/packages/?name=${pkgName}`;
       },
       download: (name: string, _version: string) => {
-        const { namespace, pkgName } = this.parseName(name)
-        if (namespace === 'aur') {
-          return `https://aur.archlinux.org/cgit/aur.git/snapshot/${pkgName}.tar.gz`
+        const { namespace, pkgName } = this.parseName(name);
+        if (namespace === "aur") {
+          return `https://aur.archlinux.org/cgit/aur.git/snapshot/${pkgName}.tar.gz`;
         }
-        const letter = pkgName.charAt(0)
-        return `https://archive.archlinux.org/packages/${letter}/${pkgName}/`
+        const letter = pkgName.charAt(0);
+        return `https://archive.archlinux.org/packages/${letter}/${pkgName}/`;
       },
       documentation: (name: string, _version?: string) => {
-        const { namespace, pkgName } = this.parseName(name)
-        if (namespace === 'aur') {
-          return `https://aur.archlinux.org/packages/${pkgName}`
+        const { namespace, pkgName } = this.parseName(name);
+        if (namespace === "aur") {
+          return `https://aur.archlinux.org/packages/${pkgName}`;
         }
-        return `https://wiki.archlinux.org/title/${pkgName}`
+        return `https://wiki.archlinux.org/title/${pkgName}`;
       },
       readme: (_name: string, _version?: string) => {
-        return ''
+        return "";
       },
       purl: (name: string, version?: string) => {
-        const { namespace, pkgName } = this.parseName(name)
-        const versionSuffix = version ? `@${version}` : ''
-        return `pkg:alpm/${namespace}/${pkgName}${versionSuffix}`
+        const { namespace, pkgName } = this.parseName(name);
+        const versionSuffix = version ? `@${version}` : "";
+        return `pkg:alpm/${namespace}/${pkgName}${versionSuffix}`;
       },
-    }
+    };
   }
 
   // --- Official Arch Linux API ---
 
   private async fetchOfficialPackage(name: string, signal?: AbortSignal): Promise<Package> {
-    const result = await this.searchOfficial(name, signal)
+    const result = await this.searchOfficial(name, signal);
 
     return {
       name: result.pkgname,
-      description: result.pkgdesc || '',
-      homepage: result.url || '',
-      documentation: '',
-      repository: '',
+      description: result.pkgdesc || "",
+      homepage: result.url || "",
+      documentation: "",
+      repository: "",
       licenses: combineLicenses(result.licenses),
       keywords: result.groups,
-      namespace: 'arch',
+      namespace: "arch",
       latestVersion: this.formatVersion(result),
       metadata: {
         repo: result.repo,
@@ -210,83 +207,96 @@ class AlpmRegistry implements Registry {
         conflicts: result.conflicts,
         replaces: result.replaces,
       },
-    }
+    };
   }
 
   private async fetchOfficialVersions(name: string, signal?: AbortSignal): Promise<Version[]> {
-    const result = await this.searchOfficial(name, signal)
+    const result = await this.searchOfficial(name, signal);
 
-    return [{
-      number: this.formatVersion(result),
-      publishedAt: result.last_update ? new Date(result.last_update) : null,
-      licenses: combineLicenses(result.licenses),
-      integrity: '',
-      status: result.flag_date ? 'deprecated' : '',
-      metadata: {
-        repo: result.repo,
-        arch: result.arch,
+    return [
+      {
+        number: this.formatVersion(result),
+        publishedAt: result.last_update ? new Date(result.last_update) : null,
+        licenses: combineLicenses(result.licenses),
+        integrity: "",
+        status: result.flag_date ? "deprecated" : "",
+        metadata: {
+          repo: result.repo,
+          arch: result.arch,
+        },
       },
-    }]
+    ];
   }
 
-  private async fetchOfficialDependencies(name: string, version: string, signal?: AbortSignal): Promise<Dependency[]> {
-    const result = await this.searchOfficial(name, signal)
-    const currentVersion = this.formatVersion(result)
-    this.assertVersionMatches(name, version, currentVersion)
+  private async fetchOfficialDependencies(
+    name: string,
+    version: string,
+    signal?: AbortSignal,
+  ): Promise<Dependency[]> {
+    const result = await this.searchOfficial(name, signal);
+    const currentVersion = this.formatVersion(result);
+    this.assertVersionMatches(name, version, currentVersion);
 
-    return this.buildDependencies(result.depends, result.makedepends, result.optdepends, result.checkdepends)
+    return this.buildDependencies(
+      result.depends,
+      result.makedepends,
+      result.optdepends,
+      result.checkdepends,
+    );
   }
 
-  private async fetchOfficialMaintainers(name: string, signal?: AbortSignal): Promise<Maintainer[]> {
-    const result = await this.searchOfficial(name, signal)
+  private async fetchOfficialMaintainers(
+    name: string,
+    signal?: AbortSignal,
+  ): Promise<Maintainer[]> {
+    const result = await this.searchOfficial(name, signal);
 
-    return result.maintainers.map(m => ({
-      uuid: '',
+    return result.maintainers.map((m) => ({
+      uuid: "",
       login: m,
       name: m,
-      email: '',
-      url: '',
-      role: 'maintainer',
-    }))
+      email: "",
+      url: "",
+      role: "maintainer",
+    }));
   }
 
   /** Search official repos by exact package name. Prefers x86_64 results. */
   private async searchOfficial(name: string, signal?: AbortSignal): Promise<ArchPackageResult> {
-    const url = `${this.baseURL}/packages/search/json/?name=${encodeURIComponent(name)}`
+    const url = `${this.baseURL}/packages/search/json/?name=${encodeURIComponent(name)}`;
 
     try {
-      const data = await this.client.getJSON<ArchSearchResponse>(url, signal)
+      const data = await this.client.getJSON<ArchSearchResponse>(url, signal);
 
       if (!data.results || data.results.length === 0) {
-        throw new NotFoundError('alpm', name)
+        throw new NotFoundError("alpm", name);
       }
 
       // Prefer x86_64 arch, fall back to first result
-      return data.results.find(r => r.arch === 'x86_64') || data.results[0]!
-    }
-    catch (error) {
-      if (error instanceof NotFoundError) throw error
+      return data.results.find((r) => r.arch === "x86_64") || data.results[0]!;
+    } catch (error) {
+      if (error instanceof NotFoundError) throw error;
       if (error instanceof HTTPError && error.isNotFound()) {
-        throw new NotFoundError('alpm', name)
+        throw new NotFoundError("alpm", name);
       }
-      throw error
+      throw error;
     }
   }
 
   // --- AUR API ---
 
   private async fetchAurPackage(name: string, signal?: AbortSignal): Promise<Package> {
-    const result = await this.fetchAurInfo(name, signal)
+    const result = await this.fetchAurInfo(name, signal);
 
     return {
       name: result.Name,
-      description: result.Description || '',
-      homepage: result.URL || '',
-      documentation: '',
-      repository: '',
+      description: result.Description || "",
+      homepage: result.URL || "",
+      documentation: "",
+      repository: "",
       licenses: combineLicenses(result.License || []),
       keywords: result.Keywords || [],
-      namespace: 'aur',
+      namespace: "aur",
       latestVersion: result.Version,
       metadata: {
         votes: result.NumVotes,
@@ -296,71 +306,78 @@ class AlpmRegistry implements Registry {
         firstSubmitted: result.FirstSubmitted,
         lastModified: result.LastModified,
       },
-    }
+    };
   }
 
   private async fetchAurVersions(name: string, signal?: AbortSignal): Promise<Version[]> {
-    const result = await this.fetchAurInfo(name, signal)
+    const result = await this.fetchAurInfo(name, signal);
 
-    return [{
-      number: result.Version,
-      publishedAt: result.LastModified ? new Date(result.LastModified * 1000) : null,
-      licenses: combineLicenses(result.License || []),
-      integrity: '',
-      status: result.OutOfDate ? 'deprecated' : '',
-      metadata: {
-        votes: result.NumVotes,
-        popularity: result.Popularity,
+    return [
+      {
+        number: result.Version,
+        publishedAt: result.LastModified ? new Date(result.LastModified * 1000) : null,
+        licenses: combineLicenses(result.License || []),
+        integrity: "",
+        status: result.OutOfDate ? "deprecated" : "",
+        metadata: {
+          votes: result.NumVotes,
+          popularity: result.Popularity,
+        },
       },
-    }]
+    ];
   }
 
-  private async fetchAurDependencies(name: string, version: string, signal?: AbortSignal): Promise<Dependency[]> {
-    const result = await this.fetchAurInfo(name, signal)
-    this.assertVersionMatches(`aur/${name}`, version, result.Version)
+  private async fetchAurDependencies(
+    name: string,
+    version: string,
+    signal?: AbortSignal,
+  ): Promise<Dependency[]> {
+    const result = await this.fetchAurInfo(name, signal);
+    this.assertVersionMatches(`aur/${name}`, version, result.Version);
 
     return this.buildDependencies(
       result.Depends || [],
       result.MakeDepends || [],
       result.OptDepends || [],
       result.CheckDepends || [],
-    )
+    );
   }
 
   private async fetchAurMaintainers(name: string, signal?: AbortSignal): Promise<Maintainer[]> {
-    const result = await this.fetchAurInfo(name, signal)
+    const result = await this.fetchAurInfo(name, signal);
 
-    if (!result.Maintainer) return []
+    if (!result.Maintainer) return [];
 
-    return [{
-      uuid: '',
-      login: result.Maintainer,
-      name: result.Maintainer,
-      email: '',
-      url: '',
-      role: 'maintainer',
-    }]
+    return [
+      {
+        uuid: "",
+        login: result.Maintainer,
+        name: result.Maintainer,
+        email: "",
+        url: "",
+        role: "maintainer",
+      },
+    ];
   }
 
   /** Fetch package info from AUR RPC v5. */
   private async fetchAurInfo(name: string, signal?: AbortSignal): Promise<AurPackageResult> {
-    const url = `${AUR_BASE_URL}/rpc/v5/info/${encodeURIComponent(name)}`
+    const url = `${AUR_BASE_URL}/rpc/v5/info/${encodeURIComponent(name)}`;
 
     try {
-      const data = await this.client.getJSON<AurResponse>(url, signal)
+      const data = await this.client.getJSON<AurResponse>(url, signal);
 
       if (!data.results || data.results.length === 0) {
-        throw new NotFoundError('alpm', `aur/${name}`)
+        throw new NotFoundError("alpm", `aur/${name}`);
       }
 
-      return data.results[0]!
-    }
-    catch (error) {
-      if (error instanceof NotFoundError) throw error
+      return data.results[0]!;
+    } catch (error) {
+      if (error instanceof NotFoundError) throw error;
       if (error instanceof HTTPError && error.isNotFound()) {
-        throw new NotFoundError('alpm', `aur/${name}`)
+        throw new NotFoundError("alpm", `aur/${name}`);
       }
-      throw error
+      throw error;
     }
   }
 
@@ -368,33 +385,33 @@ class AlpmRegistry implements Registry {
 
   /** Parse "namespace/name" into components. Defaults to "arch" namespace. */
   private parseName(fullName: string): { namespace: string; pkgName: string } {
-    const normalized = fullName.trim().toLowerCase()
-    const slashIdx = normalized.indexOf('/')
+    const normalized = fullName.trim().toLowerCase();
+    const slashIdx = normalized.indexOf("/");
     if (slashIdx === -1) {
-      return { namespace: 'arch', pkgName: normalized }
+      return { namespace: "arch", pkgName: normalized };
     }
     return {
       namespace: normalized.slice(0, slashIdx),
       pkgName: normalized.slice(slashIdx + 1),
-    }
+    };
   }
 
   private assertSupportedNamespace(namespace: string, requestedName: string): void {
-    if (namespace !== 'arch' && namespace !== 'aur') {
-      throw new NotFoundError('alpm', requestedName)
+    if (namespace !== "arch" && namespace !== "aur") {
+      throw new NotFoundError("alpm", requestedName);
     }
   }
 
   private assertVersionMatches(name: string, requested: string, current: string): void {
     if (requested && requested !== current) {
-      throw new NotFoundError('alpm', name, requested)
+      throw new NotFoundError("alpm", name, requested);
     }
   }
 
   /** Format ALPM version: epoch:pkgver-pkgrel (epoch omitted when 0). */
   private formatVersion(result: ArchPackageResult): string {
-    const epoch = result.epoch && result.epoch > 0 ? `${result.epoch}:` : ''
-    return `${epoch}${result.pkgver}-${result.pkgrel}`
+    const epoch = result.epoch && result.epoch > 0 ? `${result.epoch}:` : "";
+    return `${epoch}${result.pkgver}-${result.pkgrel}`;
   }
 
   /** Build normalized dependency list from ALPM dependency arrays. */
@@ -404,82 +421,82 @@ class AlpmRegistry implements Registry {
     optdepends: string[],
     checkdepends: string[],
   ): Dependency[] {
-    const dependencies: Dependency[] = []
+    const dependencies: Dependency[] = [];
 
     for (const dep of depends) {
-      const parsed = this.parseDep(dep)
+      const parsed = this.parseDep(dep);
       dependencies.push({
         name: parsed.name,
         requirements: parsed.requirements,
-        scope: 'runtime',
+        scope: "runtime",
         optional: false,
-      })
+      });
     }
 
     for (const dep of makedepends) {
-      const parsed = this.parseDep(dep)
+      const parsed = this.parseDep(dep);
       dependencies.push({
         name: parsed.name,
         requirements: parsed.requirements,
-        scope: 'build',
+        scope: "build",
         optional: false,
-      })
+      });
     }
 
     for (const dep of optdepends) {
-      const parsed = this.parseOptDep(dep)
+      const parsed = this.parseOptDep(dep);
       dependencies.push({
         name: parsed.name,
         requirements: parsed.requirements,
-        scope: 'optional',
+        scope: "optional",
         optional: true,
-      })
+      });
     }
 
     for (const dep of checkdepends) {
-      const parsed = this.parseDep(dep)
+      const parsed = this.parseDep(dep);
       dependencies.push({
         name: parsed.name,
         requirements: parsed.requirements,
-        scope: 'test',
+        scope: "test",
         optional: false,
-      })
+      });
     }
 
-    return dependencies
+    return dependencies;
   }
 
   /** Parse a dependency string like "glibc>=2.33" or "bash". */
   private parseDep(dep: string): { name: string; requirements: string } {
-    const match = dep.match(/^([a-zA-Z0-9@._+-]+)(.*)$/)
-    if (!match) return { name: dep, requirements: '' }
+    const match = dep.match(/^([a-zA-Z0-9@._+-]+)(.*)$/);
+    if (!match) return { name: dep, requirements: "" };
     return {
       name: match[1]!,
       requirements: match[2]!.trim(),
-    }
+    };
   }
 
   /** Parse optional dependency like "perl-locale-gettext: translation support". */
   private parseOptDep(dep: string): { name: string; requirements: string; description: string } {
-    const colonIdx = dep.indexOf(':')
+    const colonIdx = dep.indexOf(":");
     if (colonIdx === -1) {
-      const parsed = this.parseDep(dep.trim())
-      return { name: parsed.name, requirements: parsed.requirements, description: '' }
+      const parsed = this.parseDep(dep.trim());
+      return { name: parsed.name, requirements: parsed.requirements, description: "" };
     }
-    const parsed = this.parseDep(dep.slice(0, colonIdx).trim())
+    const parsed = this.parseDep(dep.slice(0, colonIdx).trim());
 
     return {
       name: parsed.name,
       requirements: parsed.requirements,
       description: dep.slice(colonIdx + 1).trim(),
-    }
+    };
   }
 }
 
 /** Factory function for creating ALPM registry instances. */
 const factory: RegistryFactory = (baseURL: string, client: Client): Registry => {
-  return new AlpmRegistry(baseURL, client)
-}
+  return new AlpmRegistry(baseURL, client);
+};
 
 // Self-register on import
-register('alpm', 'https://archlinux.org', factory)
+register("alpm", "https://archlinux.org", factory);

--- a/src/registries/cargo.ts
+++ b/src/registries/cargo.ts
@@ -1,4 +1,4 @@
-import type { Client } from '../core/client.ts'
+import type { Client } from "../core/client.ts";
 import type {
   Dependency,
   Maintainer,
@@ -7,134 +7,131 @@ import type {
   RegistryFactory,
   URLBuilder,
   Version,
-} from '../core/types.ts'
-import { register } from '../core/registry.ts'
-import { HTTPError, NotFoundError } from '../core/errors.ts'
-import { normalizeLicense } from '../core/license.ts'
-import { normalizeRepositoryURL } from '../core/repository.ts'
+} from "../core/types.ts";
+import { register } from "../core/registry.ts";
+import { HTTPError, NotFoundError } from "../core/errors.ts";
+import { normalizeLicense } from "../core/license.ts";
+import { normalizeRepositoryURL } from "../core/repository.ts";
 
 /** Crates.io API response for a single crate. */
 interface CratesPackageResponse {
   crate: {
-    id: number
-    name: string
-    updated_at: string
-    created_at: string
-    downloads: number
-    recent_downloads: number
-    max_version: string
-    max_stable_version: string
-    newest_version: string
-    description: string
-    homepage: string
-    documentation: string
-    repository: string
-    keywords: string[]
+    id: number;
+    name: string;
+    updated_at: string;
+    created_at: string;
+    downloads: number;
+    recent_downloads: number;
+    max_version: string;
+    max_stable_version: string;
+    newest_version: string;
+    description: string;
+    homepage: string;
+    documentation: string;
+    repository: string;
+    keywords: string[];
     categories: Array<{
-      id: string
-      category: string
-      created_at: string
-    }>
-    badges: unknown[]
-    links: Record<string, string>
-  }
-  versions: CratesVersion[]
+      id: string;
+      category: string;
+      created_at: string;
+    }>;
+    badges: unknown[];
+    links: Record<string, string>;
+  };
+  versions: CratesVersion[];
 }
 
 /** Crates.io version data. */
 interface CratesVersion {
-  id: number
-  num: string
-  dl_path: string
-  readme_path: string
-  created_at: string
-  updated_at: string
-  downloads: number
-  features: Record<string, string[]>
-  yanked: boolean
-  license: string
-  links: Record<string, string>
-  crate_size: number
+  id: number;
+  num: string;
+  dl_path: string;
+  readme_path: string;
+  created_at: string;
+  updated_at: string;
+  downloads: number;
+  features: Record<string, string[]>;
+  yanked: boolean;
+  license: string;
+  links: Record<string, string>;
+  crate_size: number;
   published_by: {
-    id: number
-    login: string
-    name: string
-    avatar: string
-    url: string
-  }
-  checksum: string
+    id: number;
+    login: string;
+    name: string;
+    avatar: string;
+    url: string;
+  };
+  checksum: string;
 }
 
 /** Crates.io dependencies response. */
 interface CratesDependenciesResponse {
-  dependencies: CratesDependency[]
+  dependencies: CratesDependency[];
   meta: {
-    prelude: boolean
-  }
+    prelude: boolean;
+  };
 }
 
 /** Crates.io dependency data. */
 interface CratesDependency {
-  id: number
-  version_id: number
-  crate_id: string
-  req: string
-  optional: boolean
-  default_features: boolean
-  features: string[]
-  target: string | null
-  kind: string
-  downloads: number
+  id: number;
+  version_id: number;
+  crate_id: string;
+  req: string;
+  optional: boolean;
+  default_features: boolean;
+  features: string[];
+  target: string | null;
+  kind: string;
+  downloads: number;
 }
 
 /** Crates.io maintainers response. */
 interface CratesMaintainersResponse {
-  users: CratesMaintainer[]
+  users: CratesMaintainer[];
 }
 
 /** Crates.io maintainer data. */
 interface CratesMaintainer {
-  id: number
-  login: string
-  name: string
-  avatar: string
-  url: string
+  id: number;
+  login: string;
+  name: string;
+  avatar: string;
+  url: string;
 }
 
 /** Crates.io registry client. */
 class CargoRegistry implements Registry {
-  constructor(
-    baseURL: string,
-    client: Client,
-  ) {
-    this.baseURL = baseURL
-    this.client = client
+  constructor(baseURL: string, client: Client) {
+    this.baseURL = baseURL;
+    this.client = client;
   }
 
-  readonly baseURL: string
-  readonly client: Client
+  readonly baseURL: string;
+  readonly client: Client;
 
   ecosystem(): string {
-    return 'cargo'
+    return "cargo";
   }
 
   async fetchPackage(name: string, signal?: AbortSignal): Promise<Package> {
-    const url = `${this.baseURL}/api/v1/crates/${name}`
+    const url = `${this.baseURL}/api/v1/crates/${name}`;
 
     try {
-      const data = await this.client.getJSON<CratesPackageResponse>(url, signal)
-      const crateData = data.crate
-      const latestVersion = crateData.max_stable_version || crateData.max_version
+      const data = await this.client.getJSON<CratesPackageResponse>(url, signal);
+      const crateData = data.crate;
+      const latestVersion = crateData.max_stable_version || crateData.max_version;
 
       return {
         name: crateData.name,
-        description: crateData.description || '',
-        homepage: crateData.homepage || '',
-        documentation: crateData.documentation || '',
-        repository: normalizeRepositoryURL(crateData.repository || ''),
-        licenses: normalizeLicense(data.versions[0]?.license || ''),
+        description: crateData.description || "",
+        homepage: crateData.homepage || "",
+        documentation: crateData.documentation || "",
+        repository: normalizeRepositoryURL(crateData.repository || ""),
+        licenses: normalizeLicense(data.versions[0]?.license || ""),
         keywords: crateData.keywords,
-        namespace: '',
+        namespace: "",
         latestVersion,
         metadata: {
           downloads: crateData.downloads,
@@ -145,26 +142,25 @@ class CargoRegistry implements Registry {
           updatedAt: crateData.updated_at,
           createdAt: crateData.created_at,
         },
-      }
-    }
-    catch (error) {
+      };
+    } catch (error) {
       if (error instanceof HTTPError && error.isNotFound()) {
-        throw new NotFoundError('cargo', name)
+        throw new NotFoundError("cargo", name);
       }
-      throw error
+      throw error;
     }
   }
 
   async fetchVersions(name: string, signal?: AbortSignal): Promise<Version[]> {
-    const url = `${this.baseURL}/api/v1/crates/${name}`
+    const url = `${this.baseURL}/api/v1/crates/${name}`;
 
     try {
-      const data = await this.client.getJSON<CratesPackageResponse>(url, signal)
-      const versions: Version[] = []
+      const data = await this.client.getJSON<CratesPackageResponse>(url, signal);
+      const versions: Version[] = [];
 
       for (const versionData of data.versions) {
-        const publishedAt = new Date(versionData.created_at)
-        const status = versionData.yanked ? 'yanked' : ''
+        const publishedAt = new Date(versionData.created_at);
+        const status = versionData.yanked ? "yanked" : "";
 
         versions.push({
           number: versionData.num,
@@ -177,16 +173,15 @@ class CargoRegistry implements Registry {
             features: versionData.features,
             downloads: versionData.downloads,
           },
-        })
+        });
       }
 
-      return versions
-    }
-    catch (error) {
+      return versions;
+    } catch (error) {
       if (error instanceof HTTPError && error.isNotFound()) {
-        throw new NotFoundError('cargo', name)
+        throw new NotFoundError("cargo", name);
       }
-      throw error
+      throw error;
     }
   }
 
@@ -195,23 +190,21 @@ class CargoRegistry implements Registry {
     version: string,
     signal?: AbortSignal,
   ): Promise<Dependency[]> {
-    const url = `${this.baseURL}/api/v1/crates/${name}/${version}/dependencies`
+    const url = `${this.baseURL}/api/v1/crates/${name}/${version}/dependencies`;
 
     try {
-      const data = await this.client.getJSON<CratesDependenciesResponse>(url, signal)
-      const dependencies: Dependency[] = []
+      const data = await this.client.getJSON<CratesDependenciesResponse>(url, signal);
+      const dependencies: Dependency[] = [];
 
       for (const dep of data.dependencies) {
-        let scope: 'runtime' | 'development' | 'test' | 'build' | 'optional'
+        let scope: "runtime" | "development" | "test" | "build" | "optional";
 
-        if (dep.kind === 'dev') {
-          scope = 'development'
-        }
-        else if (dep.kind === 'build') {
-          scope = 'build'
-        }
-        else {
-          scope = 'runtime'
+        if (dep.kind === "dev") {
+          scope = "development";
+        } else if (dep.kind === "build") {
+          scope = "build";
+        } else {
+          scope = "runtime";
         }
 
         dependencies.push({
@@ -219,76 +212,74 @@ class CargoRegistry implements Registry {
           requirements: dep.req,
           scope,
           optional: dep.optional,
-        })
+        });
       }
 
-      return dependencies
-    }
-    catch (error) {
+      return dependencies;
+    } catch (error) {
       if (error instanceof HTTPError && error.isNotFound()) {
-        throw new NotFoundError('cargo', name, version)
+        throw new NotFoundError("cargo", name, version);
       }
-      throw error
+      throw error;
     }
   }
 
   async fetchMaintainers(name: string, signal?: AbortSignal): Promise<Maintainer[]> {
-    const url = `${this.baseURL}/api/v1/crates/${name}/owner_user`
+    const url = `${this.baseURL}/api/v1/crates/${name}/owner_user`;
 
     try {
-      const data = await this.client.getJSON<CratesMaintainersResponse>(url, signal)
-      const maintainers: Maintainer[] = []
+      const data = await this.client.getJSON<CratesMaintainersResponse>(url, signal);
+      const maintainers: Maintainer[] = [];
 
       for (const user of data.users) {
         maintainers.push({
           uuid: user.id.toString(),
           login: user.login,
           name: user.name,
-          email: '',
+          email: "",
           url: user.url,
-          role: '',
-        })
+          role: "",
+        });
       }
 
-      return maintainers
-    }
-    catch (error) {
+      return maintainers;
+    } catch (error) {
       if (error instanceof HTTPError && error.isNotFound()) {
-        throw new NotFoundError('cargo', name)
+        throw new NotFoundError("cargo", name);
       }
-      throw error
+      throw error;
     }
   }
 
   urls(): URLBuilder {
     return {
       registry: (name: string, version?: string) => {
-        const base = `https://crates.io/crates/${name}`
-        return version ? `${base}/${version}` : base
+        const base = `https://crates.io/crates/${name}`;
+        return version ? `${base}/${version}` : base;
       },
       download: (name: string, version: string) => {
-        return `https://crates.io/api/v1/crates/${name}/${version}/download`
+        return `https://crates.io/api/v1/crates/${name}/${version}/download`;
       },
       documentation: (name: string, version?: string) => {
-        return version ? `https://docs.rs/${name}/${version}` : `https://docs.rs/${name}`
+        return version ? `https://docs.rs/${name}/${version}` : `https://docs.rs/${name}`;
       },
       readme: (name: string, version?: string) => {
         return version
           ? `https://crates.io/api/v1/crates/${name}/${version}/readme`
-          : `https://crates.io/crates/${name}`
+          : `https://crates.io/crates/${name}`;
       },
       purl: (name: string, version?: string) => {
-        const versionSuffix = version ? `@${version}` : ''
-        return `pkg:cargo/${name}${versionSuffix}`
+        const versionSuffix = version ? `@${version}` : "";
+        return `pkg:cargo/${name}${versionSuffix}`;
       },
-    }
+    };
   }
 }
 
 /** Factory function for creating Cargo registry instances. */
 const factory: RegistryFactory = (baseURL: string, client: Client): Registry => {
-  return new CargoRegistry(baseURL, client)
-}
+  return new CargoRegistry(baseURL, client);
+};
 
 // Self-register on import
-register('cargo', 'https://crates.io', factory)
+register("cargo", "https://crates.io", factory);

--- a/src/registries/index.ts
+++ b/src/registries/index.ts
@@ -1,7 +1,7 @@
 // Side-effect imports — each registers itself on import
-import './npm.ts'
-import './cargo.ts'
-import './pypi.ts'
-import './rubygems.ts'
-import './packagist.ts'
-import './alpm.ts'
+import "./npm.ts";
+import "./cargo.ts";
+import "./pypi.ts";
+import "./rubygems.ts";
+import "./packagist.ts";
+import "./alpm.ts";

--- a/src/registries/npm.ts
+++ b/src/registries/npm.ts
@@ -1,4 +1,4 @@
-import type { Client } from '../core/client.ts'
+import type { Client } from "../core/client.ts";
 import type {
   Dependency,
   Maintainer,
@@ -7,138 +7,140 @@ import type {
   RegistryFactory,
   URLBuilder,
   Version,
-} from '../core/types.ts'
-import { register } from '../core/registry.ts'
-import { HTTPError, NotFoundError } from '../core/errors.ts'
-import { normalizeLicense } from '../core/license.ts'
-import { normalizeRepositoryURL } from '../core/repository.ts'
+} from "../core/types.ts";
+import { register } from "../core/registry.ts";
+import { HTTPError, NotFoundError } from "../core/errors.ts";
+import { normalizeLicense } from "../core/license.ts";
+import { normalizeRepositoryURL } from "../core/repository.ts";
 
 /** npm registry API response for a single package. */
 interface NpmPackageResponse {
-  name: string
-  description?: string
-  homepage?: string
-  repository?: {
-    type?: string
-    url?: string
-  } | string
-  license?: string | {
-    type?: string
-  }
-  keywords?: string[]
-  'dist-tags': {
-    latest: string
-  }
-  versions: Record<string, NpmVersion>
-  time?: Record<string, string>
+  name: string;
+  description?: string;
+  homepage?: string;
+  repository?:
+    | {
+        type?: string;
+        url?: string;
+      }
+    | string;
+  license?:
+    | string
+    | {
+        type?: string;
+      };
+  keywords?: string[];
+  "dist-tags": {
+    latest: string;
+  };
+  versions: Record<string, NpmVersion>;
+  time?: Record<string, string>;
 }
 
 /** npm version data. */
 interface NpmVersion {
-  name: string
-  version: string
-  description?: string
-  license?: string | {
-    type?: string
-  }
-  keywords?: string[]
+  name: string;
+  version: string;
+  description?: string;
+  license?:
+    | string
+    | {
+        type?: string;
+      };
+  keywords?: string[];
   author?: {
-    name?: string
-    email?: string
-    url?: string
-  }
+    name?: string;
+    email?: string;
+    url?: string;
+  };
   contributors?: Array<{
-    name?: string
-    email?: string
-    url?: string
-  }>
+    name?: string;
+    email?: string;
+    url?: string;
+  }>;
   maintainers?: Array<{
-    name?: string
-    email?: string
-    url?: string
-  }>
-  dependencies?: Record<string, string>
-  devDependencies?: Record<string, string>
-  optionalDependencies?: Record<string, string>
-  peerDependencies?: Record<string, string>
+    name?: string;
+    email?: string;
+    url?: string;
+  }>;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
   dist?: {
-    integrity?: string
-    shasum?: string
-    tarball?: string
-  }
-  deprecated?: boolean | string
+    integrity?: string;
+    shasum?: string;
+    tarball?: string;
+  };
+  deprecated?: boolean | string;
 }
 
 /** npm registry client. */
 class NpmRegistry implements Registry {
-  constructor(
-    baseURL: string,
-    client: Client,
-  ) {
-    this.baseURL = baseURL
-    this.client = client
+  constructor(baseURL: string, client: Client) {
+    this.baseURL = baseURL;
+    this.client = client;
   }
 
-  readonly baseURL: string
-  readonly client: Client
+  readonly baseURL: string;
+  readonly client: Client;
 
   ecosystem(): string {
-    return 'npm'
+    return "npm";
   }
 
   async fetchPackage(name: string, signal?: AbortSignal): Promise<Package> {
-    const encodedName = this.encodeName(name)
-    const url = `${this.baseURL}/${encodedName}`
+    const encodedName = this.encodeName(name);
+    const url = `${this.baseURL}/${encodedName}`;
 
     try {
-      const data = await this.client.getJSON<NpmPackageResponse>(url, signal)
+      const data = await this.client.getJSON<NpmPackageResponse>(url, signal);
 
-      const latestVersion = data['dist-tags'].latest
-      const latestVersionData = data.versions[latestVersion]
+      const latestVersion = data["dist-tags"].latest;
+      const latestVersionData = data.versions[latestVersion];
 
-      const licenses = this.extractLicense(data.license || latestVersionData?.license)
-      const namespace = this.extractNamespace(name)
+      const licenses = this.extractLicense(data.license || latestVersionData?.license);
+      const namespace = this.extractNamespace(name);
 
       return {
         name: data.name,
-        description: data.description || '',
-        homepage: data.homepage || '',
-        documentation: '',
-        repository: normalizeRepositoryURL(data.repository || ''),
+        description: data.description || "",
+        homepage: data.homepage || "",
+        documentation: "",
+        repository: normalizeRepositoryURL(data.repository || ""),
         licenses,
         keywords: data.keywords || [],
         namespace,
         latestVersion,
         metadata: {},
-      }
-    }
-    catch (error) {
+      };
+    } catch (error) {
       if (error instanceof HTTPError && error.isNotFound()) {
-        throw new NotFoundError('npm', name)
+        throw new NotFoundError("npm", name);
       }
-      throw error
+      throw error;
     }
   }
 
   async fetchVersions(name: string, signal?: AbortSignal): Promise<Version[]> {
-    const encodedName = this.encodeName(name)
-    const url = `${this.baseURL}/${encodedName}`
+    const encodedName = this.encodeName(name);
+    const url = `${this.baseURL}/${encodedName}`;
 
     try {
-      const data = await this.client.getJSON<NpmPackageResponse>(url, signal)
-      const versions: Version[] = []
+      const data = await this.client.getJSON<NpmPackageResponse>(url, signal);
+      const versions: Version[] = [];
 
       for (const [versionStr, versionData] of Object.entries(data.versions)) {
-        const licenses = this.extractLicense(versionData.license)
-        const publishedAt = data.time?.[versionStr] ? new Date(data.time[versionStr]) : null
+        const licenses = this.extractLicense(versionData.license);
+        const publishedAt = data.time?.[versionStr] ? new Date(data.time[versionStr]) : null;
 
-        const status = versionData.deprecated ? 'deprecated' : ''
+        const status = versionData.deprecated ? "deprecated" : "";
 
         const integrity = versionData.dist?.integrity
           ? versionData.dist.integrity
           : versionData.dist?.shasum
             ? `sha1-${versionData.dist.shasum}`
-            : ''
+            : "";
 
         versions.push({
           number: versionStr,
@@ -147,16 +149,15 @@ class NpmRegistry implements Registry {
           integrity,
           status,
           metadata: {},
-        })
+        });
       }
 
-      return versions
-    }
-    catch (error) {
+      return versions;
+    } catch (error) {
       if (error instanceof HTTPError && error.isNotFound()) {
-        throw new NotFoundError('npm', name)
+        throw new NotFoundError("npm", name);
       }
-      throw error
+      throw error;
     }
   }
 
@@ -165,18 +166,18 @@ class NpmRegistry implements Registry {
     version: string,
     signal?: AbortSignal,
   ): Promise<Dependency[]> {
-    const encodedName = this.encodeName(name)
-    const url = `${this.baseURL}/${encodedName}`
+    const encodedName = this.encodeName(name);
+    const url = `${this.baseURL}/${encodedName}`;
 
     try {
-      const data = await this.client.getJSON<NpmPackageResponse>(url, signal)
-      const versionData = data.versions[version]
+      const data = await this.client.getJSON<NpmPackageResponse>(url, signal);
+      const versionData = data.versions[version];
 
       if (!versionData) {
-        throw new NotFoundError('npm', name, version)
+        throw new NotFoundError("npm", name, version);
       }
 
-      const dependencies: Dependency[] = []
+      const dependencies: Dependency[] = [];
 
       // Runtime dependencies
       if (versionData.dependencies) {
@@ -184,9 +185,9 @@ class NpmRegistry implements Registry {
           dependencies.push({
             name: depName,
             requirements,
-            scope: 'runtime',
+            scope: "runtime",
             optional: false,
-          })
+          });
         }
       }
 
@@ -196,9 +197,9 @@ class NpmRegistry implements Registry {
           dependencies.push({
             name: depName,
             requirements,
-            scope: 'development',
+            scope: "development",
             optional: false,
-          })
+          });
         }
       }
 
@@ -208,9 +209,9 @@ class NpmRegistry implements Registry {
           dependencies.push({
             name: depName,
             requirements,
-            scope: 'runtime',
+            scope: "runtime",
             optional: true,
-          })
+          });
         }
       }
 
@@ -220,162 +221,160 @@ class NpmRegistry implements Registry {
           dependencies.push({
             name: depName,
             requirements,
-            scope: 'runtime',
+            scope: "runtime",
             optional: false,
-          })
+          });
         }
       }
 
-      return dependencies
-    }
-    catch (error) {
+      return dependencies;
+    } catch (error) {
       if (error instanceof HTTPError && error.isNotFound()) {
-        throw new NotFoundError('npm', name, version)
+        throw new NotFoundError("npm", name, version);
       }
-      throw error
+      throw error;
     }
   }
 
   async fetchMaintainers(name: string, signal?: AbortSignal): Promise<Maintainer[]> {
-    const encodedName = this.encodeName(name)
-    const url = `${this.baseURL}/${encodedName}`
+    const encodedName = this.encodeName(name);
+    const url = `${this.baseURL}/${encodedName}`;
 
     try {
-      const data = await this.client.getJSON<NpmPackageResponse>(url, signal)
-      const maintainers: Maintainer[] = []
-      const seen = new Set<string>()
+      const data = await this.client.getJSON<NpmPackageResponse>(url, signal);
+      const maintainers: Maintainer[] = [];
+      const seen = new Set<string>();
 
       // Collect from maintainers field
       if (data.versions) {
         for (const versionData of Object.values(data.versions)) {
           if (versionData.maintainers) {
             for (const maintainer of versionData.maintainers) {
-              const key = `${maintainer.name}:${maintainer.email}`
+              const key = `${maintainer.name}:${maintainer.email}`;
               if (!seen.has(key)) {
-                seen.add(key)
+                seen.add(key);
                 maintainers.push({
-                  uuid: '',
-                  login: maintainer.email ? maintainer.email.split('@')[0] : '',
-                  name: maintainer.name || '',
-                  email: maintainer.email || '',
-                  url: maintainer.url || '',
-                  role: '',
-                })
+                  uuid: "",
+                  login: maintainer.email ? maintainer.email.split("@")[0] : "",
+                  name: maintainer.name || "",
+                  email: maintainer.email || "",
+                  url: maintainer.url || "",
+                  role: "",
+                });
               }
             }
           }
 
           // Collect from author field
           if (versionData.author) {
-            const key = `${versionData.author.name}:${versionData.author.email}`
+            const key = `${versionData.author.name}:${versionData.author.email}`;
             if (!seen.has(key)) {
-              seen.add(key)
+              seen.add(key);
               maintainers.push({
-                uuid: '',
-                login: versionData.author.email ? versionData.author.email.split('@')[0] : '',
-                name: versionData.author.name || '',
-                email: versionData.author.email || '',
-                url: versionData.author.url || '',
-                role: 'author',
-              })
+                uuid: "",
+                login: versionData.author.email ? versionData.author.email.split("@")[0] : "",
+                name: versionData.author.name || "",
+                email: versionData.author.email || "",
+                url: versionData.author.url || "",
+                role: "author",
+              });
             }
           }
 
           // Collect from contributors field
           if (versionData.contributors) {
             for (const contributor of versionData.contributors) {
-              const key = `${contributor.name}:${contributor.email}`
+              const key = `${contributor.name}:${contributor.email}`;
               if (!seen.has(key)) {
-                seen.add(key)
+                seen.add(key);
                 maintainers.push({
-                  uuid: '',
-                  login: contributor.email ? contributor.email.split('@')[0] : '',
-                  name: contributor.name || '',
-                  email: contributor.email || '',
-                  url: contributor.url || '',
-                  role: 'contributor',
-                })
+                  uuid: "",
+                  login: contributor.email ? contributor.email.split("@")[0] : "",
+                  name: contributor.name || "",
+                  email: contributor.email || "",
+                  url: contributor.url || "",
+                  role: "contributor",
+                });
               }
             }
           }
         }
       }
 
-      return maintainers
-    }
-    catch (error) {
+      return maintainers;
+    } catch (error) {
       if (error instanceof HTTPError && error.isNotFound()) {
-        throw new NotFoundError('npm', name)
+        throw new NotFoundError("npm", name);
       }
-      throw error
+      throw error;
     }
   }
 
   urls(): URLBuilder {
     return {
       registry: (name: string, version?: string) => {
-        const base = `https://www.npmjs.com/package/${name}`
-        return version ? `${base}/v/${version}` : base
+        const base = `https://www.npmjs.com/package/${name}`;
+        return version ? `${base}/v/${version}` : base;
       },
       download: (name: string, version: string) => {
-        const encodedName = this.encodeName(name)
-        const tarballName = name.includes('/') ? name.split('/')[1] : name
-        return `https://registry.npmjs.org/${encodedName}/-/${tarballName}-${version}.tgz`
+        const encodedName = this.encodeName(name);
+        const tarballName = name.includes("/") ? name.split("/")[1] : name;
+        return `https://registry.npmjs.org/${encodedName}/-/${tarballName}-${version}.tgz`;
       },
       documentation: (name: string, _version?: string) => {
-        return `https://www.npmjs.com/package/${name}`
+        return `https://www.npmjs.com/package/${name}`;
       },
       readme: (name: string, version?: string) => {
-        const ver = version ? `@${version}` : ''
-        return `https://cdn.jsdelivr.net/npm/${name}${ver}/README.md`
+        const ver = version ? `@${version}` : "";
+        return `https://cdn.jsdelivr.net/npm/${name}${ver}/README.md`;
       },
       purl: (name: string, version?: string) => {
-        const versionSuffix = version ? `@${version}` : ''
-        return `pkg:npm/${name}${versionSuffix}`
+        const versionSuffix = version ? `@${version}` : "";
+        return `pkg:npm/${name}${versionSuffix}`;
       },
-    }
+    };
   }
 
   /** Encode package name for URL (handle scoped packages). */
   private encodeName(name: string): string {
-    if (name.startsWith('@')) {
-      return name.replace('/', '%2F')
+    if (name.startsWith("@")) {
+      return name.replace("/", "%2F");
     }
-    return name
+    return name;
   }
 
   /** Extract namespace from scoped package name. */
   private extractNamespace(name: string): string {
-    if (name.startsWith('@')) {
-      const parts = name.split('/')
-      return parts[0] || ''
+    if (name.startsWith("@")) {
+      const parts = name.split("/");
+      return parts[0] || "";
     }
-    return ''
+    return "";
   }
 
   /** Extract and normalize license. */
   private extractLicense(raw: string | { type?: string } | undefined): string {
-    if (!raw) return ''
+    if (!raw) return "";
 
-    if (typeof raw === 'string') {
-      return normalizeLicense(raw)
+    if (typeof raw === "string") {
+      return normalizeLicense(raw);
     }
 
-    if (typeof raw === 'object' && raw !== null) {
-      const obj = raw as Record<string, unknown>
-      if (typeof obj['type'] === 'string') {
-        return normalizeLicense(obj['type'])
+    if (typeof raw === "object" && raw !== null) {
+      const obj = raw as Record<string, unknown>;
+      if (typeof obj["type"] === "string") {
+        return normalizeLicense(obj["type"]);
       }
     }
 
-    return ''
+    return "";
   }
 }
 
 /** Factory function for creating npm registry instances. */
 const factory: RegistryFactory = (baseURL: string, client: Client): Registry => {
-  return new NpmRegistry(baseURL, client)
-}
+  return new NpmRegistry(baseURL, client);
+};
 
 // Self-register on import
-register('npm', 'https://registry.npmjs.org', factory)
+register("npm", "https://registry.npmjs.org", factory);

--- a/src/registries/packagist.ts
+++ b/src/registries/packagist.ts
@@ -1,4 +1,4 @@
-import type { Client } from '../core/client.ts'
+import type { Client } from "../core/client.ts";
 import type {
   Dependency,
   Maintainer,
@@ -7,134 +7,131 @@ import type {
   RegistryFactory,
   URLBuilder,
   Version,
-} from '../core/types.ts'
-import { register } from '../core/registry.ts'
-import { HTTPError, NotFoundError, InvalidPURLError } from '../core/errors.ts'
-import { combineLicenses } from '../core/license.ts'
-import { normalizeRepositoryURL } from '../core/repository.ts'
+} from "../core/types.ts";
+import { register } from "../core/registry.ts";
+import { HTTPError, NotFoundError, InvalidPURLError } from "../core/errors.ts";
+import { combineLicenses } from "../core/license.ts";
+import { normalizeRepositoryURL } from "../core/repository.ts";
 
 /** Packagist API response for a single package. */
 interface PackagistPackageResponse {
   package: {
-    name: string
-    description: string
-    repository?: string
-    keywords?: string[]
-    versions: Record<string, PackagistVersion>
-  }
+    name: string;
+    description: string;
+    repository?: string;
+    keywords?: string[];
+    versions: Record<string, PackagistVersion>;
+  };
 }
 
 /** Packagist version data. */
 interface PackagistVersion {
-  name: string
-  version: string
-  license?: string | string[]
-  keywords?: string[]
+  name: string;
+  version: string;
+  license?: string | string[];
+  keywords?: string[];
   authors?: Array<{
-    name?: string
-    email?: string
-    homepage?: string
-    role?: string
-  }>
-  require?: Record<string, string>
-  'require-dev'?: Record<string, string>
+    name?: string;
+    email?: string;
+    homepage?: string;
+    role?: string;
+  }>;
+  require?: Record<string, string>;
+  "require-dev"?: Record<string, string>;
   source?: {
-    type?: string
-    url?: string
-    reference?: string
-  }
+    type?: string;
+    url?: string;
+    reference?: string;
+  };
   dist?: {
-    type?: string
-    url?: string
-    reference?: string
-    shasum?: string
-  }
-  time?: string
+    type?: string;
+    url?: string;
+    reference?: string;
+    shasum?: string;
+  };
+  time?: string;
 }
 
 /** Packagist registry client. */
 class PackagistRegistry implements Registry {
-  constructor(
-    baseURL: string,
-    client: Client,
-  ) {
-    this.baseURL = baseURL
-    this.client = client
+  constructor(baseURL: string, client: Client) {
+    this.baseURL = baseURL;
+    this.client = client;
   }
 
-  readonly baseURL: string
-  readonly client: Client
+  readonly baseURL: string;
+  readonly client: Client;
 
   ecosystem(): string {
-    return 'composer'
+    return "composer";
   }
 
   async fetchPackage(name: string, signal?: AbortSignal): Promise<Package> {
-    const [vendor, pkg] = this.parseName(name)
-    const url = `${this.baseURL}/packages/${vendor}/${pkg}.json`
+    const [vendor, pkg] = this.parseName(name);
+    const url = `${this.baseURL}/packages/${vendor}/${pkg}.json`;
 
     try {
-      const data = await this.client.getJSON<PackagistPackageResponse>(url, signal)
-      const packageData = data.package
+      const data = await this.client.getJSON<PackagistPackageResponse>(url, signal);
+      const packageData = data.package;
 
       // Find latest version
-      const versions = Object.keys(packageData.versions)
-      const latestVersion = this.findLatestVersion(versions)
+      const versions = Object.keys(packageData.versions);
+      const latestVersion = this.findLatestVersion(versions);
 
       // Get license from latest version
-      const latestVersionData = packageData.versions[latestVersion]
-      const licenses = this.extractLicenses(latestVersionData.license)
+      const latestVersionData = packageData.versions[latestVersion];
+      const licenses = this.extractLicenses(latestVersionData.license);
 
       return {
         name: packageData.name,
-        description: packageData.description || '',
-        homepage: '',
-        documentation: '',
-        repository: normalizeRepositoryURL(packageData.repository || latestVersionData.source?.url || ''),
+        description: packageData.description || "",
+        homepage: "",
+        documentation: "",
+        repository: normalizeRepositoryURL(
+          packageData.repository || latestVersionData.source?.url || "",
+        ),
         licenses,
         keywords: packageData.keywords || [],
         namespace: vendor,
         latestVersion,
         metadata: {},
-      }
-    }
-    catch (error) {
+      };
+    } catch (error) {
       if (error instanceof HTTPError && error.isNotFound()) {
-        throw new NotFoundError('composer', name)
+        throw new NotFoundError("composer", name);
       }
-      throw error
+      throw error;
     }
   }
 
   async fetchVersions(name: string, signal?: AbortSignal): Promise<Version[]> {
-    const [vendor, pkg] = this.parseName(name)
-    const url = `${this.baseURL}/packages/${vendor}/${pkg}.json`
+    const [vendor, pkg] = this.parseName(name);
+    const url = `${this.baseURL}/packages/${vendor}/${pkg}.json`;
 
     try {
-      const data = await this.client.getJSON<PackagistPackageResponse>(url, signal)
-      const versions: Version[] = []
+      const data = await this.client.getJSON<PackagistPackageResponse>(url, signal);
+      const versions: Version[] = [];
 
       for (const [versionStr, versionData] of Object.entries(data.package.versions)) {
-        const licenses = this.extractLicenses(versionData.license)
-        const publishedAt = versionData.time ? new Date(versionData.time) : null
+        const licenses = this.extractLicenses(versionData.license);
+        const publishedAt = versionData.time ? new Date(versionData.time) : null;
 
         versions.push({
           number: versionStr,
           publishedAt,
           licenses,
-          integrity: versionData.dist?.shasum ? `sha1-${versionData.dist.shasum}` : '',
-          status: '',
+          integrity: versionData.dist?.shasum ? `sha1-${versionData.dist.shasum}` : "",
+          status: "",
           metadata: {},
-        })
+        });
       }
 
-      return versions
-    }
-    catch (error) {
+      return versions;
+    } catch (error) {
       if (error instanceof HTTPError && error.isNotFound()) {
-        throw new NotFoundError('composer', name)
+        throw new NotFoundError("composer", name);
       }
-      throw error
+      throw error;
     }
   }
 
@@ -143,18 +140,18 @@ class PackagistRegistry implements Registry {
     version: string,
     signal?: AbortSignal,
   ): Promise<Dependency[]> {
-    const [vendor, pkg] = this.parseName(name)
-    const url = `${this.baseURL}/packages/${vendor}/${pkg}.json`
+    const [vendor, pkg] = this.parseName(name);
+    const url = `${this.baseURL}/packages/${vendor}/${pkg}.json`;
 
     try {
-      const data = await this.client.getJSON<PackagistPackageResponse>(url, signal)
-      const versionData = data.package.versions[version]
+      const data = await this.client.getJSON<PackagistPackageResponse>(url, signal);
+      const versionData = data.package.versions[version];
 
       if (!versionData) {
-        throw new NotFoundError('composer', name, version)
+        throw new NotFoundError("composer", name, version);
       }
 
-      const dependencies: Dependency[] = []
+      const dependencies: Dependency[] = [];
 
       // Runtime dependencies
       if (versionData.require) {
@@ -163,159 +160,164 @@ class PackagistRegistry implements Registry {
             dependencies.push({
               name: depName,
               requirements,
-              scope: 'runtime',
+              scope: "runtime",
               optional: false,
-            })
+            });
           }
         }
       }
 
       // Development dependencies
-      if (versionData['require-dev']) {
-        for (const [depName, requirements] of Object.entries(versionData['require-dev'])) {
+      if (versionData["require-dev"]) {
+        for (const [depName, requirements] of Object.entries(versionData["require-dev"])) {
           if (!this.shouldSkipDependency(depName)) {
             dependencies.push({
               name: depName,
               requirements,
-              scope: 'development',
+              scope: "development",
               optional: false,
-            })
+            });
           }
         }
       }
 
-      return dependencies
-    }
-    catch (error) {
+      return dependencies;
+    } catch (error) {
       if (error instanceof HTTPError && error.isNotFound()) {
-        throw new NotFoundError('composer', name, version)
+        throw new NotFoundError("composer", name, version);
       }
-      throw error
+      throw error;
     }
   }
 
   async fetchMaintainers(name: string, signal?: AbortSignal): Promise<Maintainer[]> {
-    const [vendor, pkg] = this.parseName(name)
-    const url = `${this.baseURL}/packages/${vendor}/${pkg}.json`
+    const [vendor, pkg] = this.parseName(name);
+    const url = `${this.baseURL}/packages/${vendor}/${pkg}.json`;
 
     try {
-      const data = await this.client.getJSON<PackagistPackageResponse>(url, signal)
-      const maintainers: Maintainer[] = []
-      const seen = new Set<string>()
+      const data = await this.client.getJSON<PackagistPackageResponse>(url, signal);
+      const maintainers: Maintainer[] = [];
+      const seen = new Set<string>();
 
       // Collect authors from all versions
       for (const versionData of Object.values(data.package.versions)) {
         if (versionData.authors) {
           for (const author of versionData.authors) {
-            const key = `${author.name}:${author.email}`
+            const key = `${author.name}:${author.email}`;
             if (!seen.has(key)) {
-              seen.add(key)
+              seen.add(key);
               maintainers.push({
-                uuid: '',
-                login: author.email ? author.email.split('@')[0] : '',
-                name: author.name || '',
-                email: author.email || '',
-                url: author.homepage || '',
-                role: author.role || '',
-              })
+                uuid: "",
+                login: author.email ? author.email.split("@")[0] : "",
+                name: author.name || "",
+                email: author.email || "",
+                url: author.homepage || "",
+                role: author.role || "",
+              });
             }
           }
         }
       }
 
-      return maintainers
-    }
-    catch (error) {
+      return maintainers;
+    } catch (error) {
       if (error instanceof HTTPError && error.isNotFound()) {
-        throw new NotFoundError('composer', name)
+        throw new NotFoundError("composer", name);
       }
-      throw error
+      throw error;
     }
   }
 
   urls(): URLBuilder {
     return {
       registry: (name: string, version?: string) => {
-        const [vendor, pkg] = this.parseName(name)
-        const base = `https://packagist.org/packages/${vendor}/${pkg}`
-        return version ? `${base}#${version}` : base
+        const [vendor, pkg] = this.parseName(name);
+        const base = `https://packagist.org/packages/${vendor}/${pkg}`;
+        return version ? `${base}#${version}` : base;
       },
       download: (name: string, version: string) => {
-        const [vendor, pkg] = this.parseName(name)
-        return `https://repo.packagist.org/p/${vendor}/${pkg}/${version}.json`
+        const [vendor, pkg] = this.parseName(name);
+        return `https://repo.packagist.org/p/${vendor}/${pkg}/${version}.json`;
       },
       documentation: (name: string, _version?: string) => {
-        const [vendor, pkg] = this.parseName(name)
-        return `https://packagist.org/packages/${vendor}/${pkg}`
+        const [vendor, pkg] = this.parseName(name);
+        return `https://packagist.org/packages/${vendor}/${pkg}`;
       },
       readme: (name: string, _version?: string) => {
-        const [vendor, pkg] = this.parseName(name)
-        return `https://packagist.org/packages/${vendor}/${pkg}`
+        const [vendor, pkg] = this.parseName(name);
+        return `https://packagist.org/packages/${vendor}/${pkg}`;
       },
       purl: (name: string, version?: string) => {
-        const versionSuffix = version ? `@${version}` : ''
-        return `pkg:composer/${name}${versionSuffix}`
+        const versionSuffix = version ? `@${version}` : "";
+        return `pkg:composer/${name}${versionSuffix}`;
       },
-    }
+    };
   }
 
   /** Parse "vendor/package" format. */
   private parseName(name: string): [string, string] {
-    const parts = name.split('/')
+    const parts = name.split("/");
     if (parts.length !== 2 || !parts[0] || !parts[1]) {
-      throw new InvalidPURLError(`pkg:composer/${name}`, 'invalid Composer package name, expected "vendor/package" format')
+      throw new InvalidPURLError(
+        `pkg:composer/${name}`,
+        'invalid Composer package name, expected "vendor/package" format',
+      );
     }
-    return [parts[0]!, parts[1]!]
+    return [parts[0]!, parts[1]!];
   }
 
   /** Find the highest non-dev version. */
   private findLatestVersion(versions: string[]): string {
     // Filter out dev versions
-    const stable = versions.filter(v => !v.startsWith('dev-'))
+    const stable = versions.filter((v) => !v.startsWith("dev-"));
     if (stable.length === 0) {
-      return versions[0] || ''
+      return versions[0] || "";
     }
 
     // Sort by semantic versioning (simplified)
-    return stable.sort((a, b) => {
-      // Remove 'v' prefix if present
-      const aClean = a.replace(/^v/, '')
-      const bClean = b.replace(/^v/, '')
+    return (
+      stable.sort((a, b) => {
+        // Remove 'v' prefix if present
+        const aClean = a.replace(/^v/, "");
+        const bClean = b.replace(/^v/, "");
 
-      // Try numeric comparison for simple versions
-      const aParts = aClean.split('.').map(p => Number.parseInt(p, 10))
-      const bParts = bClean.split('.').map(p => Number.parseInt(p, 10))
+        // Try numeric comparison for simple versions
+        const aParts = aClean.split(".").map((p) => Number.parseInt(p, 10));
+        const bParts = bClean.split(".").map((p) => Number.parseInt(p, 10));
 
-      for (let i = 0; i < Math.max(aParts.length, bParts.length); i++) {
-        const aPart = aParts[i] ?? 0
-        const bPart = bParts[i] ?? 0
-        if (aPart !== bPart) {
-          return bPart - aPart
+        for (let i = 0; i < Math.max(aParts.length, bParts.length); i++) {
+          const aPart = aParts[i] ?? 0;
+          const bPart = bParts[i] ?? 0;
+          if (aPart !== bPart) {
+            return bPart - aPart;
+          }
         }
-      }
 
-      return 0
-    })[0] || versions[0] || ''
+        return 0;
+      })[0] ||
+      versions[0] ||
+      ""
+    );
   }
 
   /** Extract and normalize licenses. */
   private extractLicenses(raw: string | string[] | undefined): string {
-    if (!raw) return ''
+    if (!raw) return "";
 
-    const licenses = Array.isArray(raw) ? raw : [raw]
-    return combineLicenses(licenses)
+    const licenses = Array.isArray(raw) ? raw : [raw];
+    return combineLicenses(licenses);
   }
 
   /** Skip PHP and extension dependencies. */
   private shouldSkipDependency(name: string): boolean {
-    return name === 'php' || name.startsWith('ext-')
+    return name === "php" || name.startsWith("ext-");
   }
 }
 
 /** Factory function for creating Packagist registry instances. */
 const factory: RegistryFactory = (baseURL: string, client: Client): Registry => {
-  return new PackagistRegistry(baseURL, client)
-}
+  return new PackagistRegistry(baseURL, client);
+};
 
 // Self-register on import
-register('composer', 'https://packagist.org', factory)
+register("composer", "https://packagist.org", factory);

--- a/src/registries/pypi.ts
+++ b/src/registries/pypi.ts
@@ -1,4 +1,4 @@
-import type { Client } from '../core/client.ts'
+import type { Client } from "../core/client.ts";
 import type {
   Dependency,
   Maintainer,
@@ -7,139 +7,132 @@ import type {
   RegistryFactory,
   URLBuilder,
   Version,
-} from '../core/types.ts'
-import { register } from '../core/registry.ts'
-import { HTTPError, NotFoundError } from '../core/errors.ts'
-import { normalizeLicense } from '../core/license.ts'
-import { normalizeRepositoryURL } from '../core/repository.ts'
+} from "../core/types.ts";
+import { register } from "../core/registry.ts";
+import { HTTPError, NotFoundError } from "../core/errors.ts";
+import { normalizeLicense } from "../core/license.ts";
+import { normalizeRepositoryURL } from "../core/repository.ts";
 
 /** PyPI JSON API response for a package. */
 interface PyPIPackageResponse {
   info: {
-    name: string
-    version: string
-    summary: string
-    description: string
-    license: string
-    keywords: string
-    author: string
-    author_email: string
-    project_urls: Record<string, string>
-    requires_dist: string[] | null
-  }
-  releases: Record<string, PyPIRelease[]>
-  urls: PyPIFile[]
+    name: string;
+    version: string;
+    summary: string;
+    description: string;
+    license: string;
+    keywords: string;
+    author: string;
+    author_email: string;
+    project_urls: Record<string, string>;
+    requires_dist: string[] | null;
+  };
+  releases: Record<string, PyPIRelease[]>;
+  urls: PyPIFile[];
 }
 
 /** PyPI release file information. */
 interface PyPIRelease {
-  filename: string
-  url: string
-  upload_time_iso_8601: string
-  yanked: boolean
+  filename: string;
+  url: string;
+  upload_time_iso_8601: string;
+  yanked: boolean;
   digests: {
-    sha256: string
-  }
+    sha256: string;
+  };
 }
 
 /** PyPI file information. */
 interface PyPIFile {
-  filename: string
-  url: string
-  upload_time_iso_8601: string
-  yanked: boolean
+  filename: string;
+  url: string;
+  upload_time_iso_8601: string;
+  yanked: boolean;
   digests: {
-    sha256: string
-  }
+    sha256: string;
+  };
 }
 
 /** PyPI registry client. */
 class PyPIRegistry implements Registry {
-  constructor(
-    baseURL: string,
-    client: Client,
-  ) {
-    this.baseURL = baseURL
-    this.client = client
+  constructor(baseURL: string, client: Client) {
+    this.baseURL = baseURL;
+    this.client = client;
   }
 
-  readonly baseURL: string
-  readonly client: Client
+  readonly baseURL: string;
+  readonly client: Client;
 
   ecosystem(): string {
-    return 'pypi'
+    return "pypi";
   }
 
   async fetchPackage(name: string, signal?: AbortSignal): Promise<Package> {
-    const normalized = this.normalizeName(name)
-    const url = `${this.baseURL}/pypi/${normalized}/json`
+    const normalized = this.normalizeName(name);
+    const url = `${this.baseURL}/pypi/${normalized}/json`;
 
     try {
-      const data = await this.client.getJSON<PyPIPackageResponse>(url, signal)
-      const info = data.info
+      const data = await this.client.getJSON<PyPIPackageResponse>(url, signal);
+      const info = data.info;
 
-      const licenses = normalizeLicense(info.license)
-      const repository = this.extractRepository(info.project_urls)
-      const keywords = this.parseKeywords(info.keywords)
+      const licenses = normalizeLicense(info.license);
+      const repository = this.extractRepository(info.project_urls);
+      const keywords = this.parseKeywords(info.keywords);
 
       return {
         name: info.name,
-        description: info.summary || info.description || '',
-        homepage: info.project_urls?.['Homepage'] || '',
-        documentation: info.project_urls?.['Documentation'] || '',
+        description: info.summary || info.description || "",
+        homepage: info.project_urls?.["Homepage"] || "",
+        documentation: info.project_urls?.["Documentation"] || "",
         repository,
         licenses,
         keywords,
-        namespace: '',
+        namespace: "",
         latestVersion: info.version,
         metadata: {},
-      }
-    }
-    catch (error) {
+      };
+    } catch (error) {
       if (error instanceof HTTPError && error.isNotFound()) {
-        throw new NotFoundError('pypi', name)
+        throw new NotFoundError("pypi", name);
       }
-      throw error
+      throw error;
     }
   }
 
   async fetchVersions(name: string, signal?: AbortSignal): Promise<Version[]> {
-    const normalized = this.normalizeName(name)
-    const url = `${this.baseURL}/pypi/${normalized}/json`
+    const normalized = this.normalizeName(name);
+    const url = `${this.baseURL}/pypi/${normalized}/json`;
 
     try {
-      const data = await this.client.getJSON<PyPIPackageResponse>(url, signal)
-      const versions: Version[] = []
+      const data = await this.client.getJSON<PyPIPackageResponse>(url, signal);
+      const versions: Version[] = [];
 
       for (const [versionStr, releases] of Object.entries(data.releases)) {
-        if (releases.length === 0) continue
+        if (releases.length === 0) continue;
 
-        const release = releases[0]!
+        const release = releases[0]!;
         const publishedAt = release.upload_time_iso_8601
           ? new Date(release.upload_time_iso_8601)
-          : null
-        const integrity = release.digests?.sha256
-          ? `sha256-${release.digests.sha256}`
-          : ''
-        const status = release.yanked ? 'yanked' : ''
+          : null;
+        const integrity = release.digests?.sha256 ? `sha256-${release.digests.sha256}` : "";
+        const status = release.yanked ? "yanked" : "";
 
         versions.push({
           number: versionStr,
           publishedAt,
-          licenses: '',
+          licenses: "",
           integrity,
           status,
           metadata: {},
-        })
+        });
       }
 
-      return versions
-    }
-    catch (error) {
+      return versions;
+    } catch (error) {
       if (error instanceof HTTPError && error.isNotFound()) {
-        throw new NotFoundError('pypi', name)
+        throw new NotFoundError("pypi", name);
       }
-      throw error
+      throw error;
     }
   }
 
@@ -148,149 +141,145 @@ class PyPIRegistry implements Registry {
     version: string,
     signal?: AbortSignal,
   ): Promise<Dependency[]> {
-    const normalized = this.normalizeName(name)
-    const url = `${this.baseURL}/pypi/${normalized}/${version}/json`
+    const normalized = this.normalizeName(name);
+    const url = `${this.baseURL}/pypi/${normalized}/${version}/json`;
 
     try {
-      const data = await this.client.getJSON<PyPIPackageResponse>(url, signal)
-      const dependencies: Dependency[] = []
+      const data = await this.client.getJSON<PyPIPackageResponse>(url, signal);
+      const dependencies: Dependency[] = [];
 
       if (data.info.requires_dist) {
         for (const depStr of data.info.requires_dist) {
-          const dep = this.parsePEP508(depStr)
+          const dep = this.parsePEP508(depStr);
           if (dep) {
-            dependencies.push(dep)
+            dependencies.push(dep);
           }
         }
       }
 
-      return dependencies
-    }
-    catch (error) {
+      return dependencies;
+    } catch (error) {
       if (error instanceof HTTPError && error.isNotFound()) {
-        throw new NotFoundError('pypi', name, version)
+        throw new NotFoundError("pypi", name, version);
       }
-      throw error
+      throw error;
     }
   }
 
   async fetchMaintainers(name: string, signal?: AbortSignal): Promise<Maintainer[]> {
-    const normalized = this.normalizeName(name)
-    const url = `${this.baseURL}/pypi/${normalized}/json`
+    const normalized = this.normalizeName(name);
+    const url = `${this.baseURL}/pypi/${normalized}/json`;
 
     try {
-      const data = await this.client.getJSON<PyPIPackageResponse>(url, signal)
-      const maintainers: Maintainer[] = []
+      const data = await this.client.getJSON<PyPIPackageResponse>(url, signal);
+      const maintainers: Maintainer[] = [];
 
       if (data.info.author || data.info.author_email) {
         maintainers.push({
-          uuid: '',
-          login: data.info.author_email
-            ? data.info.author_email.split('@')[0]
-            : '',
-          name: data.info.author || '',
-          email: data.info.author_email || '',
-          url: '',
-          role: 'author',
-        })
+          uuid: "",
+          login: data.info.author_email ? data.info.author_email.split("@")[0] : "",
+          name: data.info.author || "",
+          email: data.info.author_email || "",
+          url: "",
+          role: "author",
+        });
       }
 
-      return maintainers
-    }
-    catch (error) {
+      return maintainers;
+    } catch (error) {
       if (error instanceof HTTPError && error.isNotFound()) {
-        throw new NotFoundError('pypi', name)
+        throw new NotFoundError("pypi", name);
       }
-      throw error
+      throw error;
     }
   }
 
   urls(): URLBuilder {
     return {
       registry: (name: string, version?: string) => {
-        const normalized = this.normalizeName(name)
-        const base = `https://pypi.org/project/${normalized}`
-        return version ? `${base}/${version}` : base
+        const normalized = this.normalizeName(name);
+        const base = `https://pypi.org/project/${normalized}`;
+        return version ? `${base}/${version}` : base;
       },
       download: (name: string, version: string) => {
-        const normalized = this.normalizeName(name)
-        return `https://pypi.org/pypi/${normalized}/${version}`
+        const normalized = this.normalizeName(name);
+        return `https://pypi.org/pypi/${normalized}/${version}`;
       },
       documentation: (name: string, _version?: string) => {
-        const normalized = this.normalizeName(name)
-        return `https://pypi.org/project/${normalized}`
+        const normalized = this.normalizeName(name);
+        return `https://pypi.org/project/${normalized}`;
       },
       readme: (name: string, version?: string) => {
-        const normalized = this.normalizeName(name)
+        const normalized = this.normalizeName(name);
         return version
           ? `https://pypi.org/project/${normalized}/${version}/`
-          : `https://pypi.org/project/${normalized}/`
+          : `https://pypi.org/project/${normalized}/`;
       },
       purl: (name: string, version?: string) => {
-        const normalized = this.normalizeName(name)
-        const versionSuffix = version ? `@${version}` : ''
-        return `pkg:pypi/${normalized}${versionSuffix}`
+        const normalized = this.normalizeName(name);
+        const versionSuffix = version ? `@${version}` : "";
+        return `pkg:pypi/${normalized}${versionSuffix}`;
       },
-    }
+    };
   }
 
   /** Normalize package name per PEP 503. */
   private normalizeName(name: string): string {
-    return name.toLowerCase().replace(/_/g, '-')
+    return name.toLowerCase().replace(/_/g, "-");
   }
 
   /** Extract repository URL from project_urls. */
   private extractRepository(projectUrls: Record<string, string> | undefined): string {
-    if (!projectUrls) return ''
+    if (!projectUrls) return "";
 
-    const keys = ['Repository', 'Source', 'Source Code', 'GitHub', 'Homepage']
+    const keys = ["Repository", "Source", "Source Code", "GitHub", "Homepage"];
     for (const key of keys) {
-      const url = projectUrls[key]
+      const url = projectUrls[key];
       if (url) {
-        return normalizeRepositoryURL(url)
+        return normalizeRepositoryURL(url);
       }
     }
 
-    return ''
+    return "";
   }
 
   /** Parse comma-separated keywords. */
   private parseKeywords(keywords: string | undefined): string[] {
-    if (!keywords) return []
+    if (!keywords) return [];
     return keywords
-      .split(',')
-      .map(k => k.trim())
-      .filter(Boolean)
+      .split(",")
+      .map((k) => k.trim())
+      .filter(Boolean);
   }
 
   /** Parse PEP 508 dependency string. */
   private parsePEP508(depStr: string): Dependency | null {
     // Basic parsing: "name (version_spec) ; extras"
     // For now, extract just the name and requirements
-    const parts = depStr.split(';')
-    const mainPart = parts[0]!.trim()
+    const parts = depStr.split(";");
+    const mainPart = parts[0]!.trim();
 
     // Extract name and version spec
-    const match = mainPart.match(/^([a-zA-Z0-9._-]+)\s*(.*)$/)
-    if (!match) return null
+    const match = mainPart.match(/^([a-zA-Z0-9._-]+)\s*(.*)$/);
+    if (!match) return null;
 
-    const depName = match[1]!
-    const versionSpec = match[2]!.trim()
+    const depName = match[1]!;
+    const versionSpec = match[2]!.trim();
 
     // Determine scope based on extras (simplified)
-    let scope: 'runtime' | 'development' | 'test' | 'build' | 'optional' = 'runtime'
-    let optional = false
+    let scope: "runtime" | "development" | "test" | "build" | "optional" = "runtime";
+    let optional = false;
 
     if (parts.length > 1) {
-      const extras = parts[1]!.toLowerCase()
-      if (extras.includes('extra')) {
-        optional = true
+      const extras = parts[1]!.toLowerCase();
+      if (extras.includes("extra")) {
+        optional = true;
       }
-      if (extras.includes('dev')) {
-        scope = 'development'
+      if (extras.includes("dev")) {
+        scope = "development";
       }
-      if (extras.includes('test')) {
-        scope = 'test'
+      if (extras.includes("test")) {
+        scope = "test";
       }
     }
 
@@ -299,14 +288,14 @@ class PyPIRegistry implements Registry {
       requirements: versionSpec,
       scope,
       optional,
-    }
+    };
   }
 }
 
 /** Factory function for creating PyPI registry instances. */
 const factory: RegistryFactory = (baseURL: string, client: Client): Registry => {
-  return new PyPIRegistry(baseURL, client)
-}
+  return new PyPIRegistry(baseURL, client);
+};
 
 // Self-register on import
-register('pypi', 'https://pypi.org', factory)
+register("pypi", "https://pypi.org", factory);

--- a/src/registries/rubygems.ts
+++ b/src/registries/rubygems.ts
@@ -1,4 +1,4 @@
-import type { Client } from '../core/client.ts'
+import type { Client } from "../core/client.ts";
 import type {
   Dependency,
   Maintainer,
@@ -7,128 +7,128 @@ import type {
   RegistryFactory,
   URLBuilder,
   Version,
-} from '../core/types.ts'
-import { register } from '../core/registry.ts'
-import { HTTPError, NotFoundError } from '../core/errors.ts'
-import { combineLicenses, normalizeLicense } from '../core/license.ts'
-import { normalizeRepositoryURL } from '../core/repository.ts'
+} from "../core/types.ts";
+import { register } from "../core/registry.ts";
+import { HTTPError, NotFoundError } from "../core/errors.ts";
+import { combineLicenses, normalizeLicense } from "../core/license.ts";
+import { normalizeRepositoryURL } from "../core/repository.ts";
 
 /** RubyGems API response for a single gem. */
 interface RubyGemsGemResponse {
-  name: string
-  version?: string
-  description: string
-  homepage_uri?: string
-  documentation_uri?: string
-  source_code_uri?: string
-  licenses?: string[]
-  metadata?: Record<string, unknown>
+  name: string;
+  version?: string;
+  description: string;
+  homepage_uri?: string;
+  documentation_uri?: string;
+  source_code_uri?: string;
+  licenses?: string[];
+  metadata?: Record<string, unknown>;
   dependencies?: {
     runtime?: Array<{
-      name: string
-      requirements: string
-    }>
+      name: string;
+      requirements: string;
+    }>;
     development?: Array<{
-      name: string
-      requirements: string
-    }>
-  }
+      name: string;
+      requirements: string;
+    }>;
+  };
 }
 
 /** RubyGems version data. */
 interface RubyGemsVersionResponse {
-  number: string
-  sha: string
-  created_at?: string
-  yanked?: boolean
+  number: string;
+  sha: string;
+  created_at?: string;
+  yanked?: boolean;
 }
 
 /** RubyGems owner data. */
 interface RubyGemsOwnerResponse {
-  handle: string
-  email?: string
+  handle: string;
+  email?: string;
 }
 
 /** RubyGems registry client. */
 class RubyGemsRegistry implements Registry {
-  constructor(
-    baseURL: string,
-    client: Client,
-  ) {
-    this.baseURL = baseURL
-    this.client = client
+  constructor(baseURL: string, client: Client) {
+    this.baseURL = baseURL;
+    this.client = client;
   }
 
-  readonly baseURL: string
-  readonly client: Client
+  readonly baseURL: string;
+  readonly client: Client;
 
   ecosystem(): string {
-    return 'gem'
+    return "gem";
   }
 
   async fetchPackage(name: string, signal?: AbortSignal): Promise<Package> {
-    const url = `${this.baseURL}/api/v1/gems/${name}.json`
+    const url = `${this.baseURL}/api/v1/gems/${name}.json`;
 
     try {
-      const data = await this.client.getJSON<RubyGemsGemResponse>(url, signal)
+      const data = await this.client.getJSON<RubyGemsGemResponse>(url, signal);
 
       // Extract licenses
-      const licenses = data.licenses ? combineLicenses(data.licenses.map(l => normalizeLicense(l))) : ''
+      const licenses = data.licenses
+        ? combineLicenses(data.licenses.map((l) => normalizeLicense(l)))
+        : "";
 
       // Extract repository URL
       const repository = normalizeRepositoryURL(
-        data.source_code_uri || (data.metadata?.source_code_uri as string) || data.homepage_uri || ''
-      )
+        data.source_code_uri ||
+          (data.metadata?.source_code_uri as string) ||
+          data.homepage_uri ||
+          "",
+      );
 
       return {
         name: data.name,
-        description: data.description || '',
-        homepage: data.homepage_uri || '',
-        documentation: data.documentation_uri || '',
+        description: data.description || "",
+        homepage: data.homepage_uri || "",
+        documentation: data.documentation_uri || "",
         repository,
         licenses,
         keywords: [],
-        namespace: '',
-        latestVersion: data.version || '',
+        namespace: "",
+        latestVersion: data.version || "",
         metadata: data.metadata || {},
-      }
-    }
-    catch (error) {
+      };
+    } catch (error) {
       if (error instanceof HTTPError && error.isNotFound()) {
-        throw new NotFoundError('gem', name)
+        throw new NotFoundError("gem", name);
       }
-      throw error
+      throw error;
     }
   }
 
   async fetchVersions(name: string, signal?: AbortSignal): Promise<Version[]> {
-    const url = `${this.baseURL}/api/v1/versions/${name}.json`
+    const url = `${this.baseURL}/api/v1/versions/${name}.json`;
 
     try {
-      const data = await this.client.getJSON<RubyGemsVersionResponse[]>(url, signal)
-      const versions: Version[] = []
+      const data = await this.client.getJSON<RubyGemsVersionResponse[]>(url, signal);
+      const versions: Version[] = [];
 
       for (const versionData of data) {
-        const publishedAt = versionData.created_at ? new Date(versionData.created_at) : null
-        const status = versionData.yanked ? 'yanked' : ''
+        const publishedAt = versionData.created_at ? new Date(versionData.created_at) : null;
+        const status = versionData.yanked ? "yanked" : "";
 
         versions.push({
           number: versionData.number,
           publishedAt,
-          licenses: '',
-          integrity: versionData.sha ? `sha256-${versionData.sha}` : '',
+          licenses: "",
+          integrity: versionData.sha ? `sha256-${versionData.sha}` : "",
           status,
           metadata: {},
-        })
+        });
       }
 
-      return versions
-    }
-    catch (error) {
+      return versions;
+    } catch (error) {
       if (error instanceof HTTPError && error.isNotFound()) {
-        throw new NotFoundError('gem', name)
+        throw new NotFoundError("gem", name);
       }
-      throw error
+      throw error;
     }
   }
 
@@ -137,11 +137,11 @@ class RubyGemsRegistry implements Registry {
     version: string,
     signal?: AbortSignal,
   ): Promise<Dependency[]> {
-    const url = `${this.baseURL}/api/v1/gems/${name}.json`
+    const url = `${this.baseURL}/api/v1/gems/${name}.json`;
 
     try {
-      const data = await this.client.getJSON<RubyGemsGemResponse>(url, signal)
-      const dependencies: Dependency[] = []
+      const data = await this.client.getJSON<RubyGemsGemResponse>(url, signal);
+      const dependencies: Dependency[] = [];
 
       // Runtime dependencies
       if (data.dependencies?.runtime) {
@@ -149,9 +149,9 @@ class RubyGemsRegistry implements Registry {
           dependencies.push({
             name: dep.name,
             requirements: dep.requirements,
-            scope: 'runtime',
+            scope: "runtime",
             optional: false,
-          })
+          });
         }
       }
 
@@ -161,79 +161,77 @@ class RubyGemsRegistry implements Registry {
           dependencies.push({
             name: dep.name,
             requirements: dep.requirements,
-            scope: 'development',
+            scope: "development",
             optional: false,
-          })
+          });
         }
       }
 
-      return dependencies
-    }
-    catch (error) {
+      return dependencies;
+    } catch (error) {
       if (error instanceof HTTPError && error.isNotFound()) {
-        throw new NotFoundError('gem', name, version)
+        throw new NotFoundError("gem", name, version);
       }
-      throw error
+      throw error;
     }
   }
 
   async fetchMaintainers(name: string, signal?: AbortSignal): Promise<Maintainer[]> {
-    const url = `${this.baseURL}/api/v1/gems/${name}/owners.json`
+    const url = `${this.baseURL}/api/v1/gems/${name}/owners.json`;
 
     try {
-      const data = await this.client.getJSON<RubyGemsOwnerResponse[]>(url, signal)
-      const maintainers: Maintainer[] = []
+      const data = await this.client.getJSON<RubyGemsOwnerResponse[]>(url, signal);
+      const maintainers: Maintainer[] = [];
 
       for (const owner of data) {
         maintainers.push({
-          uuid: '',
+          uuid: "",
           login: owner.handle,
           name: owner.handle,
-          email: owner.email || '',
-          url: '',
-          role: '',
-        })
+          email: owner.email || "",
+          url: "",
+          role: "",
+        });
       }
 
-      return maintainers
-    }
-    catch (error) {
+      return maintainers;
+    } catch (error) {
       if (error instanceof HTTPError && error.isNotFound()) {
-        throw new NotFoundError('gem', name)
+        throw new NotFoundError("gem", name);
       }
-      throw error
+      throw error;
     }
   }
 
   urls(): URLBuilder {
     return {
       registry: (name: string, version?: string) => {
-        const base = `https://rubygems.org/gems/${name}`
-        return version ? `${base}/versions/${version}` : base
+        const base = `https://rubygems.org/gems/${name}`;
+        return version ? `${base}/versions/${version}` : base;
       },
       download: (name: string, version: string) => {
-        return `https://rubygems.org/downloads/${name}-${version}.gem`
+        return `https://rubygems.org/downloads/${name}-${version}.gem`;
       },
       documentation: (name: string, version?: string) => {
-        const versionSuffix = version ? `/${version}` : ''
-        return `https://www.rubydoc.info/gems/${name}${versionSuffix}`
+        const versionSuffix = version ? `/${version}` : "";
+        return `https://www.rubydoc.info/gems/${name}${versionSuffix}`;
       },
       readme: (name: string, version?: string) => {
-        const base = `https://rubygems.org/gems/${name}`
-        return version ? `${base}/versions/${version}` : base
+        const base = `https://rubygems.org/gems/${name}`;
+        return version ? `${base}/versions/${version}` : base;
       },
       purl: (name: string, version?: string) => {
-        const versionSuffix = version ? `@${version}` : ''
-        return `pkg:gem/${name}${versionSuffix}`
+        const versionSuffix = version ? `@${version}` : "";
+        return `pkg:gem/${name}${versionSuffix}`;
       },
-    }
+    };
   }
 }
 
 /** Factory function for creating RubyGems registry instances. */
 const factory: RegistryFactory = (baseURL: string, client: Client): Registry => {
-  return new RubyGemsRegistry(baseURL, client)
-}
+  return new RubyGemsRegistry(baseURL, client);
+};
 
 // Self-register on import
-register('gem', 'https://rubygems.org', factory)
+register("gem", "https://rubygems.org", factory);

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,4 +12,4 @@ export type {
   ClientOptions,
   RateLimiter,
   ParsedPURL,
-} from './core/types.ts'
+} from "./core/types.ts";

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -1,9 +1,11 @@
 # TEST GUIDE
 
 ## OVERVIEW
+
 `test/` is split into deterministic unit coverage and live-network e2e smoke checks under Vitest projects.
 
 ## STRUCTURE
+
 ```text
 test/
 |- unit/  # focused unit suites per module
@@ -11,21 +13,24 @@ test/
 ```
 
 ## WHERE TO LOOK
-| Task | Location | Notes |
-|------|----------|-------|
-| PURL contract tests | `test/unit/purl.test.ts` | Parse/build validation matrix |
-| Registry factory + plugin tests | `test/unit/registry.test.ts`, `test/unit/registries.test.ts` | Registration + per-ecosystem behavior |
-| Cache behavior tests | `test/unit/lockfile.test.ts`, `test/unit/cached-registry.test.ts` | Freshness, TTL, integrity, wrapper behavior |
-| Normalization tests | `test/unit/license.test.ts`, `test/unit/repository.test.ts` | Canonical output normalization |
-| Error-type expectations | `test/unit/errors.test.ts` | Custom error classes |
-| Live smoke tests | `test/e2e/smoke.test.ts` | Network-sensitive ecosystem checks |
+
+| Task                            | Location                                                          | Notes                                       |
+| ------------------------------- | ----------------------------------------------------------------- | ------------------------------------------- |
+| PURL contract tests             | `test/unit/purl.test.ts`                                          | Parse/build validation matrix               |
+| Registry factory + plugin tests | `test/unit/registry.test.ts`, `test/unit/registries.test.ts`      | Registration + per-ecosystem behavior       |
+| Cache behavior tests            | `test/unit/lockfile.test.ts`, `test/unit/cached-registry.test.ts` | Freshness, TTL, integrity, wrapper behavior |
+| Normalization tests             | `test/unit/license.test.ts`, `test/unit/repository.test.ts`       | Canonical output normalization              |
+| Error-type expectations         | `test/unit/errors.test.ts`                                        | Custom error classes                        |
+| Live smoke tests                | `test/e2e/smoke.test.ts`                                          | Network-sensitive ecosystem checks          |
 
 ## CONVENTIONS
+
 - Test files use `*.test.ts` naming.
 - Vitest globals are enabled (`describe`, `it`, `expect`, `vi` without imports).
 - Unit tests rely on mocks/spies; e2e tests use real HTTP.
 
 ## ANTI-PATTERNS
+
 - Do not rely on e2e tests for deterministic behavior checks handled by unit suites.
 - Do not add module coverage gaps without corresponding unit tests.
 - Do not place production helper code under `test/`.

--- a/test/e2e/smoke.test.ts
+++ b/test/e2e/smoke.test.ts
@@ -4,109 +4,109 @@
  *
  * These tests hit live APIs and may fail due to rate limiting or network issues.
  */
-import { create, ecosystems, has } from '../../src/core/registry.ts'
-import '../../src/registries/index.ts'
+import { create, ecosystems, has } from "../../src/core/registry.ts";
+import "../../src/registries/index.ts";
 
-describe('registry smoke tests', () => {
-  it('all 6 ecosystems are registered', () => {
-    const registered = ecosystems()
-    expect(registered).toContain('npm')
-    expect(registered).toContain('cargo')
-    expect(registered).toContain('pypi')
-    expect(registered).toContain('gem')
-    expect(registered).toContain('composer')
-    expect(registered).toContain('alpm')
-    expect(registered).toHaveLength(6)
-  })
+describe("registry smoke tests", () => {
+  it("all 6 ecosystems are registered", () => {
+    const registered = ecosystems();
+    expect(registered).toContain("npm");
+    expect(registered).toContain("cargo");
+    expect(registered).toContain("pypi");
+    expect(registered).toContain("gem");
+    expect(registered).toContain("composer");
+    expect(registered).toContain("alpm");
+    expect(registered).toHaveLength(6);
+  });
 
-  it('has() returns correct values', () => {
-    expect(has('npm')).toBe(true)
-    expect(has('cargo')).toBe(true)
-    expect(has('unknown')).toBe(false)
-  })
+  it("has() returns correct values", () => {
+    expect(has("npm")).toBe(true);
+    expect(has("cargo")).toBe(true);
+    expect(has("unknown")).toBe(false);
+  });
 
-  describe('npm — lodash', { timeout: 15_000 }, () => {
-    it('fetchPackage', async () => {
-      const reg = create('npm')
-      const pkg = await reg.fetchPackage('lodash')
-      expect(pkg.name).toBe('lodash')
-      expect(pkg.licenses).toBeTruthy()
-      expect(pkg.repository).toContain('github.com')
-      expect(pkg.latestVersion).toBeTruthy()
-    })
+  describe("npm — lodash", { timeout: 15_000 }, () => {
+    it("fetchPackage", async () => {
+      const reg = create("npm");
+      const pkg = await reg.fetchPackage("lodash");
+      expect(pkg.name).toBe("lodash");
+      expect(pkg.licenses).toBeTruthy();
+      expect(pkg.repository).toContain("github.com");
+      expect(pkg.latestVersion).toBeTruthy();
+    });
 
-    it('fetchVersions', async () => {
-      const reg = create('npm')
-      const versions = await reg.fetchVersions('lodash')
-      expect(versions.length).toBeGreaterThan(10)
-      expect(versions[0]!.number).toBeTruthy()
-    })
+    it("fetchVersions", async () => {
+      const reg = create("npm");
+      const versions = await reg.fetchVersions("lodash");
+      expect(versions.length).toBeGreaterThan(10);
+      expect(versions[0]!.number).toBeTruthy();
+    });
 
-    it('urls', () => {
-      const reg = create('npm')
-      const urls = reg.urls()
-      expect(urls.registry('lodash')).toContain('npmjs.com')
-      expect(urls.purl('lodash', '4.17.21')).toBe('pkg:npm/lodash@4.17.21')
-    })
-  })
+    it("urls", () => {
+      const reg = create("npm");
+      const urls = reg.urls();
+      expect(urls.registry("lodash")).toContain("npmjs.com");
+      expect(urls.purl("lodash", "4.17.21")).toBe("pkg:npm/lodash@4.17.21");
+    });
+  });
 
-  describe('cargo — serde', { timeout: 15_000 }, () => {
-    it('fetchPackage', async () => {
-      const reg = create('cargo')
-      const pkg = await reg.fetchPackage('serde')
-      expect(pkg.name).toBe('serde')
-      expect(pkg.licenses).toBeTruthy()
-      expect(pkg.repository).toContain('github.com')
-    })
-  })
+  describe("cargo — serde", { timeout: 15_000 }, () => {
+    it("fetchPackage", async () => {
+      const reg = create("cargo");
+      const pkg = await reg.fetchPackage("serde");
+      expect(pkg.name).toBe("serde");
+      expect(pkg.licenses).toBeTruthy();
+      expect(pkg.repository).toContain("github.com");
+    });
+  });
 
-  describe('pypi — requests', { timeout: 15_000 }, () => {
-    it('fetchPackage', async () => {
-      const reg = create('pypi')
-      const pkg = await reg.fetchPackage('requests')
-      expect(pkg.name).toBe('requests')
-      expect(pkg.licenses).toBeTruthy()
-      expect(pkg.repository).toContain('github.com')
-    })
-  })
+  describe("pypi — requests", { timeout: 15_000 }, () => {
+    it("fetchPackage", async () => {
+      const reg = create("pypi");
+      const pkg = await reg.fetchPackage("requests");
+      expect(pkg.name).toBe("requests");
+      expect(pkg.licenses).toBeTruthy();
+      expect(pkg.repository).toContain("github.com");
+    });
+  });
 
-  describe('gem — rails', { timeout: 15_000 }, () => {
-    it('fetchPackage', async () => {
-      const reg = create('gem')
-      const pkg = await reg.fetchPackage('rails')
-      expect(pkg.name).toBe('rails')
-      expect(pkg.licenses).toBeTruthy()
-    })
-  })
+  describe("gem — rails", { timeout: 15_000 }, () => {
+    it("fetchPackage", async () => {
+      const reg = create("gem");
+      const pkg = await reg.fetchPackage("rails");
+      expect(pkg.name).toBe("rails");
+      expect(pkg.licenses).toBeTruthy();
+    });
+  });
 
-  describe('composer — laravel/framework', { timeout: 15_000 }, () => {
-    it('fetchPackage', async () => {
-      const reg = create('composer')
-      const pkg = await reg.fetchPackage('laravel/framework')
-      expect(pkg.name).toBe('laravel/framework')
-      expect(pkg.licenses).toBeTruthy()
-      expect(pkg.namespace).toBe('laravel')
-    })
-  })
+  describe("composer — laravel/framework", { timeout: 15_000 }, () => {
+    it("fetchPackage", async () => {
+      const reg = create("composer");
+      const pkg = await reg.fetchPackage("laravel/framework");
+      expect(pkg.name).toBe("laravel/framework");
+      expect(pkg.licenses).toBeTruthy();
+      expect(pkg.namespace).toBe("laravel");
+    });
+  });
 
-  describe('alpm — pacman (official)', { timeout: 15_000 }, () => {
-    it('fetchPackage', async () => {
-      const reg = create('alpm')
-      const pkg = await reg.fetchPackage('arch/pacman')
-      expect(pkg.name).toBe('pacman')
-      expect(pkg.licenses).toBeTruthy()
-      expect(pkg.namespace).toBe('arch')
-      expect(pkg.latestVersion).toBeTruthy()
-    })
-  })
+  describe("alpm — pacman (official)", { timeout: 15_000 }, () => {
+    it("fetchPackage", async () => {
+      const reg = create("alpm");
+      const pkg = await reg.fetchPackage("arch/pacman");
+      expect(pkg.name).toBe("pacman");
+      expect(pkg.licenses).toBeTruthy();
+      expect(pkg.namespace).toBe("arch");
+      expect(pkg.latestVersion).toBeTruthy();
+    });
+  });
 
-  describe('alpm — yay (AUR)', { timeout: 15_000 }, () => {
-    it('fetchPackage', async () => {
-      const reg = create('alpm')
-      const pkg = await reg.fetchPackage('aur/yay')
-      expect(pkg.name).toBe('yay')
-      expect(pkg.namespace).toBe('aur')
-      expect(pkg.latestVersion).toBeTruthy()
-    })
-  })
-})
+  describe("alpm — yay (AUR)", { timeout: 15_000 }, () => {
+    it("fetchPackage", async () => {
+      const reg = create("alpm");
+      const pkg = await reg.fetchPackage("aur/yay");
+      expect(pkg.name).toBe("yay");
+      expect(pkg.namespace).toBe("aur");
+      expect(pkg.latestVersion).toBeTruthy();
+    });
+  });
+});

--- a/test/unit/ai-tool.test.ts
+++ b/test/unit/ai-tool.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from "vitest";
 
 const {
   mockFetchPackageFromPURL,
@@ -12,95 +12,97 @@ const {
   mockFetchDependenciesFromPURL: vi.fn(),
   mockFetchMaintainersFromPURL: vi.fn(),
   mockBulkFetchPackages: vi.fn(),
-}))
+}));
 
-vi.mock('../../src/helpers.ts', () => ({
+vi.mock("../../src/helpers.ts", () => ({
   fetchPackageFromPURL: mockFetchPackageFromPURL,
   fetchVersionsFromPURL: mockFetchVersionsFromPURL,
   fetchDependenciesFromPURL: mockFetchDependenciesFromPURL,
   fetchMaintainersFromPURL: mockFetchMaintainersFromPURL,
   bulkFetchPackages: mockBulkFetchPackages,
-}))
+}));
 
-import { packageTool } from '../../src/ai.ts'
+import { packageTool } from "../../src/ai.ts";
 
-describe('packageTool', () => {
-  it('has description and input schema', () => {
-    expect(packageTool.description).toBeTypeOf('string')
-    expect(packageTool.inputSchema).toBeDefined()
-    expect(packageTool.execute).toBeTypeOf('function')
-  })
+describe("packageTool", () => {
+  it("has description and input schema", () => {
+    expect(packageTool.description).toBeTypeOf("string");
+    expect(packageTool.inputSchema).toBeDefined();
+    expect(packageTool.execute).toBeTypeOf("function");
+  });
 
-  it('fetches package metadata', async () => {
-    mockFetchPackageFromPURL.mockResolvedValueOnce({ name: 'lodash', latestVersion: '4.17.21' })
-
-    const result = await packageTool.execute!(
-      { operation: 'package', purl: 'pkg:npm/lodash' },
-      { toolCallId: 'call-1', messages: [] },
-    )
-
-    expect(mockFetchPackageFromPURL).toHaveBeenCalledWith('pkg:npm/lodash', undefined)
-    expect(result).toEqual({ name: 'lodash', latestVersion: '4.17.21' })
-  })
-
-  it('fetches versions', async () => {
-    mockFetchVersionsFromPURL.mockResolvedValueOnce([{ number: '1.0.0' }, { number: '2.0.0' }])
+  it("fetches package metadata", async () => {
+    mockFetchPackageFromPURL.mockResolvedValueOnce({ name: "lodash", latestVersion: "4.17.21" });
 
     const result = await packageTool.execute!(
-      { operation: 'versions', purl: 'pkg:cargo/serde' },
-      { toolCallId: 'call-2', messages: [] },
-    )
+      { operation: "package", purl: "pkg:npm/lodash" },
+      { toolCallId: "call-1", messages: [] },
+    );
 
-    expect(mockFetchVersionsFromPURL).toHaveBeenCalledWith('pkg:cargo/serde', undefined)
-    expect(result).toEqual([{ number: '1.0.0' }, { number: '2.0.0' }])
-  })
+    expect(mockFetchPackageFromPURL).toHaveBeenCalledWith("pkg:npm/lodash", undefined);
+    expect(result).toEqual({ name: "lodash", latestVersion: "4.17.21" });
+  });
 
-  it('fetches dependencies', async () => {
-    mockFetchDependenciesFromPURL.mockResolvedValueOnce([{ name: 'click', requirements: '>=8.0' }])
-
-    const result = await packageTool.execute!(
-      { operation: 'dependencies', purl: 'pkg:pypi/flask@3.1.1' },
-      { toolCallId: 'call-3', messages: [] },
-    )
-
-    expect(mockFetchDependenciesFromPURL).toHaveBeenCalledWith('pkg:pypi/flask@3.1.1', undefined)
-    expect(result).toEqual([{ name: 'click', requirements: '>=8.0' }])
-  })
-
-  it('fetches maintainers', async () => {
-    mockFetchMaintainersFromPURL.mockResolvedValueOnce([{ login: 'dhh', role: 'author' }])
+  it("fetches versions", async () => {
+    mockFetchVersionsFromPURL.mockResolvedValueOnce([{ number: "1.0.0" }, { number: "2.0.0" }]);
 
     const result = await packageTool.execute!(
-      { operation: 'maintainers', purl: 'pkg:gem/rails' },
-      { toolCallId: 'call-4', messages: [] },
-    )
+      { operation: "versions", purl: "pkg:cargo/serde" },
+      { toolCallId: "call-2", messages: [] },
+    );
 
-    expect(mockFetchMaintainersFromPURL).toHaveBeenCalledWith('pkg:gem/rails', undefined)
-    expect(result).toEqual([{ login: 'dhh', role: 'author' }])
-  })
+    expect(mockFetchVersionsFromPURL).toHaveBeenCalledWith("pkg:cargo/serde", undefined);
+    expect(result).toEqual([{ number: "1.0.0" }, { number: "2.0.0" }]);
+  });
 
-  it('fetches bulk package metadata and serializes the map', async () => {
-    mockBulkFetchPackages.mockResolvedValueOnce(new Map([
-      ['pkg:npm/lodash', { name: 'lodash' }],
-      ['pkg:cargo/serde', { name: 'serde' }],
-    ]))
+  it("fetches dependencies", async () => {
+    mockFetchDependenciesFromPURL.mockResolvedValueOnce([{ name: "click", requirements: ">=8.0" }]);
+
+    const result = await packageTool.execute!(
+      { operation: "dependencies", purl: "pkg:pypi/flask@3.1.1" },
+      { toolCallId: "call-3", messages: [] },
+    );
+
+    expect(mockFetchDependenciesFromPURL).toHaveBeenCalledWith("pkg:pypi/flask@3.1.1", undefined);
+    expect(result).toEqual([{ name: "click", requirements: ">=8.0" }]);
+  });
+
+  it("fetches maintainers", async () => {
+    mockFetchMaintainersFromPURL.mockResolvedValueOnce([{ login: "dhh", role: "author" }]);
+
+    const result = await packageTool.execute!(
+      { operation: "maintainers", purl: "pkg:gem/rails" },
+      { toolCallId: "call-4", messages: [] },
+    );
+
+    expect(mockFetchMaintainersFromPURL).toHaveBeenCalledWith("pkg:gem/rails", undefined);
+    expect(result).toEqual([{ login: "dhh", role: "author" }]);
+  });
+
+  it("fetches bulk package metadata and serializes the map", async () => {
+    mockBulkFetchPackages.mockResolvedValueOnce(
+      new Map([
+        ["pkg:npm/lodash", { name: "lodash" }],
+        ["pkg:cargo/serde", { name: "serde" }],
+      ]),
+    );
 
     const result = await packageTool.execute!(
       {
-        operation: 'bulk-packages',
-        purls: ['pkg:npm/lodash', 'pkg:cargo/serde'],
+        operation: "bulk-packages",
+        purls: ["pkg:npm/lodash", "pkg:cargo/serde"],
         concurrency: 4,
       },
-      { toolCallId: 'call-5', messages: [] },
-    )
+      { toolCallId: "call-5", messages: [] },
+    );
 
-    expect(mockBulkFetchPackages).toHaveBeenCalledWith(
-      ['pkg:npm/lodash', 'pkg:cargo/serde'],
-      { concurrency: 4, signal: undefined },
-    )
+    expect(mockBulkFetchPackages).toHaveBeenCalledWith(["pkg:npm/lodash", "pkg:cargo/serde"], {
+      concurrency: 4,
+      signal: undefined,
+    });
     expect(result).toEqual({
-      'pkg:npm/lodash': { name: 'lodash' },
-      'pkg:cargo/serde': { name: 'serde' },
-    })
-  })
-})
+      "pkg:npm/lodash": { name: "lodash" },
+      "pkg:cargo/serde": { name: "serde" },
+    });
+  });
+});

--- a/test/unit/alpm.test.ts
+++ b/test/unit/alpm.test.ts
@@ -1,477 +1,482 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { Client } from '../../src/core/client.ts'
-import { NotFoundError, HTTPError } from '../../src/core/errors.ts'
-import { create } from '../../src/core/registry.ts'
-import '../../src/registries/index.ts'
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Client } from "../../src/core/client.ts";
+import { NotFoundError, HTTPError } from "../../src/core/errors.ts";
+import { create } from "../../src/core/registry.ts";
+import "../../src/registries/index.ts";
 
 /** Helper — minimal Arch official search response. */
 function archSearchResponse(overrides: Record<string, unknown> = {}) {
   return {
-    results: [{
-      pkgname: 'pacman',
-      pkgbase: 'pacman',
-      repo: 'Core',
-      arch: 'x86_64',
-      pkgver: '6.1.0',
-      pkgrel: '3',
-      epoch: 0,
-      pkgdesc: 'A library-based package manager with dependency support',
-      url: 'https://www.archlinux.org/pacman/',
-      filename: 'pacman-6.1.0-3-x86_64.pkg.tar.zst',
-      compressed_size: 500000,
-      installed_size: 2000000,
-      build_date: '2025-11-10T10:00:00Z',
-      last_update: '2025-11-10T12:00:00Z',
-      flag_date: null,
-      maintainers: ['Allan'],
-      packager: 'Allan',
-      groups: ['base-devel'],
-      licenses: ['GPL-3.0-or-later'],
-      conflicts: [],
-      provides: ['libalpm.so=14-64'],
-      replaces: [],
-      depends: ['bash', 'glibc', 'libarchive', 'curl>=7.55'],
-      optdepends: ['perl-locale-gettext: translation support in makepkg-template'],
-      makedepends: ['meson'],
-      checkdepends: ['python', 'fakechroot'],
-      ...overrides,
-    }],
-  }
+    results: [
+      {
+        pkgname: "pacman",
+        pkgbase: "pacman",
+        repo: "Core",
+        arch: "x86_64",
+        pkgver: "6.1.0",
+        pkgrel: "3",
+        epoch: 0,
+        pkgdesc: "A library-based package manager with dependency support",
+        url: "https://www.archlinux.org/pacman/",
+        filename: "pacman-6.1.0-3-x86_64.pkg.tar.zst",
+        compressed_size: 500000,
+        installed_size: 2000000,
+        build_date: "2025-11-10T10:00:00Z",
+        last_update: "2025-11-10T12:00:00Z",
+        flag_date: null,
+        maintainers: ["Allan"],
+        packager: "Allan",
+        groups: ["base-devel"],
+        licenses: ["GPL-3.0-or-later"],
+        conflicts: [],
+        provides: ["libalpm.so=14-64"],
+        replaces: [],
+        depends: ["bash", "glibc", "libarchive", "curl>=7.55"],
+        optdepends: ["perl-locale-gettext: translation support in makepkg-template"],
+        makedepends: ["meson"],
+        checkdepends: ["python", "fakechroot"],
+        ...overrides,
+      },
+    ],
+  };
 }
 
 /** Helper — minimal AUR info response. */
 function aurInfoResponse(overrides: Record<string, unknown> = {}) {
   return {
     resultcount: 1,
-    type: 'multiinfo',
+    type: "multiinfo",
     version: 5,
-    results: [{
-      ID: 1234,
-      Name: 'yay',
-      PackageBase: 'yay',
-      PackageBaseID: 5678,
-      Version: '12.4.2-1',
-      Description: 'Yet another yogurt - An AUR Helper written in Go',
-      URL: 'https://github.com/Jguer/yay',
-      NumVotes: 2500,
-      Popularity: 25.5,
-      OutOfDate: null,
-      Maintainer: 'Jguer',
-      FirstSubmitted: 1500000000,
-      LastModified: 1700000000,
-      URLPath: '/cgit/aur.git/snapshot/yay.tar.gz',
-      Depends: ['pacman>=5.2', 'git'],
-      OptDepends: ['sudo: privilege elevation'],
-      MakeDepends: ['go>=1.21'],
-      CheckDepends: [],
-      License: ['GPL-3.0-or-later'],
-      Keywords: ['aur', 'helper'],
-      ...overrides,
-    }],
-  }
+    results: [
+      {
+        ID: 1234,
+        Name: "yay",
+        PackageBase: "yay",
+        PackageBaseID: 5678,
+        Version: "12.4.2-1",
+        Description: "Yet another yogurt - An AUR Helper written in Go",
+        URL: "https://github.com/Jguer/yay",
+        NumVotes: 2500,
+        Popularity: 25.5,
+        OutOfDate: null,
+        Maintainer: "Jguer",
+        FirstSubmitted: 1500000000,
+        LastModified: 1700000000,
+        URLPath: "/cgit/aur.git/snapshot/yay.tar.gz",
+        Depends: ["pacman>=5.2", "git"],
+        OptDepends: ["sudo: privilege elevation"],
+        MakeDepends: ["go>=1.21"],
+        CheckDepends: [],
+        License: ["GPL-3.0-or-later"],
+        Keywords: ["aur", "helper"],
+        ...overrides,
+      },
+    ],
+  };
 }
 
-describe('alpm registry', () => {
+describe("alpm registry", () => {
   beforeEach(() => {
-    vi.clearAllMocks()
-  })
+    vi.clearAllMocks();
+  });
 
   afterEach(() => {
-    vi.restoreAllMocks()
-  })
+    vi.restoreAllMocks();
+  });
 
-  describe('official packages', () => {
-    it('should fetch and normalize official package', async () => {
-      const client = new Client()
-      vi.spyOn(client, 'getJSON').mockResolvedValueOnce(archSearchResponse())
+  describe("official packages", () => {
+    it("should fetch and normalize official package", async () => {
+      const client = new Client();
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(archSearchResponse());
 
-      const registry = create('alpm', undefined, client)
-      const pkg = await registry.fetchPackage('arch/pacman')
+      const registry = create("alpm", undefined, client);
+      const pkg = await registry.fetchPackage("arch/pacman");
 
-      expect(pkg.name).toBe('pacman')
-      expect(pkg.description).toBe('A library-based package manager with dependency support')
-      expect(pkg.homepage).toBe('https://www.archlinux.org/pacman/')
-      expect(pkg.licenses).toBe('GPL-3.0-or-later')
-      expect(pkg.namespace).toBe('arch')
-      expect(pkg.latestVersion).toBe('6.1.0-3')
-      expect(pkg.keywords).toContain('base-devel')
-      expect(pkg.metadata.repo).toBe('Core')
-      expect(pkg.metadata.arch).toBe('x86_64')
-    })
+      expect(pkg.name).toBe("pacman");
+      expect(pkg.description).toBe("A library-based package manager with dependency support");
+      expect(pkg.homepage).toBe("https://www.archlinux.org/pacman/");
+      expect(pkg.licenses).toBe("GPL-3.0-or-later");
+      expect(pkg.namespace).toBe("arch");
+      expect(pkg.latestVersion).toBe("6.1.0-3");
+      expect(pkg.keywords).toContain("base-devel");
+      expect(pkg.metadata.repo).toBe("Core");
+      expect(pkg.metadata.arch).toBe("x86_64");
+    });
 
-    it('should format version with epoch when > 0', async () => {
-      const client = new Client()
-      vi.spyOn(client, 'getJSON').mockResolvedValueOnce(
-        archSearchResponse({ epoch: 2, pkgver: '1.0.0', pkgrel: '1' }),
-      )
+    it("should format version with epoch when > 0", async () => {
+      const client = new Client();
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(
+        archSearchResponse({ epoch: 2, pkgver: "1.0.0", pkgrel: "1" }),
+      );
 
-      const registry = create('alpm', undefined, client)
-      const pkg = await registry.fetchPackage('arch/some-pkg')
+      const registry = create("alpm", undefined, client);
+      const pkg = await registry.fetchPackage("arch/some-pkg");
 
-      expect(pkg.latestVersion).toBe('2:1.0.0-1')
-    })
+      expect(pkg.latestVersion).toBe("2:1.0.0-1");
+    });
 
-    it('should prefer x86_64 result when multiple archs exist', async () => {
-      const client = new Client()
+    it("should prefer x86_64 result when multiple archs exist", async () => {
+      const client = new Client();
       const response = {
         results: [
-          { ...archSearchResponse().results[0], arch: 'any', pkgver: '1.0.0' },
-          { ...archSearchResponse().results[0], arch: 'x86_64', pkgver: '2.0.0' },
+          { ...archSearchResponse().results[0], arch: "any", pkgver: "1.0.0" },
+          { ...archSearchResponse().results[0], arch: "x86_64", pkgver: "2.0.0" },
         ],
-      }
-      vi.spyOn(client, 'getJSON').mockResolvedValueOnce(response)
+      };
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(response);
 
-      const registry = create('alpm', undefined, client)
-      const pkg = await registry.fetchPackage('arch/pacman')
+      const registry = create("alpm", undefined, client);
+      const pkg = await registry.fetchPackage("arch/pacman");
 
-      expect(pkg.metadata.arch).toBe('x86_64')
-    })
+      expect(pkg.metadata.arch).toBe("x86_64");
+    });
 
-    it('should throw NotFoundError for missing official package', async () => {
-      const client = new Client()
-      vi.spyOn(client, 'getJSON').mockResolvedValueOnce({ results: [] })
+    it("should throw NotFoundError for missing official package", async () => {
+      const client = new Client();
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce({ results: [] });
 
-      const registry = create('alpm', undefined, client)
+      const registry = create("alpm", undefined, client);
 
-      await expect(registry.fetchPackage('arch/nonexistent-pkg-xyz')).rejects.toThrow(
+      await expect(registry.fetchPackage("arch/nonexistent-pkg-xyz")).rejects.toThrow(
         NotFoundError,
-      )
-    })
+      );
+    });
 
-    it('should throw NotFoundError on HTTP 404', async () => {
-      const client = new Client()
-      vi.spyOn(client, 'getJSON').mockRejectedValueOnce(
-        new HTTPError(404, 'https://mock/not-found', 'Not Found'),
-      )
+    it("should throw NotFoundError on HTTP 404", async () => {
+      const client = new Client();
+      vi.spyOn(client, "getJSON").mockRejectedValueOnce(
+        new HTTPError(404, "https://mock/not-found", "Not Found"),
+      );
 
-      const registry = create('alpm', undefined, client)
+      const registry = create("alpm", undefined, client);
 
-      await expect(registry.fetchPackage('arch/nonexistent-pkg-xyz')).rejects.toThrow(
+      await expect(registry.fetchPackage("arch/nonexistent-pkg-xyz")).rejects.toThrow(
         NotFoundError,
-      )
-    })
+      );
+    });
 
-    it('should fetch versions (single current version)', async () => {
-      const client = new Client()
-      vi.spyOn(client, 'getJSON').mockResolvedValueOnce(archSearchResponse())
+    it("should fetch versions (single current version)", async () => {
+      const client = new Client();
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(archSearchResponse());
 
-      const registry = create('alpm', undefined, client)
-      const versions = await registry.fetchVersions('arch/pacman')
+      const registry = create("alpm", undefined, client);
+      const versions = await registry.fetchVersions("arch/pacman");
 
-      expect(versions).toHaveLength(1)
-      expect(versions[0].number).toBe('6.1.0-3')
-      expect(versions[0].licenses).toBe('GPL-3.0-or-later')
-      expect(versions[0].status).toBe('')
-      expect(versions[0].publishedAt).toBeInstanceOf(Date)
-    })
+      expect(versions).toHaveLength(1);
+      expect(versions[0].number).toBe("6.1.0-3");
+      expect(versions[0].licenses).toBe("GPL-3.0-or-later");
+      expect(versions[0].status).toBe("");
+      expect(versions[0].publishedAt).toBeInstanceOf(Date);
+    });
 
-    it('should mark flagged package version as deprecated', async () => {
-      const client = new Client()
-      vi.spyOn(client, 'getJSON').mockResolvedValueOnce(
-        archSearchResponse({ flag_date: '2025-12-01T00:00:00Z' }),
-      )
+    it("should mark flagged package version as deprecated", async () => {
+      const client = new Client();
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(
+        archSearchResponse({ flag_date: "2025-12-01T00:00:00Z" }),
+      );
 
-      const registry = create('alpm', undefined, client)
-      const versions = await registry.fetchVersions('arch/old-pkg')
+      const registry = create("alpm", undefined, client);
+      const versions = await registry.fetchVersions("arch/old-pkg");
 
-      expect(versions[0].status).toBe('deprecated')
-    })
+      expect(versions[0].status).toBe("deprecated");
+    });
 
-    it('should parse dependencies with version constraints', async () => {
-      const client = new Client()
-      vi.spyOn(client, 'getJSON').mockResolvedValueOnce(archSearchResponse())
+    it("should parse dependencies with version constraints", async () => {
+      const client = new Client();
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(archSearchResponse());
 
-      const registry = create('alpm', undefined, client)
-      const deps = await registry.fetchDependencies('arch/pacman', '6.1.0-3')
+      const registry = create("alpm", undefined, client);
+      const deps = await registry.fetchDependencies("arch/pacman", "6.1.0-3");
 
       // Runtime deps
-      const bash = deps.find(d => d.name === 'bash')
-      expect(bash).toBeDefined()
-      expect(bash!.scope).toBe('runtime')
-      expect(bash!.optional).toBe(false)
+      const bash = deps.find((d) => d.name === "bash");
+      expect(bash).toBeDefined();
+      expect(bash!.scope).toBe("runtime");
+      expect(bash!.optional).toBe(false);
 
       // Dep with version constraint
-      const curl = deps.find(d => d.name === 'curl')
-      expect(curl).toBeDefined()
-      expect(curl!.requirements).toBe('>=7.55')
+      const curl = deps.find((d) => d.name === "curl");
+      expect(curl).toBeDefined();
+      expect(curl!.requirements).toBe(">=7.55");
 
       // Build dep
-      const meson = deps.find(d => d.name === 'meson')
-      expect(meson).toBeDefined()
-      expect(meson!.scope).toBe('build')
+      const meson = deps.find((d) => d.name === "meson");
+      expect(meson).toBeDefined();
+      expect(meson!.scope).toBe("build");
 
       // Optional dep (description stripped)
-      const perl = deps.find(d => d.name === 'perl-locale-gettext')
-      expect(perl).toBeDefined()
-      expect(perl!.scope).toBe('optional')
-      expect(perl!.optional).toBe(true)
-      expect(perl!.requirements).toBe('')
+      const perl = deps.find((d) => d.name === "perl-locale-gettext");
+      expect(perl).toBeDefined();
+      expect(perl!.scope).toBe("optional");
+      expect(perl!.optional).toBe(true);
+      expect(perl!.requirements).toBe("");
 
       // Check dep
-      const python = deps.find(d => d.name === 'python')
-      expect(python).toBeDefined()
-      expect(python!.scope).toBe('test')
-    })
+      const python = deps.find((d) => d.name === "python");
+      expect(python).toBeDefined();
+      expect(python!.scope).toBe("test");
+    });
 
-    it('should enforce exact version for official dependency lookups', async () => {
-      const client = new Client()
-      vi.spyOn(client, 'getJSON').mockResolvedValueOnce(archSearchResponse())
+    it("should enforce exact version for official dependency lookups", async () => {
+      const client = new Client();
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(archSearchResponse());
 
-      const registry = create('alpm', undefined, client)
+      const registry = create("alpm", undefined, client);
 
-      await expect(registry.fetchDependencies('arch/pacman', '6.1.0-2')).rejects.toThrow(
+      await expect(registry.fetchDependencies("arch/pacman", "6.1.0-2")).rejects.toThrow(
         NotFoundError,
-      )
-    })
+      );
+    });
 
-    it('should parse optional dependency requirements', async () => {
-      const client = new Client()
-      vi.spyOn(client, 'getJSON').mockResolvedValueOnce(
+    it("should parse optional dependency requirements", async () => {
+      const client = new Client();
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(
         archSearchResponse({
           depends: [],
           makedepends: [],
           checkdepends: [],
-          optdepends: ['foo>=1.2: optional runtime integration'],
+          optdepends: ["foo>=1.2: optional runtime integration"],
         }),
-      )
+      );
 
-      const registry = create('alpm', undefined, client)
-      const deps = await registry.fetchDependencies('arch/pacman', '6.1.0-3')
+      const registry = create("alpm", undefined, client);
+      const deps = await registry.fetchDependencies("arch/pacman", "6.1.0-3");
 
-      expect(deps).toHaveLength(1)
-      expect(deps[0].name).toBe('foo')
-      expect(deps[0].requirements).toBe('>=1.2')
-      expect(deps[0].scope).toBe('optional')
-      expect(deps[0].optional).toBe(true)
-    })
+      expect(deps).toHaveLength(1);
+      expect(deps[0].name).toBe("foo");
+      expect(deps[0].requirements).toBe(">=1.2");
+      expect(deps[0].scope).toBe("optional");
+      expect(deps[0].optional).toBe(true);
+    });
 
-    it('should fetch maintainers', async () => {
-      const client = new Client()
-      vi.spyOn(client, 'getJSON').mockResolvedValueOnce(archSearchResponse())
+    it("should fetch maintainers", async () => {
+      const client = new Client();
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(archSearchResponse());
 
-      const registry = create('alpm', undefined, client)
-      const maintainers = await registry.fetchMaintainers('arch/pacman')
+      const registry = create("alpm", undefined, client);
+      const maintainers = await registry.fetchMaintainers("arch/pacman");
 
-      expect(maintainers).toHaveLength(1)
-      expect(maintainers[0].login).toBe('Allan')
-      expect(maintainers[0].role).toBe('maintainer')
-    })
-  })
+      expect(maintainers).toHaveLength(1);
+      expect(maintainers[0].login).toBe("Allan");
+      expect(maintainers[0].role).toBe("maintainer");
+    });
+  });
 
-  describe('AUR packages', () => {
-    it('should fetch and normalize AUR package', async () => {
-      const client = new Client()
-      vi.spyOn(client, 'getJSON').mockResolvedValueOnce(aurInfoResponse())
+  describe("AUR packages", () => {
+    it("should fetch and normalize AUR package", async () => {
+      const client = new Client();
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(aurInfoResponse());
 
-      const registry = create('alpm', undefined, client)
-      const pkg = await registry.fetchPackage('aur/yay')
+      const registry = create("alpm", undefined, client);
+      const pkg = await registry.fetchPackage("aur/yay");
 
-      expect(pkg.name).toBe('yay')
-      expect(pkg.description).toContain('AUR Helper')
-      expect(pkg.homepage).toBe('https://github.com/Jguer/yay')
-      expect(pkg.licenses).toBe('GPL-3.0-or-later')
-      expect(pkg.namespace).toBe('aur')
-      expect(pkg.latestVersion).toBe('12.4.2-1')
-      expect(pkg.keywords).toContain('aur')
-      expect(pkg.metadata.votes).toBe(2500)
-      expect(pkg.metadata.popularity).toBe(25.5)
-    })
+      expect(pkg.name).toBe("yay");
+      expect(pkg.description).toContain("AUR Helper");
+      expect(pkg.homepage).toBe("https://github.com/Jguer/yay");
+      expect(pkg.licenses).toBe("GPL-3.0-or-later");
+      expect(pkg.namespace).toBe("aur");
+      expect(pkg.latestVersion).toBe("12.4.2-1");
+      expect(pkg.keywords).toContain("aur");
+      expect(pkg.metadata.votes).toBe(2500);
+      expect(pkg.metadata.popularity).toBe(25.5);
+    });
 
-    it('should throw NotFoundError for missing AUR package', async () => {
-      const client = new Client()
-      vi.spyOn(client, 'getJSON').mockResolvedValueOnce({ resultcount: 0, results: [], type: 'multiinfo', version: 5 })
+    it("should throw NotFoundError for missing AUR package", async () => {
+      const client = new Client();
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce({
+        resultcount: 0,
+        results: [],
+        type: "multiinfo",
+        version: 5,
+      });
 
-      const registry = create('alpm', undefined, client)
+      const registry = create("alpm", undefined, client);
 
-      await expect(registry.fetchPackage('aur/nonexistent-pkg-xyz')).rejects.toThrow(
-        NotFoundError,
-      )
-    })
+      await expect(registry.fetchPackage("aur/nonexistent-pkg-xyz")).rejects.toThrow(NotFoundError);
+    });
 
-    it('should fetch AUR versions with timestamp conversion', async () => {
-      const client = new Client()
-      vi.spyOn(client, 'getJSON').mockResolvedValueOnce(aurInfoResponse())
+    it("should fetch AUR versions with timestamp conversion", async () => {
+      const client = new Client();
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(aurInfoResponse());
 
-      const registry = create('alpm', undefined, client)
-      const versions = await registry.fetchVersions('aur/yay')
+      const registry = create("alpm", undefined, client);
+      const versions = await registry.fetchVersions("aur/yay");
 
-      expect(versions).toHaveLength(1)
-      expect(versions[0].number).toBe('12.4.2-1')
-      expect(versions[0].publishedAt).toBeInstanceOf(Date)
+      expect(versions).toHaveLength(1);
+      expect(versions[0].number).toBe("12.4.2-1");
+      expect(versions[0].publishedAt).toBeInstanceOf(Date);
       // AUR timestamps are unix seconds — verify correct ms conversion
-      expect(versions[0].publishedAt!.getTime()).toBe(1700000000 * 1000)
-    })
+      expect(versions[0].publishedAt!.getTime()).toBe(1700000000 * 1000);
+    });
 
-    it('should mark out-of-date AUR package as deprecated', async () => {
-      const client = new Client()
-      vi.spyOn(client, 'getJSON').mockResolvedValueOnce(
-        aurInfoResponse({ OutOfDate: 1700000000 }),
-      )
+    it("should mark out-of-date AUR package as deprecated", async () => {
+      const client = new Client();
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(aurInfoResponse({ OutOfDate: 1700000000 }));
 
-      const registry = create('alpm', undefined, client)
-      const versions = await registry.fetchVersions('aur/old-pkg')
+      const registry = create("alpm", undefined, client);
+      const versions = await registry.fetchVersions("aur/old-pkg");
 
-      expect(versions[0].status).toBe('deprecated')
-    })
+      expect(versions[0].status).toBe("deprecated");
+    });
 
-    it('should parse AUR dependencies', async () => {
-      const client = new Client()
-      vi.spyOn(client, 'getJSON').mockResolvedValueOnce(aurInfoResponse())
+    it("should parse AUR dependencies", async () => {
+      const client = new Client();
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(aurInfoResponse());
 
-      const registry = create('alpm', undefined, client)
-      const deps = await registry.fetchDependencies('aur/yay', '12.4.2-1')
+      const registry = create("alpm", undefined, client);
+      const deps = await registry.fetchDependencies("aur/yay", "12.4.2-1");
 
-      const pacman = deps.find(d => d.name === 'pacman')
-      expect(pacman).toBeDefined()
-      expect(pacman!.scope).toBe('runtime')
-      expect(pacman!.requirements).toBe('>=5.2')
+      const pacman = deps.find((d) => d.name === "pacman");
+      expect(pacman).toBeDefined();
+      expect(pacman!.scope).toBe("runtime");
+      expect(pacman!.requirements).toBe(">=5.2");
 
-      const go = deps.find(d => d.name === 'go')
-      expect(go).toBeDefined()
-      expect(go!.scope).toBe('build')
-      expect(go!.requirements).toBe('>=1.21')
+      const go = deps.find((d) => d.name === "go");
+      expect(go).toBeDefined();
+      expect(go!.scope).toBe("build");
+      expect(go!.requirements).toBe(">=1.21");
 
-      const sudo = deps.find(d => d.name === 'sudo')
-      expect(sudo).toBeDefined()
-      expect(sudo!.scope).toBe('optional')
-      expect(sudo!.optional).toBe(true)
-    })
+      const sudo = deps.find((d) => d.name === "sudo");
+      expect(sudo).toBeDefined();
+      expect(sudo!.scope).toBe("optional");
+      expect(sudo!.optional).toBe(true);
+    });
 
-    it('should enforce exact version for AUR dependency lookups', async () => {
-      const client = new Client()
-      vi.spyOn(client, 'getJSON').mockResolvedValueOnce(aurInfoResponse())
+    it("should enforce exact version for AUR dependency lookups", async () => {
+      const client = new Client();
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(aurInfoResponse());
 
-      const registry = create('alpm', undefined, client)
+      const registry = create("alpm", undefined, client);
 
-      await expect(registry.fetchDependencies('aur/yay', '12.4.2-0')).rejects.toThrow(
+      await expect(registry.fetchDependencies("aur/yay", "12.4.2-0")).rejects.toThrow(
         NotFoundError,
-      )
-    })
+      );
+    });
 
-    it('should parse AUR optional dependency requirements', async () => {
-      const client = new Client()
-      vi.spyOn(client, 'getJSON').mockResolvedValueOnce(
+    it("should parse AUR optional dependency requirements", async () => {
+      const client = new Client();
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(
         aurInfoResponse({
           Depends: [],
           MakeDepends: [],
           CheckDepends: [],
-          OptDepends: ['bar>=2: optional helper'],
+          OptDepends: ["bar>=2: optional helper"],
         }),
-      )
+      );
 
-      const registry = create('alpm', undefined, client)
-      const deps = await registry.fetchDependencies('aur/yay', '12.4.2-1')
+      const registry = create("alpm", undefined, client);
+      const deps = await registry.fetchDependencies("aur/yay", "12.4.2-1");
 
-      expect(deps).toHaveLength(1)
-      expect(deps[0].name).toBe('bar')
-      expect(deps[0].requirements).toBe('>=2')
-      expect(deps[0].scope).toBe('optional')
-      expect(deps[0].optional).toBe(true)
-    })
+      expect(deps).toHaveLength(1);
+      expect(deps[0].name).toBe("bar");
+      expect(deps[0].requirements).toBe(">=2");
+      expect(deps[0].scope).toBe("optional");
+      expect(deps[0].optional).toBe(true);
+    });
 
-    it('should return empty maintainers for orphaned AUR package', async () => {
-      const client = new Client()
-      vi.spyOn(client, 'getJSON').mockResolvedValueOnce(
-        aurInfoResponse({ Maintainer: null }),
-      )
+    it("should return empty maintainers for orphaned AUR package", async () => {
+      const client = new Client();
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(aurInfoResponse({ Maintainer: null }));
 
-      const registry = create('alpm', undefined, client)
-      const maintainers = await registry.fetchMaintainers('aur/orphaned-pkg')
+      const registry = create("alpm", undefined, client);
+      const maintainers = await registry.fetchMaintainers("aur/orphaned-pkg");
 
-      expect(maintainers).toHaveLength(0)
-    })
+      expect(maintainers).toHaveLength(0);
+    });
 
-    it('should fetch AUR maintainer', async () => {
-      const client = new Client()
-      vi.spyOn(client, 'getJSON').mockResolvedValueOnce(aurInfoResponse())
+    it("should fetch AUR maintainer", async () => {
+      const client = new Client();
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(aurInfoResponse());
 
-      const registry = create('alpm', undefined, client)
-      const maintainers = await registry.fetchMaintainers('aur/yay')
+      const registry = create("alpm", undefined, client);
+      const maintainers = await registry.fetchMaintainers("aur/yay");
 
-      expect(maintainers).toHaveLength(1)
-      expect(maintainers[0].login).toBe('Jguer')
-      expect(maintainers[0].role).toBe('maintainer')
-    })
-  })
+      expect(maintainers).toHaveLength(1);
+      expect(maintainers[0].login).toBe("Jguer");
+      expect(maintainers[0].role).toBe("maintainer");
+    });
+  });
 
-  describe('namespace routing', () => {
-    it('should reject unsupported namespaces', async () => {
-      const client = new Client()
-      const registry = create('alpm', undefined, client)
+  describe("namespace routing", () => {
+    it("should reject unsupported namespaces", async () => {
+      const client = new Client();
+      const registry = create("alpm", undefined, client);
 
-      await expect(registry.fetchPackage('manjaro/pacman')).rejects.toThrow(NotFoundError)
-    })
+      await expect(registry.fetchPackage("manjaro/pacman")).rejects.toThrow(NotFoundError);
+    });
 
-    it('should normalize input casing and whitespace', async () => {
-      const client = new Client()
-      vi.spyOn(client, 'getJSON').mockResolvedValueOnce(archSearchResponse())
+    it("should normalize input casing and whitespace", async () => {
+      const client = new Client();
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(archSearchResponse());
 
-      const registry = create('alpm', undefined, client)
-      const pkg = await registry.fetchPackage('  Arch/Pacman  ')
+      const registry = create("alpm", undefined, client);
+      const pkg = await registry.fetchPackage("  Arch/Pacman  ");
 
-      expect(pkg.name).toBe('pacman')
+      expect(pkg.name).toBe("pacman");
       expect(client.getJSON).toHaveBeenCalledWith(
-        expect.stringContaining('name=pacman'),
+        expect.stringContaining("name=pacman"),
         undefined,
-      )
-    })
+      );
+    });
 
     it('should default to "arch" namespace when no slash in name', async () => {
-      const client = new Client()
-      vi.spyOn(client, 'getJSON').mockResolvedValueOnce(archSearchResponse())
+      const client = new Client();
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(archSearchResponse());
 
-      const registry = create('alpm', undefined, client)
-      const pkg = await registry.fetchPackage('pacman')
+      const registry = create("alpm", undefined, client);
+      const pkg = await registry.fetchPackage("pacman");
 
-      expect(pkg.namespace).toBe('arch')
+      expect(pkg.namespace).toBe("arch");
       expect(client.getJSON).toHaveBeenCalledWith(
-        expect.stringContaining('archlinux.org/packages/search/json'),
+        expect.stringContaining("archlinux.org/packages/search/json"),
         undefined,
-      )
-    })
+      );
+    });
 
     it('should route "aur/..." to AUR API', async () => {
-      const client = new Client()
-      vi.spyOn(client, 'getJSON').mockResolvedValueOnce(aurInfoResponse())
+      const client = new Client();
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(aurInfoResponse());
 
-      const registry = create('alpm', undefined, client)
-      await registry.fetchPackage('aur/yay')
+      const registry = create("alpm", undefined, client);
+      await registry.fetchPackage("aur/yay");
 
       expect(client.getJSON).toHaveBeenCalledWith(
-        expect.stringContaining('aur.archlinux.org/rpc/v5/info'),
+        expect.stringContaining("aur.archlinux.org/rpc/v5/info"),
         undefined,
-      )
-    })
-  })
+      );
+    });
+  });
 
-  describe('URL builder', () => {
-    it('should generate official package URLs', () => {
-      const registry = create('alpm')
-      const urls = registry.urls()
+  describe("URL builder", () => {
+    it("should generate official package URLs", () => {
+      const registry = create("alpm");
+      const urls = registry.urls();
 
-      expect(urls.registry('arch/pacman')).toContain('archlinux.org/packages')
-      expect(urls.download('arch/pacman', '6.1.0-3')).toBe('https://archive.archlinux.org/packages/p/pacman/')
-      expect(urls.documentation('arch/pacman')).toContain('wiki.archlinux.org')
-      expect(urls.purl('arch/pacman', '6.1.0-3')).toBe('pkg:alpm/arch/pacman@6.1.0-3')
-    })
+      expect(urls.registry("arch/pacman")).toContain("archlinux.org/packages");
+      expect(urls.download("arch/pacman", "6.1.0-3")).toBe(
+        "https://archive.archlinux.org/packages/p/pacman/",
+      );
+      expect(urls.documentation("arch/pacman")).toContain("wiki.archlinux.org");
+      expect(urls.purl("arch/pacman", "6.1.0-3")).toBe("pkg:alpm/arch/pacman@6.1.0-3");
+    });
 
-    it('should generate AUR package URLs', () => {
-      const registry = create('alpm')
-      const urls = registry.urls()
+    it("should generate AUR package URLs", () => {
+      const registry = create("alpm");
+      const urls = registry.urls();
 
-      expect(urls.registry('aur/yay')).toContain('aur.archlinux.org/packages/yay')
-      expect(urls.download('aur/yay', '12.4.2-1')).toContain('snapshot/yay.tar.gz')
-      expect(urls.purl('aur/yay', '12.4.2-1')).toBe('pkg:alpm/aur/yay@12.4.2-1')
-    })
+      expect(urls.registry("aur/yay")).toContain("aur.archlinux.org/packages/yay");
+      expect(urls.download("aur/yay", "12.4.2-1")).toContain("snapshot/yay.tar.gz");
+      expect(urls.purl("aur/yay", "12.4.2-1")).toBe("pkg:alpm/aur/yay@12.4.2-1");
+    });
 
-    it('should point download URL to archive directory without hardcoded arch', () => {
-      const registry = create('alpm')
-      const urls = registry.urls()
+    it("should point download URL to archive directory without hardcoded arch", () => {
+      const registry = create("alpm");
+      const urls = registry.urls();
 
-      const url = urls.download('arch/some-pkg', '2:1.0.0-1')
-      expect(url).toBe('https://archive.archlinux.org/packages/s/some-pkg/')
-      expect(url).not.toContain('x86_64')
-      expect(url).not.toContain('any')
-    })
-  })
-})
+      const url = urls.download("arch/some-pkg", "2:1.0.0-1");
+      expect(url).toBe("https://archive.archlinux.org/packages/s/some-pkg/");
+      expect(url).not.toContain("x86_64");
+      expect(url).not.toContain("any");
+    });
+  });
+});

--- a/test/unit/cached-registry.test.ts
+++ b/test/unit/cached-registry.test.ts
@@ -1,49 +1,49 @@
-import { CachedRegistry } from '../../src/cache/cached-registry.ts'
-import { readLockfile, writeLockfile, cacheKey, DEFAULT_TTL } from '../../src/cache/lockfile.ts'
-import { createHash } from 'node:crypto'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { Registry, Package, Version, Dependency, Maintainer, URLBuilder } from '../../src/core/types.ts'
-import type { Lockfile } from '../../src/cache/lockfile.ts'
+import { CachedRegistry } from "../../src/cache/cached-registry.ts";
+import { readLockfile, cacheKey, DEFAULT_TTL } from "../../src/cache/lockfile.ts";
+import { createHash } from "node:crypto";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Registry, URLBuilder } from "../../src/core/types.ts";
+import type { Lockfile } from "../../src/cache/lockfile.ts";
 
 // Mock storage to avoid real file I/O
-vi.mock('../../src/cache/storage.ts', () => {
-  const storage = new Map<string, unknown>()
+vi.mock("../../src/cache/storage.ts", () => {
+  const storage = new Map<string, unknown>();
   const mockStorage = {
     getItem: async (key: string) => storage.get(key) ?? null,
     setItem: async (key: string, value: unknown) => {
-      storage.set(key, value)
+      storage.set(key, value);
     },
     clear: async () => {
-      storage.clear()
+      storage.clear();
     },
     dispose: async () => {
-      storage.clear()
+      storage.clear();
     },
-  }
+  };
   return {
     getStorage: () => mockStorage,
     getEcosystemStorage: () => mockStorage,
     computeIntegrity: (value: unknown) => {
-      const json = JSON.stringify(value)
-      const hash = createHash('sha256').update(json).digest('hex')
-      return `sha256-${hash}`
+      const json = JSON.stringify(value);
+      const hash = createHash("sha256").update(json).digest("hex");
+      return `sha256-${hash}`;
     },
-  }
-})
+  };
+});
 
 // Mock lockfile I/O
-let mockLockfile: Lockfile = { version: 1, entries: {} }
+let mockLockfile: Lockfile = { version: 1, entries: {} };
 
-vi.mock('../../src/cache/lockfile.ts', async () => {
-  const actual = await vi.importActual('../../src/cache/lockfile.ts')
+vi.mock("../../src/cache/lockfile.ts", async () => {
+  const actual = await vi.importActual("../../src/cache/lockfile.ts");
   return {
     ...actual,
     readLockfile: async () => JSON.parse(JSON.stringify(mockLockfile)),
     writeLockfile: async (lockfile: Lockfile) => {
-      mockLockfile = JSON.parse(JSON.stringify(lockfile))
+      mockLockfile = JSON.parse(JSON.stringify(lockfile));
     },
-  }
-})
+  };
+});
 
 function createMockRegistry(ecosystem: string, overrides?: Partial<Registry>): Registry {
   return {
@@ -56,567 +56,566 @@ function createMockRegistry(ecosystem: string, overrides?: Partial<Registry>): R
       purl: () => `pkg:${ecosystem}/`,
     }),
     fetchPackage: async () => ({
-      name: 'test-package',
-      description: 'A test package',
-      homepage: 'https://example.com',
-      repository: 'https://github.com/example/test',
-      licenses: 'MIT',
-      keywords: ['test'],
-      namespace: '',
-      latestVersion: '1.0.0',
+      name: "test-package",
+      description: "A test package",
+      homepage: "https://example.com",
+      repository: "https://github.com/example/test",
+      licenses: "MIT",
+      keywords: ["test"],
+      namespace: "",
+      latestVersion: "1.0.0",
       metadata: {},
     }),
     fetchVersions: async () => [
       {
-        number: '1.0.0',
-        publishedAt: new Date('2024-01-01'),
-        licenses: 'MIT',
-        integrity: 'sha256-abc123',
-        status: '',
+        number: "1.0.0",
+        publishedAt: new Date("2024-01-01"),
+        licenses: "MIT",
+        integrity: "sha256-abc123",
+        status: "",
         metadata: {},
       },
     ],
     fetchDependencies: async () => [
       {
-        name: 'dep-package',
-        requirements: '^1.0.0',
-        scope: 'runtime',
+        name: "dep-package",
+        requirements: "^1.0.0",
+        scope: "runtime",
         optional: false,
       },
     ],
     fetchMaintainers: async () => [
       {
-        uuid: 'uuid-123',
-        login: 'testuser',
-        name: 'Test User',
-        email: 'test@example.com',
-        url: 'https://example.com/testuser',
-        role: 'owner',
+        uuid: "uuid-123",
+        login: "testuser",
+        name: "Test User",
+        email: "test@example.com",
+        url: "https://example.com/testuser",
+        role: "owner",
       },
     ],
     ...overrides,
-  }
+  };
 }
 
-describe('CachedRegistry', () => {
+describe("CachedRegistry", () => {
   beforeEach(() => {
     // Reset mock lockfile and storage before each test
-    mockLockfile = { version: 1, entries: {} }
-    vi.clearAllMocks()
-  })
+    mockLockfile = { version: 1, entries: {} };
+    vi.clearAllMocks();
+  });
 
-  describe('constructor', () => {
-    it('wraps a registry', () => {
-      const inner = createMockRegistry('npm')
-      const cached = new CachedRegistry(inner)
-      expect(cached.inner).toBe(inner)
-    })
+  describe("constructor", () => {
+    it("wraps a registry", () => {
+      const inner = createMockRegistry("npm");
+      const cached = new CachedRegistry(inner);
+      expect(cached.inner).toBe(inner);
+    });
 
-    it('initializes storage for ecosystem', () => {
-      const inner = createMockRegistry('npm')
-      const cached = new CachedRegistry(inner)
-      expect(cached.storage).toBeDefined()
-    })
+    it("initializes storage for ecosystem", () => {
+      const inner = createMockRegistry("npm");
+      const cached = new CachedRegistry(inner);
+      expect(cached.storage).toBeDefined();
+    });
+  });
 
-  })
+  describe("ecosystem", () => {
+    it("returns inner registry ecosystem", () => {
+      const inner = createMockRegistry("npm");
+      const cached = new CachedRegistry(inner);
+      expect(cached.ecosystem()).toBe("npm");
+    });
 
-  describe('ecosystem', () => {
-    it('returns inner registry ecosystem', () => {
-      const inner = createMockRegistry('npm')
-      const cached = new CachedRegistry(inner)
-      expect(cached.ecosystem()).toBe('npm')
-    })
+    it("works with different ecosystems", () => {
+      const npm = new CachedRegistry(createMockRegistry("npm"));
+      const cargo = new CachedRegistry(createMockRegistry("cargo"));
+      expect(npm.ecosystem()).toBe("npm");
+      expect(cargo.ecosystem()).toBe("cargo");
+    });
+  });
 
-    it('works with different ecosystems', () => {
-      const npm = new CachedRegistry(createMockRegistry('npm'))
-      const cargo = new CachedRegistry(createMockRegistry('cargo'))
-      expect(npm.ecosystem()).toBe('npm')
-      expect(cargo.ecosystem()).toBe('cargo')
-    })
-  })
+  describe("urls", () => {
+    it("returns inner registry URLs", () => {
+      const inner = createMockRegistry("npm");
+      const cached = new CachedRegistry(inner);
+      const urls = cached.urls();
+      expect(urls.registry("pkg")).toBe("https://npm.example.com");
+    });
+  });
 
-  describe('urls', () => {
-    it('returns inner registry URLs', () => {
-      const inner = createMockRegistry('npm')
-      const cached = new CachedRegistry(inner)
-      const urls = cached.urls()
-      expect(urls.registry('pkg')).toBe('https://npm.example.com')
-    })
-  })
-
-  describe('fetchPackage', () => {
-    it('caches package on first fetch', async () => {
-      let fetchCount = 0
-      const inner = createMockRegistry('npm', {
+  describe("fetchPackage", () => {
+    it("caches package on first fetch", async () => {
+      let fetchCount = 0;
+      const inner = createMockRegistry("npm", {
         fetchPackage: async () => {
-          fetchCount++
+          fetchCount++;
           return {
-            name: 'lodash',
-            description: 'Utility library',
-            homepage: 'https://lodash.com',
-            repository: 'https://github.com/lodash/lodash',
-            licenses: 'MIT',
-            keywords: ['utility'],
-            namespace: '',
-            latestVersion: '4.17.21',
+            name: "lodash",
+            description: "Utility library",
+            homepage: "https://lodash.com",
+            repository: "https://github.com/lodash/lodash",
+            licenses: "MIT",
+            keywords: ["utility"],
+            namespace: "",
+            latestVersion: "4.17.21",
             metadata: {},
-          }
+          };
         },
-      })
-      const cached = new CachedRegistry(inner)
+      });
+      const cached = new CachedRegistry(inner);
 
-      const pkg1 = await cached.fetchPackage('lodash')
-      expect(pkg1.name).toBe('lodash')
-      expect(fetchCount).toBe(1)
+      const pkg1 = await cached.fetchPackage("lodash");
+      expect(pkg1.name).toBe("lodash");
+      expect(fetchCount).toBe(1);
 
       // Second fetch should use cache
-      const pkg2 = await cached.fetchPackage('lodash')
-      expect(pkg2.name).toBe('lodash')
-      expect(fetchCount).toBe(1) // Not incremented
-    })
+      const pkg2 = await cached.fetchPackage("lodash");
+      expect(pkg2.name).toBe("lodash");
+      expect(fetchCount).toBe(1); // Not incremented
+    });
 
-    it('stores package in lockfile with latestVersion', async () => {
-      const inner = createMockRegistry('npm', {
+    it("stores package in lockfile with latestVersion", async () => {
+      const inner = createMockRegistry("npm", {
         fetchPackage: async () => ({
-          name: 'react',
-          description: 'React library',
-          homepage: 'https://react.dev',
-          repository: 'https://github.com/facebook/react',
-          licenses: 'MIT',
-          keywords: ['ui'],
-          namespace: '',
-          latestVersion: '18.2.0',
+          name: "react",
+          description: "React library",
+          homepage: "https://react.dev",
+          repository: "https://github.com/facebook/react",
+          licenses: "MIT",
+          keywords: ["ui"],
+          namespace: "",
+          latestVersion: "18.2.0",
           metadata: {},
         }),
-      })
-      const cached = new CachedRegistry(inner)
+      });
+      const cached = new CachedRegistry(inner);
 
-      await cached.fetchPackage('react')
+      await cached.fetchPackage("react");
 
-      const lockfile = await readLockfile()
-      const key = cacheKey('npm', 'react', 'package')
-      const entry = lockfile.entries[key]
-      expect(entry).toBeDefined()
-      expect(entry?.latestVersion).toBe('18.2.0')
-    })
+      const lockfile = await readLockfile();
+      const key = cacheKey("npm", "react", "package");
+      const entry = lockfile.entries[key];
+      expect(entry).toBeDefined();
+      expect(entry?.latestVersion).toBe("18.2.0");
+    });
 
-    it('refetches on cache miss', async () => {
-      let fetchCount = 0
-      const inner = createMockRegistry('npm', {
+    it("refetches on cache miss", async () => {
+      let fetchCount = 0;
+      const inner = createMockRegistry("npm", {
         fetchPackage: async () => {
-          fetchCount++
+          fetchCount++;
           return {
-            name: 'pkg',
-            description: 'Package',
-            homepage: '',
-            repository: '',
-            licenses: 'MIT',
+            name: "pkg",
+            description: "Package",
+            homepage: "",
+            repository: "",
+            licenses: "MIT",
             keywords: [],
-            namespace: '',
-            latestVersion: '1.0.0',
+            namespace: "",
+            latestVersion: "1.0.0",
             metadata: {},
-          }
+          };
         },
-      })
-      const cached = new CachedRegistry(inner)
+      });
+      const cached = new CachedRegistry(inner);
 
       // First fetch
-      await cached.fetchPackage('pkg')
-      expect(fetchCount).toBe(1)
+      await cached.fetchPackage("pkg");
+      expect(fetchCount).toBe(1);
 
       // Clear lockfile to simulate cache miss
-      mockLockfile = { version: 1, entries: {} }
+      mockLockfile = { version: 1, entries: {} };
 
       // Second fetch should refetch
-      await cached.fetchPackage('pkg')
-      expect(fetchCount).toBe(2)
-    })
+      await cached.fetchPackage("pkg");
+      expect(fetchCount).toBe(2);
+    });
 
-    it('refetches on integrity mismatch', async () => {
-      let fetchCount = 0
-      const inner = createMockRegistry('npm', {
+    it("refetches on integrity mismatch", async () => {
+      let fetchCount = 0;
+      const inner = createMockRegistry("npm", {
         fetchPackage: async () => {
-          fetchCount++
+          fetchCount++;
           return {
-            name: 'pkg',
-            description: 'Package',
-            homepage: '',
-            repository: '',
-            licenses: 'MIT',
+            name: "pkg",
+            description: "Package",
+            homepage: "",
+            repository: "",
+            licenses: "MIT",
             keywords: [],
-            namespace: '',
-            latestVersion: '1.0.0',
+            namespace: "",
+            latestVersion: "1.0.0",
             metadata: {},
-          }
+          };
         },
-      })
-      const cached = new CachedRegistry(inner)
+      });
+      const cached = new CachedRegistry(inner);
 
       // First fetch
-      await cached.fetchPackage('pkg')
-      expect(fetchCount).toBe(1)
+      await cached.fetchPackage("pkg");
+      expect(fetchCount).toBe(1);
 
       // Corrupt the lockfile entry integrity
-      const key = cacheKey('npm', 'pkg', 'package')
-      const entry = mockLockfile.entries[key]
+      const key = cacheKey("npm", "pkg", "package");
+      const entry = mockLockfile.entries[key];
       if (entry) {
-        entry.integrity = 'sha256-corrupted'
+        entry.integrity = "sha256-corrupted";
       }
 
       // Second fetch should refetch due to integrity mismatch
-      await cached.fetchPackage('pkg')
-      expect(fetchCount).toBe(2)
-    })
-  })
+      await cached.fetchPackage("pkg");
+      expect(fetchCount).toBe(2);
+    });
+  });
 
-  describe('fetchVersions', () => {
-    it('caches versions on first fetch', async () => {
-      let fetchCount = 0
-      const inner = createMockRegistry('npm', {
+  describe("fetchVersions", () => {
+    it("caches versions on first fetch", async () => {
+      let fetchCount = 0;
+      const inner = createMockRegistry("npm", {
         fetchVersions: async () => {
-          fetchCount++
+          fetchCount++;
           return [
             {
-              number: '1.0.0',
-              publishedAt: new Date('2024-01-01'),
-              licenses: 'MIT',
-              integrity: 'sha256-v1',
-              status: '',
+              number: "1.0.0",
+              publishedAt: new Date("2024-01-01"),
+              licenses: "MIT",
+              integrity: "sha256-v1",
+              status: "",
               metadata: {},
             },
             {
-              number: '1.1.0',
-              publishedAt: new Date('2024-02-01'),
-              licenses: 'MIT',
-              integrity: 'sha256-v2',
-              status: '',
+              number: "1.1.0",
+              publishedAt: new Date("2024-02-01"),
+              licenses: "MIT",
+              integrity: "sha256-v2",
+              status: "",
               metadata: {},
             },
-          ]
+          ];
         },
-      })
-      const cached = new CachedRegistry(inner)
+      });
+      const cached = new CachedRegistry(inner);
 
-      const versions1 = await cached.fetchVersions('pkg')
-      expect(versions1).toHaveLength(2)
-      expect(fetchCount).toBe(1)
+      const versions1 = await cached.fetchVersions("pkg");
+      expect(versions1).toHaveLength(2);
+      expect(fetchCount).toBe(1);
 
-      const versions2 = await cached.fetchVersions('pkg')
-      expect(versions2).toHaveLength(2)
-      expect(fetchCount).toBe(1) // Not incremented
-    })
+      const versions2 = await cached.fetchVersions("pkg");
+      expect(versions2).toHaveLength(2);
+      expect(fetchCount).toBe(1); // Not incremented
+    });
 
-    it('respects versions TTL', async () => {
-      let fetchCount = 0
-      const inner = createMockRegistry('npm', {
+    it("respects versions TTL", async () => {
+      let fetchCount = 0;
+      const inner = createMockRegistry("npm", {
         fetchVersions: async () => {
-          fetchCount++
+          fetchCount++;
           return [
             {
-              number: '1.0.0',
-              publishedAt: new Date('2024-01-01'),
-              licenses: 'MIT',
-              integrity: 'sha256-v1',
-              status: '',
+              number: "1.0.0",
+              publishedAt: new Date("2024-01-01"),
+              licenses: "MIT",
+              integrity: "sha256-v1",
+              status: "",
               metadata: {},
             },
-          ]
+          ];
         },
-      })
-      const cached = new CachedRegistry(inner)
+      });
+      const cached = new CachedRegistry(inner);
 
-      await cached.fetchVersions('pkg')
-      expect(fetchCount).toBe(1)
+      await cached.fetchVersions("pkg");
+      expect(fetchCount).toBe(1);
 
       // Manually expire the cache entry
-      const key = cacheKey('npm', 'pkg', 'versions')
-      const entry = mockLockfile.entries[key]
+      const key = cacheKey("npm", "pkg", "versions");
+      const entry = mockLockfile.entries[key];
       if (entry) {
-        entry.fetchedAt = Date.now() - 2000000 // Older than TTL
+        entry.fetchedAt = Date.now() - 2000000; // Older than TTL
       }
 
       // Should refetch
-      await cached.fetchVersions('pkg')
-      expect(fetchCount).toBe(2)
-    })
-  })
+      await cached.fetchVersions("pkg");
+      expect(fetchCount).toBe(2);
+    });
+  });
 
-  describe('fetchDependencies', () => {
-    it('caches dependencies with version', async () => {
-      let fetchCount = 0
-      const inner = createMockRegistry('npm', {
+  describe("fetchDependencies", () => {
+    it("caches dependencies with version", async () => {
+      let fetchCount = 0;
+      const inner = createMockRegistry("npm", {
         fetchDependencies: async () => {
-          fetchCount++
+          fetchCount++;
           return [
             {
-              name: 'lodash',
-              requirements: '^4.17.0',
-              scope: 'runtime',
+              name: "lodash",
+              requirements: "^4.17.0",
+              scope: "runtime",
               optional: false,
             },
-          ]
+          ];
         },
-      })
-      const cached = new CachedRegistry(inner)
+      });
+      const cached = new CachedRegistry(inner);
 
-      const deps1 = await cached.fetchDependencies('pkg', '1.0.0')
-      expect(deps1).toHaveLength(1)
-      expect(fetchCount).toBe(1)
+      const deps1 = await cached.fetchDependencies("pkg", "1.0.0");
+      expect(deps1).toHaveLength(1);
+      expect(fetchCount).toBe(1);
 
-      const deps2 = await cached.fetchDependencies('pkg', '1.0.0')
-      expect(deps2).toHaveLength(1)
-      expect(fetchCount).toBe(1) // Not incremented
-    })
+      const deps2 = await cached.fetchDependencies("pkg", "1.0.0");
+      expect(deps2).toHaveLength(1);
+      expect(fetchCount).toBe(1); // Not incremented
+    });
 
-    it('caches different versions separately', async () => {
-      let fetchCount = 0
-      const inner = createMockRegistry('npm', {
+    it("caches different versions separately", async () => {
+      let fetchCount = 0;
+      const inner = createMockRegistry("npm", {
         fetchDependencies: async (name, version) => {
-          fetchCount++
-          if (version === '1.0.0') {
+          fetchCount++;
+          if (version === "1.0.0") {
             return [
               {
-                name: 'dep-v1',
-                requirements: '^1.0.0',
-                scope: 'runtime',
+                name: "dep-v1",
+                requirements: "^1.0.0",
+                scope: "runtime",
                 optional: false,
               },
-            ]
+            ];
           }
           return [
             {
-              name: 'dep-v2',
-              requirements: '^2.0.0',
-              scope: 'runtime',
+              name: "dep-v2",
+              requirements: "^2.0.0",
+              scope: "runtime",
               optional: false,
             },
-          ]
+          ];
         },
-      })
-      const cached = new CachedRegistry(inner)
+      });
+      const cached = new CachedRegistry(inner);
 
-      const deps1 = await cached.fetchDependencies('pkg', '1.0.0')
-      expect(deps1[0]?.name).toBe('dep-v1')
-      expect(fetchCount).toBe(1)
+      const deps1 = await cached.fetchDependencies("pkg", "1.0.0");
+      expect(deps1[0]?.name).toBe("dep-v1");
+      expect(fetchCount).toBe(1);
 
-      const deps2 = await cached.fetchDependencies('pkg', '2.0.0')
-      expect(deps2[0]?.name).toBe('dep-v2')
-      expect(fetchCount).toBe(2)
+      const deps2 = await cached.fetchDependencies("pkg", "2.0.0");
+      expect(deps2[0]?.name).toBe("dep-v2");
+      expect(fetchCount).toBe(2);
 
       // Fetch v1 again — should use cache
-      const deps1Again = await cached.fetchDependencies('pkg', '1.0.0')
-      expect(deps1Again[0]?.name).toBe('dep-v1')
-      expect(fetchCount).toBe(2) // Not incremented
-    })
+      const deps1Again = await cached.fetchDependencies("pkg", "1.0.0");
+      expect(deps1Again[0]?.name).toBe("dep-v1");
+      expect(fetchCount).toBe(2); // Not incremented
+    });
 
-    it('respects dependencies TTL (24 hours)', async () => {
-      let fetchCount = 0
-      const inner = createMockRegistry('npm', {
+    it("respects dependencies TTL (24 hours)", async () => {
+      let fetchCount = 0;
+      const inner = createMockRegistry("npm", {
         fetchDependencies: async () => {
-          fetchCount++
+          fetchCount++;
           return [
             {
-              name: 'dep',
-              requirements: '^1.0.0',
-              scope: 'runtime',
+              name: "dep",
+              requirements: "^1.0.0",
+              scope: "runtime",
               optional: false,
             },
-          ]
+          ];
         },
-      })
-      const cached = new CachedRegistry(inner)
+      });
+      const cached = new CachedRegistry(inner);
 
-      await cached.fetchDependencies('pkg', '1.0.0')
-      expect(fetchCount).toBe(1)
+      await cached.fetchDependencies("pkg", "1.0.0");
+      expect(fetchCount).toBe(1);
 
       // Manually expire the cache entry
-      const key = cacheKey('npm', 'pkg', 'dependencies', '1.0.0')
-      const entry = mockLockfile.entries[key]
+      const key = cacheKey("npm", "pkg", "dependencies", "1.0.0");
+      const entry = mockLockfile.entries[key];
       if (entry) {
-        entry.fetchedAt = Date.now() - 90000000 // Older than 24 hours
+        entry.fetchedAt = Date.now() - 90000000; // Older than 24 hours
       }
 
       // Should refetch
-      await cached.fetchDependencies('pkg', '1.0.0')
-      expect(fetchCount).toBe(2)
-    })
-  })
+      await cached.fetchDependencies("pkg", "1.0.0");
+      expect(fetchCount).toBe(2);
+    });
+  });
 
-  describe('fetchMaintainers', () => {
-    it('caches maintainers on first fetch', async () => {
-      let fetchCount = 0
-      const inner = createMockRegistry('npm', {
+  describe("fetchMaintainers", () => {
+    it("caches maintainers on first fetch", async () => {
+      let fetchCount = 0;
+      const inner = createMockRegistry("npm", {
         fetchMaintainers: async () => {
-          fetchCount++
+          fetchCount++;
           return [
             {
-              uuid: 'uuid-1',
-              login: 'user1',
-              name: 'User One',
-              email: 'user1@example.com',
-              url: 'https://example.com/user1',
-              role: 'owner',
+              uuid: "uuid-1",
+              login: "user1",
+              name: "User One",
+              email: "user1@example.com",
+              url: "https://example.com/user1",
+              role: "owner",
             },
-          ]
+          ];
         },
-      })
-      const cached = new CachedRegistry(inner)
+      });
+      const cached = new CachedRegistry(inner);
 
-      const maintainers1 = await cached.fetchMaintainers('pkg')
-      expect(maintainers1).toHaveLength(1)
-      expect(fetchCount).toBe(1)
+      const maintainers1 = await cached.fetchMaintainers("pkg");
+      expect(maintainers1).toHaveLength(1);
+      expect(fetchCount).toBe(1);
 
-      const maintainers2 = await cached.fetchMaintainers('pkg')
-      expect(maintainers2).toHaveLength(1)
-      expect(fetchCount).toBe(1) // Not incremented
-    })
+      const maintainers2 = await cached.fetchMaintainers("pkg");
+      expect(maintainers2).toHaveLength(1);
+      expect(fetchCount).toBe(1); // Not incremented
+    });
 
-    it('respects maintainers TTL (24 hours)', async () => {
-      let fetchCount = 0
-      const inner = createMockRegistry('npm', {
+    it("respects maintainers TTL (24 hours)", async () => {
+      let fetchCount = 0;
+      const inner = createMockRegistry("npm", {
         fetchMaintainers: async () => {
-          fetchCount++
+          fetchCount++;
           return [
             {
-              uuid: 'uuid-1',
-              login: 'user1',
-              name: 'User One',
-              email: 'user1@example.com',
-              url: 'https://example.com/user1',
-              role: 'owner',
+              uuid: "uuid-1",
+              login: "user1",
+              name: "User One",
+              email: "user1@example.com",
+              url: "https://example.com/user1",
+              role: "owner",
             },
-          ]
+          ];
         },
-      })
-      const cached = new CachedRegistry(inner)
+      });
+      const cached = new CachedRegistry(inner);
 
-      await cached.fetchMaintainers('pkg')
-      expect(fetchCount).toBe(1)
+      await cached.fetchMaintainers("pkg");
+      expect(fetchCount).toBe(1);
 
       // Manually expire the cache entry
-      const key = cacheKey('npm', 'pkg', 'maintainers')
-      const entry = mockLockfile.entries[key]
+      const key = cacheKey("npm", "pkg", "maintainers");
+      const entry = mockLockfile.entries[key];
       if (entry) {
-        entry.fetchedAt = Date.now() - 90000000 // Older than 24 hours
+        entry.fetchedAt = Date.now() - 90000000; // Older than 24 hours
       }
 
       // Should refetch
-      await cached.fetchMaintainers('pkg')
-      expect(fetchCount).toBe(2)
-    })
-  })
+      await cached.fetchMaintainers("pkg");
+      expect(fetchCount).toBe(2);
+    });
+  });
 
-  describe('cache behavior', () => {
-    it('handles multiple packages independently', async () => {
-      let fetchCounts: Record<string, number> = { lodash: 0, react: 0 }
-      const inner = createMockRegistry('npm', {
+  describe("cache behavior", () => {
+    it("handles multiple packages independently", async () => {
+      let fetchCounts: Record<string, number> = { lodash: 0, react: 0 };
+      const inner = createMockRegistry("npm", {
         fetchPackage: async (name) => {
-          fetchCounts[name]++
+          fetchCounts[name]++;
           return {
             name,
             description: `${name} package`,
             homepage: `https://${name}.com`,
             repository: `https://github.com/${name}/${name}`,
-            licenses: 'MIT',
+            licenses: "MIT",
             keywords: [],
-            namespace: '',
-            latestVersion: '1.0.0',
+            namespace: "",
+            latestVersion: "1.0.0",
             metadata: {},
-          }
+          };
         },
-      })
-      const cached = new CachedRegistry(inner)
+      });
+      const cached = new CachedRegistry(inner);
 
-      await cached.fetchPackage('lodash')
-      await cached.fetchPackage('react')
-      await cached.fetchPackage('lodash')
+      await cached.fetchPackage("lodash");
+      await cached.fetchPackage("react");
+      await cached.fetchPackage("lodash");
 
-      expect(fetchCounts.lodash).toBe(1)
-      expect(fetchCounts.react).toBe(1)
-    })
+      expect(fetchCounts.lodash).toBe(1);
+      expect(fetchCounts.react).toBe(1);
+    });
 
-    it('stores correct integrity hash', async () => {
-      const testData = { name: 'test', version: '1.0.0' }
-      const inner = createMockRegistry('npm', {
+    it("stores correct integrity hash", async () => {
+      const testData = { name: "test", version: "1.0.0" };
+      const inner = createMockRegistry("npm", {
         fetchPackage: async () => ({
-          name: 'test',
-          description: 'Test',
-          homepage: '',
-          repository: '',
-          licenses: 'MIT',
+          name: "test",
+          description: "Test",
+          homepage: "",
+          repository: "",
+          licenses: "MIT",
           keywords: [],
-          namespace: '',
-          latestVersion: '1.0.0',
+          namespace: "",
+          latestVersion: "1.0.0",
           metadata: testData,
         }),
-      })
-      const cached = new CachedRegistry(inner)
+      });
+      const cached = new CachedRegistry(inner);
 
-      await cached.fetchPackage('test')
+      await cached.fetchPackage("test");
 
-      const key = cacheKey('npm', 'test', 'package')
-      const entry = mockLockfile.entries[key]
-      expect(entry?.integrity).toMatch(/^sha256-[a-f0-9]{64}$/)
-    })
+      const key = cacheKey("npm", "test", "package");
+      const entry = mockLockfile.entries[key];
+      expect(entry?.integrity).toMatch(/^sha256-[a-f0-9]{64}$/);
+    });
 
-    it('uses correct TTL for each entry type', async () => {
-      const inner = createMockRegistry('npm')
-      const cached = new CachedRegistry(inner)
+    it("uses correct TTL for each entry type", async () => {
+      const inner = createMockRegistry("npm");
+      const cached = new CachedRegistry(inner);
 
-      await cached.fetchPackage('pkg')
-      await cached.fetchVersions('pkg')
-      await cached.fetchDependencies('pkg', '1.0.0')
-      await cached.fetchMaintainers('pkg')
+      await cached.fetchPackage("pkg");
+      await cached.fetchVersions("pkg");
+      await cached.fetchDependencies("pkg", "1.0.0");
+      await cached.fetchMaintainers("pkg");
 
-      const pkgEntry = mockLockfile.entries[cacheKey('npm', 'pkg', 'package')]
-      const versionsEntry = mockLockfile.entries[cacheKey('npm', 'pkg', 'versions')]
-      const depsEntry = mockLockfile.entries[cacheKey('npm', 'pkg', 'dependencies', '1.0.0')]
-      const maintainersEntry = mockLockfile.entries[cacheKey('npm', 'pkg', 'maintainers')]
+      const pkgEntry = mockLockfile.entries[cacheKey("npm", "pkg", "package")];
+      const versionsEntry = mockLockfile.entries[cacheKey("npm", "pkg", "versions")];
+      const depsEntry = mockLockfile.entries[cacheKey("npm", "pkg", "dependencies", "1.0.0")];
+      const maintainersEntry = mockLockfile.entries[cacheKey("npm", "pkg", "maintainers")];
 
-      expect(pkgEntry?.ttl).toBe(DEFAULT_TTL.package)
-      expect(versionsEntry?.ttl).toBe(DEFAULT_TTL.versions)
-      expect(depsEntry?.ttl).toBe(DEFAULT_TTL.dependencies)
-      expect(maintainersEntry?.ttl).toBe(DEFAULT_TTL.maintainers)
-    })
-  })
+      expect(pkgEntry?.ttl).toBe(DEFAULT_TTL.package);
+      expect(versionsEntry?.ttl).toBe(DEFAULT_TTL.versions);
+      expect(depsEntry?.ttl).toBe(DEFAULT_TTL.dependencies);
+      expect(maintainersEntry?.ttl).toBe(DEFAULT_TTL.maintainers);
+    });
+  });
 
-  describe('error handling', () => {
-    it('propagates fetch errors', async () => {
-      const inner = createMockRegistry('npm', {
+  describe("error handling", () => {
+    it("propagates fetch errors", async () => {
+      const inner = createMockRegistry("npm", {
         fetchPackage: async () => {
-          throw new Error('Network error')
+          throw new Error("Network error");
         },
-      })
-      const cached = new CachedRegistry(inner)
+      });
+      const cached = new CachedRegistry(inner);
 
-      await expect(cached.fetchPackage('pkg')).rejects.toThrow('Network error')
-    })
+      await expect(cached.fetchPackage("pkg")).rejects.toThrow("Network error");
+    });
 
-    it('handles AbortSignal', async () => {
-      const inner = createMockRegistry('npm', {
+    it("handles AbortSignal", async () => {
+      const inner = createMockRegistry("npm", {
         fetchPackage: async (name, signal) => {
           if (signal?.aborted) {
-            throw new Error('Aborted')
+            throw new Error("Aborted");
           }
           return {
             name,
-            description: '',
-            homepage: '',
-            repository: '',
-            licenses: 'MIT',
+            description: "",
+            homepage: "",
+            repository: "",
+            licenses: "MIT",
             keywords: [],
-            namespace: '',
-            latestVersion: '1.0.0',
+            namespace: "",
+            latestVersion: "1.0.0",
             metadata: {},
-          }
+          };
         },
-      })
-      const cached = new CachedRegistry(inner)
+      });
+      const cached = new CachedRegistry(inner);
 
-      const controller = new AbortController()
-      controller.abort()
+      const controller = new AbortController();
+      controller.abort();
 
-      await expect(cached.fetchPackage('pkg', controller.signal)).rejects.toThrow('Aborted')
-    })
-  })
-})
+      await expect(cached.fetchPackage("pkg", controller.signal)).rejects.toThrow("Aborted");
+    });
+  });
+});

--- a/test/unit/errors.test.ts
+++ b/test/unit/errors.test.ts
@@ -5,220 +5,220 @@ import {
   RateLimitError,
   UnknownEcosystemError,
   InvalidPURLError,
-} from '../../src/core/errors.ts'
+} from "../../src/core/errors.ts";
 
-describe('errors', () => {
-  describe('PkioError', () => {
-    it('creates error with message', () => {
-      const error = new PkioError('Test error')
-      expect(error.message).toBe('Test error')
-      expect(error.name).toBe('PkioError')
-    })
+describe("errors", () => {
+  describe("PkioError", () => {
+    it("creates error with message", () => {
+      const error = new PkioError("Test error");
+      expect(error.message).toBe("Test error");
+      expect(error.name).toBe("PkioError");
+    });
 
-    it('is instanceof Error', () => {
-      const error = new PkioError('Test')
-      expect(error).toBeInstanceOf(Error)
-    })
+    it("is instanceof Error", () => {
+      const error = new PkioError("Test");
+      expect(error).toBeInstanceOf(Error);
+    });
 
-    it('is instanceof PkioError', () => {
-      const error = new PkioError('Test')
-      expect(error).toBeInstanceOf(PkioError)
-    })
+    it("is instanceof PkioError", () => {
+      const error = new PkioError("Test");
+      expect(error).toBeInstanceOf(PkioError);
+    });
 
-    it('has correct stack trace', () => {
-      const error = new PkioError('Test')
-      expect(error.stack).toBeDefined()
-      expect(error.stack).toContain('PkioError')
-    })
-  })
+    it("has correct stack trace", () => {
+      const error = new PkioError("Test");
+      expect(error.stack).toBeDefined();
+      expect(error.stack).toContain("PkioError");
+    });
+  });
 
-  describe('HTTPError', () => {
-    it('creates error with statusCode, url, and body', () => {
-      const error = new HTTPError(404, 'https://api.example.com/pkg', 'Not found')
-      expect(error.statusCode).toBe(404)
-      expect(error.url).toBe('https://api.example.com/pkg')
-      expect(error.body).toBe('Not found')
-      expect(error.name).toBe('HTTPError')
-    })
+  describe("HTTPError", () => {
+    it("creates error with statusCode, url, and body", () => {
+      const error = new HTTPError(404, "https://api.example.com/pkg", "Not found");
+      expect(error.statusCode).toBe(404);
+      expect(error.url).toBe("https://api.example.com/pkg");
+      expect(error.body).toBe("Not found");
+      expect(error.name).toBe("HTTPError");
+    });
 
-    it('includes status code in message', () => {
-      const error = new HTTPError(500, 'https://api.example.com', 'Server error')
-      expect(error.message).toContain('HTTP 500')
-      expect(error.message).toContain('https://api.example.com')
-    })
+    it("includes status code in message", () => {
+      const error = new HTTPError(500, "https://api.example.com", "Server error");
+      expect(error.message).toContain("HTTP 500");
+      expect(error.message).toContain("https://api.example.com");
+    });
 
-    it('is instanceof PkioError', () => {
-      const error = new HTTPError(404, 'https://api.example.com', 'Not found')
-      expect(error).toBeInstanceOf(PkioError)
-    })
+    it("is instanceof PkioError", () => {
+      const error = new HTTPError(404, "https://api.example.com", "Not found");
+      expect(error).toBeInstanceOf(PkioError);
+    });
 
-    it('is instanceof HTTPError', () => {
-      const error = new HTTPError(404, 'https://api.example.com', 'Not found')
-      expect(error).toBeInstanceOf(HTTPError)
-    })
+    it("is instanceof HTTPError", () => {
+      const error = new HTTPError(404, "https://api.example.com", "Not found");
+      expect(error).toBeInstanceOf(HTTPError);
+    });
 
-    it('isNotFound() returns true for 404', () => {
-      const error = new HTTPError(404, 'https://api.example.com', 'Not found')
-      expect(error.isNotFound()).toBe(true)
-    })
+    it("isNotFound() returns true for 404", () => {
+      const error = new HTTPError(404, "https://api.example.com", "Not found");
+      expect(error.isNotFound()).toBe(true);
+    });
 
-    it('isNotFound() returns false for non-404', () => {
-      const error = new HTTPError(500, 'https://api.example.com', 'Server error')
-      expect(error.isNotFound()).toBe(false)
-    })
+    it("isNotFound() returns false for non-404", () => {
+      const error = new HTTPError(500, "https://api.example.com", "Server error");
+      expect(error.isNotFound()).toBe(false);
+    });
 
-    it('isRateLimit() returns true for 429', () => {
-      const error = new HTTPError(429, 'https://api.example.com', 'Too many requests')
-      expect(error.isRateLimit()).toBe(true)
-    })
+    it("isRateLimit() returns true for 429", () => {
+      const error = new HTTPError(429, "https://api.example.com", "Too many requests");
+      expect(error.isRateLimit()).toBe(true);
+    });
 
-    it('isRateLimit() returns false for non-429', () => {
-      const error = new HTTPError(404, 'https://api.example.com', 'Not found')
-      expect(error.isRateLimit()).toBe(false)
-    })
+    it("isRateLimit() returns false for non-429", () => {
+      const error = new HTTPError(404, "https://api.example.com", "Not found");
+      expect(error.isRateLimit()).toBe(false);
+    });
 
-    it('isServerError() returns true for 5xx', () => {
-      expect(new HTTPError(500, 'https://api.example.com', 'Error').isServerError()).toBe(true)
-      expect(new HTTPError(502, 'https://api.example.com', 'Error').isServerError()).toBe(true)
-      expect(new HTTPError(503, 'https://api.example.com', 'Error').isServerError()).toBe(true)
-      expect(new HTTPError(599, 'https://api.example.com', 'Error').isServerError()).toBe(true)
-    })
+    it("isServerError() returns true for 5xx", () => {
+      expect(new HTTPError(500, "https://api.example.com", "Error").isServerError()).toBe(true);
+      expect(new HTTPError(502, "https://api.example.com", "Error").isServerError()).toBe(true);
+      expect(new HTTPError(503, "https://api.example.com", "Error").isServerError()).toBe(true);
+      expect(new HTTPError(599, "https://api.example.com", "Error").isServerError()).toBe(true);
+    });
 
-    it('isServerError() returns false for non-5xx', () => {
-      expect(new HTTPError(404, 'https://api.example.com', 'Error').isServerError()).toBe(false)
-      expect(new HTTPError(429, 'https://api.example.com', 'Error').isServerError()).toBe(false)
-      expect(new HTTPError(200, 'https://api.example.com', 'Error').isServerError()).toBe(false)
-    })
+    it("isServerError() returns false for non-5xx", () => {
+      expect(new HTTPError(404, "https://api.example.com", "Error").isServerError()).toBe(false);
+      expect(new HTTPError(429, "https://api.example.com", "Error").isServerError()).toBe(false);
+      expect(new HTTPError(200, "https://api.example.com", "Error").isServerError()).toBe(false);
+    });
 
-    it('handles empty body', () => {
-      const error = new HTTPError(404, 'https://api.example.com', '')
-      expect(error.body).toBe('')
-    })
-  })
+    it("handles empty body", () => {
+      const error = new HTTPError(404, "https://api.example.com", "");
+      expect(error.body).toBe("");
+    });
+  });
 
-  describe('NotFoundError', () => {
-    it('creates error with ecosystem and packageName', () => {
-      const error = new NotFoundError('npm', 'nonexistent-package')
-      expect(error.ecosystem).toBe('npm')
-      expect(error.packageName).toBe('nonexistent-package')
-      expect(error.version).toBe('')
-      expect(error.name).toBe('NotFoundError')
-    })
+  describe("NotFoundError", () => {
+    it("creates error with ecosystem and packageName", () => {
+      const error = new NotFoundError("npm", "nonexistent-package");
+      expect(error.ecosystem).toBe("npm");
+      expect(error.packageName).toBe("nonexistent-package");
+      expect(error.version).toBe("");
+      expect(error.name).toBe("NotFoundError");
+    });
 
-    it('creates error with version', () => {
-      const error = new NotFoundError('npm', 'lodash', '1.0.0')
-      expect(error.ecosystem).toBe('npm')
-      expect(error.packageName).toBe('lodash')
-      expect(error.version).toBe('1.0.0')
-    })
+    it("creates error with version", () => {
+      const error = new NotFoundError("npm", "lodash", "1.0.0");
+      expect(error.ecosystem).toBe("npm");
+      expect(error.packageName).toBe("lodash");
+      expect(error.version).toBe("1.0.0");
+    });
 
-    it('includes package info in message without version', () => {
-      const error = new NotFoundError('npm', 'lodash')
-      expect(error.message).toContain('npm/lodash')
-      expect(error.message).not.toContain('@')
-    })
+    it("includes package info in message without version", () => {
+      const error = new NotFoundError("npm", "lodash");
+      expect(error.message).toContain("npm/lodash");
+      expect(error.message).not.toContain("@");
+    });
 
-    it('includes package info in message with version', () => {
-      const error = new NotFoundError('npm', 'lodash', '1.0.0')
-      expect(error.message).toContain('npm/lodash@1.0.0')
-    })
+    it("includes package info in message with version", () => {
+      const error = new NotFoundError("npm", "lodash", "1.0.0");
+      expect(error.message).toContain("npm/lodash@1.0.0");
+    });
 
-    it('is instanceof PkioError', () => {
-      const error = new NotFoundError('npm', 'lodash')
-      expect(error).toBeInstanceOf(PkioError)
-    })
+    it("is instanceof PkioError", () => {
+      const error = new NotFoundError("npm", "lodash");
+      expect(error).toBeInstanceOf(PkioError);
+    });
 
-    it('is instanceof NotFoundError', () => {
-      const error = new NotFoundError('npm', 'lodash')
-      expect(error).toBeInstanceOf(NotFoundError)
-    })
-  })
+    it("is instanceof NotFoundError", () => {
+      const error = new NotFoundError("npm", "lodash");
+      expect(error).toBeInstanceOf(NotFoundError);
+    });
+  });
 
-  describe('RateLimitError', () => {
-    it('creates error with retryAfter', () => {
-      const error = new RateLimitError(60)
-      expect(error.retryAfter).toBe(60)
-      expect(error.name).toBe('RateLimitError')
-    })
+  describe("RateLimitError", () => {
+    it("creates error with retryAfter", () => {
+      const error = new RateLimitError(60);
+      expect(error.retryAfter).toBe(60);
+      expect(error.name).toBe("RateLimitError");
+    });
 
-    it('includes retryAfter in message', () => {
-      const error = new RateLimitError(120)
-      expect(error.message).toContain('120')
-    })
+    it("includes retryAfter in message", () => {
+      const error = new RateLimitError(120);
+      expect(error.message).toContain("120");
+    });
 
-    it('is instanceof PkioError', () => {
-      const error = new RateLimitError(60)
-      expect(error).toBeInstanceOf(PkioError)
-    })
+    it("is instanceof PkioError", () => {
+      const error = new RateLimitError(60);
+      expect(error).toBeInstanceOf(PkioError);
+    });
 
-    it('is instanceof RateLimitError', () => {
-      const error = new RateLimitError(60)
-      expect(error).toBeInstanceOf(RateLimitError)
-    })
-  })
+    it("is instanceof RateLimitError", () => {
+      const error = new RateLimitError(60);
+      expect(error).toBeInstanceOf(RateLimitError);
+    });
+  });
 
-  describe('UnknownEcosystemError', () => {
-    it('creates error with ecosystem', () => {
-      const error = new UnknownEcosystemError('unknown-ecosystem')
-      expect(error.ecosystem).toBe('unknown-ecosystem')
-      expect(error.name).toBe('UnknownEcosystemError')
-    })
+  describe("UnknownEcosystemError", () => {
+    it("creates error with ecosystem", () => {
+      const error = new UnknownEcosystemError("unknown-ecosystem");
+      expect(error.ecosystem).toBe("unknown-ecosystem");
+      expect(error.name).toBe("UnknownEcosystemError");
+    });
 
-    it('includes ecosystem in message', () => {
-      const error = new UnknownEcosystemError('custom-pkg')
-      expect(error.message).toContain('custom-pkg')
-    })
+    it("includes ecosystem in message", () => {
+      const error = new UnknownEcosystemError("custom-pkg");
+      expect(error.message).toContain("custom-pkg");
+    });
 
-    it('is instanceof PkioError', () => {
-      const error = new UnknownEcosystemError('unknown')
-      expect(error).toBeInstanceOf(PkioError)
-    })
+    it("is instanceof PkioError", () => {
+      const error = new UnknownEcosystemError("unknown");
+      expect(error).toBeInstanceOf(PkioError);
+    });
 
-    it('is instanceof UnknownEcosystemError', () => {
-      const error = new UnknownEcosystemError('unknown')
-      expect(error).toBeInstanceOf(UnknownEcosystemError)
-    })
-  })
+    it("is instanceof UnknownEcosystemError", () => {
+      const error = new UnknownEcosystemError("unknown");
+      expect(error).toBeInstanceOf(UnknownEcosystemError);
+    });
+  });
 
-  describe('InvalidPURLError', () => {
-    it('creates error with purl and reason', () => {
-      const error = new InvalidPURLError('invalid-purl', 'missing type')
-      expect(error.purl).toBe('invalid-purl')
-      expect(error.name).toBe('InvalidPURLError')
-    })
+  describe("InvalidPURLError", () => {
+    it("creates error with purl and reason", () => {
+      const error = new InvalidPURLError("invalid-purl", "missing type");
+      expect(error.purl).toBe("invalid-purl");
+      expect(error.name).toBe("InvalidPURLError");
+    });
 
-    it('includes purl and reason in message', () => {
-      const error = new InvalidPURLError('pkg:npm', 'empty name')
-      expect(error.message).toContain('pkg:npm')
-      expect(error.message).toContain('empty name')
-    })
+    it("includes purl and reason in message", () => {
+      const error = new InvalidPURLError("pkg:npm", "empty name");
+      expect(error.message).toContain("pkg:npm");
+      expect(error.message).toContain("empty name");
+    });
 
-    it('is instanceof PkioError', () => {
-      const error = new InvalidPURLError('bad', 'reason')
-      expect(error).toBeInstanceOf(PkioError)
-    })
+    it("is instanceof PkioError", () => {
+      const error = new InvalidPURLError("bad", "reason");
+      expect(error).toBeInstanceOf(PkioError);
+    });
 
-    it('is instanceof InvalidPURLError', () => {
-      const error = new InvalidPURLError('bad', 'reason')
-      expect(error).toBeInstanceOf(InvalidPURLError)
-    })
-  })
+    it("is instanceof InvalidPURLError", () => {
+      const error = new InvalidPURLError("bad", "reason");
+      expect(error).toBeInstanceOf(InvalidPURLError);
+    });
+  });
 
-  describe('error hierarchy', () => {
-    it('all custom errors are instanceof PkioError', () => {
-      expect(new HTTPError(404, 'url', 'body')).toBeInstanceOf(PkioError)
-      expect(new NotFoundError('npm', 'pkg')).toBeInstanceOf(PkioError)
-      expect(new RateLimitError(60)).toBeInstanceOf(PkioError)
-      expect(new UnknownEcosystemError('eco')).toBeInstanceOf(PkioError)
-      expect(new InvalidPURLError('purl', 'reason')).toBeInstanceOf(PkioError)
-    })
+  describe("error hierarchy", () => {
+    it("all custom errors are instanceof PkioError", () => {
+      expect(new HTTPError(404, "url", "body")).toBeInstanceOf(PkioError);
+      expect(new NotFoundError("npm", "pkg")).toBeInstanceOf(PkioError);
+      expect(new RateLimitError(60)).toBeInstanceOf(PkioError);
+      expect(new UnknownEcosystemError("eco")).toBeInstanceOf(PkioError);
+      expect(new InvalidPURLError("purl", "reason")).toBeInstanceOf(PkioError);
+    });
 
-    it('all custom errors are instanceof Error', () => {
-      expect(new HTTPError(404, 'url', 'body')).toBeInstanceOf(Error)
-      expect(new NotFoundError('npm', 'pkg')).toBeInstanceOf(Error)
-      expect(new RateLimitError(60)).toBeInstanceOf(Error)
-      expect(new UnknownEcosystemError('eco')).toBeInstanceOf(Error)
-      expect(new InvalidPURLError('purl', 'reason')).toBeInstanceOf(Error)
-    })
-  })
-})
+    it("all custom errors are instanceof Error", () => {
+      expect(new HTTPError(404, "url", "body")).toBeInstanceOf(Error);
+      expect(new NotFoundError("npm", "pkg")).toBeInstanceOf(Error);
+      expect(new RateLimitError(60)).toBeInstanceOf(Error);
+      expect(new UnknownEcosystemError("eco")).toBeInstanceOf(Error);
+      expect(new InvalidPURLError("purl", "reason")).toBeInstanceOf(Error);
+    });
+  });
+});

--- a/test/unit/helpers.test.ts
+++ b/test/unit/helpers.test.ts
@@ -1,168 +1,180 @@
-import type { Package, Version, URLBuilder } from '../../src/core/types.ts'
-import { selectVersion, resolveDocsUrl, resolveReadmeUrl, fetchDependenciesFromPURL } from '../../src/helpers.ts'
-import { InvalidPURLError } from '../../src/core/errors.ts'
-import '../../src/registries/index.ts'
+import type { Package, Version, URLBuilder } from "../../src/core/types.ts";
+import {
+  selectVersion,
+  resolveDocsUrl,
+  resolveReadmeUrl,
+  fetchDependenciesFromPURL,
+} from "../../src/helpers.ts";
+import { InvalidPURLError } from "../../src/core/errors.ts";
+import "../../src/registries/index.ts";
 
-function version(num: string, status: '' | 'yanked' | 'deprecated' | 'retracted' = '', date = '2024-01-01T00:00:00Z'): Version {
+function version(
+  num: string,
+  status: "" | "yanked" | "deprecated" | "retracted" = "",
+  date = "2024-01-01T00:00:00Z",
+): Version {
   return {
     number: num,
     publishedAt: new Date(date),
-    licenses: '',
-    integrity: '',
+    licenses: "",
+    integrity: "",
     status,
     metadata: {},
-  }
+  };
 }
 
 function pkg(overrides: Partial<Package> = {}): Package {
   return {
-    name: 'test',
-    description: '',
-    homepage: '',
-    documentation: '',
-    repository: '',
-    licenses: '',
+    name: "test",
+    description: "",
+    homepage: "",
+    documentation: "",
+    repository: "",
+    licenses: "",
     keywords: [],
-    namespace: '',
-    latestVersion: '1.0.0',
+    namespace: "",
+    latestVersion: "1.0.0",
     metadata: {},
     ...overrides,
-  }
+  };
 }
 
 const stubUrls: URLBuilder = {
-  registry: () => '',
-  download: () => '',
-  documentation: (name: string, ver?: string) => `https://docs.example.com/${name}/${ver ?? 'latest'}`,
-  readme: (name: string, ver?: string) => `https://readme.example.com/${name}/${ver ?? 'latest'}`,
-  purl: () => '',
-}
+  registry: () => "",
+  download: () => "",
+  documentation: (name: string, ver?: string) =>
+    `https://docs.example.com/${name}/${ver ?? "latest"}`,
+  readme: (name: string, ver?: string) => `https://readme.example.com/${name}/${ver ?? "latest"}`,
+  purl: () => "",
+};
 
-describe('selectVersion', () => {
-  it('returns exact requested version when available', () => {
-    const versions = [version('1.0.0'), version('2.0.0'), version('3.0.0')]
-    const result = selectVersion(versions, { requested: '2.0.0' })
-    expect(result?.number).toBe('2.0.0')
-  })
+describe("selectVersion", () => {
+  it("returns exact requested version when available", () => {
+    const versions = [version("1.0.0"), version("2.0.0"), version("3.0.0")];
+    const result = selectVersion(versions, { requested: "2.0.0" });
+    expect(result?.number).toBe("2.0.0");
+  });
 
-  it('skips yanked requested version and falls back to latest', () => {
-    const versions = [version('1.0.0'), version('2.0.0', 'yanked'), version('3.0.0')]
-    const result = selectVersion(versions, { requested: '2.0.0', latest: '3.0.0' })
-    expect(result?.number).toBe('3.0.0')
-  })
+  it("skips yanked requested version and falls back to latest", () => {
+    const versions = [version("1.0.0"), version("2.0.0", "yanked"), version("3.0.0")];
+    const result = selectVersion(versions, { requested: "2.0.0", latest: "3.0.0" });
+    expect(result?.number).toBe("3.0.0");
+  });
 
-  it('skips deprecated requested version', () => {
-    const versions = [version('1.0.0'), version('2.0.0', 'deprecated')]
-    const result = selectVersion(versions, { requested: '2.0.0', latest: '1.0.0' })
-    expect(result?.number).toBe('1.0.0')
-  })
+  it("skips deprecated requested version", () => {
+    const versions = [version("1.0.0"), version("2.0.0", "deprecated")];
+    const result = selectVersion(versions, { requested: "2.0.0", latest: "1.0.0" });
+    expect(result?.number).toBe("1.0.0");
+  });
 
-  it('skips retracted requested version', () => {
-    const versions = [version('1.0.0'), version('2.0.0', 'retracted')]
-    const result = selectVersion(versions, { requested: '2.0.0', latest: '1.0.0' })
-    expect(result?.number).toBe('1.0.0')
-  })
+  it("skips retracted requested version", () => {
+    const versions = [version("1.0.0"), version("2.0.0", "retracted")];
+    const result = selectVersion(versions, { requested: "2.0.0", latest: "1.0.0" });
+    expect(result?.number).toBe("1.0.0");
+  });
 
-  it('falls back to first clean version when both requested and latest are unusable', () => {
+  it("falls back to first clean version when both requested and latest are unusable", () => {
+    const versions = [version("1.0.0", "yanked"), version("2.0.0", "yanked"), version("3.0.0")];
+    const result = selectVersion(versions, { requested: "1.0.0", latest: "2.0.0" });
+    expect(result?.number).toBe("3.0.0");
+  });
+
+  it("returns null when all versions are yanked", () => {
+    const versions = [version("1.0.0", "yanked"), version("2.0.0", "yanked")];
+    const result = selectVersion(versions, { requested: "1.0.0" });
+    expect(result).toBeNull();
+  });
+
+  it("returns null for empty version list", () => {
+    const result = selectVersion([], { requested: "1.0.0" });
+    expect(result).toBeNull();
+  });
+
+  it("works without options — returns newest clean version", () => {
     const versions = [
-      version('1.0.0', 'yanked'),
-      version('2.0.0', 'yanked'),
-      version('3.0.0'),
-    ]
-    const result = selectVersion(versions, { requested: '1.0.0', latest: '2.0.0' })
-    expect(result?.number).toBe('3.0.0')
-  })
+      version("1.0.0", "yanked"),
+      version("2.0.0", "", "2024-06-01"),
+      version("3.0.0", "", "2024-01-01"),
+    ];
+    const result = selectVersion(versions);
+    expect(result?.number).toBe("2.0.0");
+  });
 
-  it('returns null when all versions are yanked', () => {
-    const versions = [version('1.0.0', 'yanked'), version('2.0.0', 'yanked')]
-    const result = selectVersion(versions, { requested: '1.0.0' })
-    expect(result).toBeNull()
-  })
+  it("falls back to latest when requested version does not exist", () => {
+    const versions = [version("1.0.0"), version("2.0.0")];
+    const result = selectVersion(versions, { requested: "9.9.9", latest: "2.0.0" });
+    expect(result?.number).toBe("2.0.0");
+  });
 
-  it('returns null for empty version list', () => {
-    const result = selectVersion([], { requested: '1.0.0' })
-    expect(result).toBeNull()
-  })
-
-  it('works without options — returns newest clean version', () => {
-    const versions = [version('1.0.0', 'yanked'), version('2.0.0', '', '2024-06-01'), version('3.0.0', '', '2024-01-01')]
-    const result = selectVersion(versions)
-    expect(result?.number).toBe('2.0.0')
-  })
-
-  it('falls back to latest when requested version does not exist', () => {
-    const versions = [version('1.0.0'), version('2.0.0')]
-    const result = selectVersion(versions, { requested: '9.9.9', latest: '2.0.0' })
-    expect(result?.number).toBe('2.0.0')
-  })
-
-  it('returns newest clean version when fallback is needed', () => {
+  it("returns newest clean version when fallback is needed", () => {
     const versions = [
-      version('1.0.0', '', '2024-01-01'),
-      version('2.0.0', '', '2024-09-01'),
-      version('3.0.0', '', '2024-06-01'),
-    ]
-    const result = selectVersion(versions, { requested: '9.9.9' })
-    expect(result?.number).toBe('2.0.0')
-  })
-})
+      version("1.0.0", "", "2024-01-01"),
+      version("2.0.0", "", "2024-09-01"),
+      version("3.0.0", "", "2024-06-01"),
+    ];
+    const result = selectVersion(versions, { requested: "9.9.9" });
+    expect(result?.number).toBe("2.0.0");
+  });
+});
 
-describe('resolveDocsUrl', () => {
-  it('prefers documentation field when set', () => {
-    const p = pkg({ documentation: 'https://serde.rs/docs' })
-    expect(resolveDocsUrl(p, stubUrls)).toBe('https://serde.rs/docs')
-  })
+describe("resolveDocsUrl", () => {
+  it("prefers documentation field when set", () => {
+    const p = pkg({ documentation: "https://serde.rs/docs" });
+    expect(resolveDocsUrl(p, stubUrls)).toBe("https://serde.rs/docs");
+  });
 
-  it('falls back to homepage when documentation is empty', () => {
-    const p = pkg({ homepage: 'https://serde.rs' })
-    expect(resolveDocsUrl(p, stubUrls)).toBe('https://serde.rs')
-  })
+  it("falls back to homepage when documentation is empty", () => {
+    const p = pkg({ homepage: "https://serde.rs" });
+    expect(resolveDocsUrl(p, stubUrls)).toBe("https://serde.rs");
+  });
 
-  it('falls back to URLBuilder when both documentation and homepage are empty', () => {
-    const p = pkg()
-    expect(resolveDocsUrl(p, stubUrls, '1.0.0')).toBe('https://docs.example.com/test/1.0.0')
-  })
+  it("falls back to URLBuilder when both documentation and homepage are empty", () => {
+    const p = pkg();
+    expect(resolveDocsUrl(p, stubUrls, "1.0.0")).toBe("https://docs.example.com/test/1.0.0");
+  });
 
-  it('passes version to URLBuilder fallback', () => {
-    const p = pkg()
-    expect(resolveDocsUrl(p, stubUrls, '2.5.0')).toBe('https://docs.example.com/test/2.5.0')
-  })
+  it("passes version to URLBuilder fallback", () => {
+    const p = pkg();
+    expect(resolveDocsUrl(p, stubUrls, "2.5.0")).toBe("https://docs.example.com/test/2.5.0");
+  });
 
-  it('uses latest when no version specified in URLBuilder fallback', () => {
-    const p = pkg()
-    expect(resolveDocsUrl(p, stubUrls)).toBe('https://docs.example.com/test/latest')
-  })
+  it("uses latest when no version specified in URLBuilder fallback", () => {
+    const p = pkg();
+    expect(resolveDocsUrl(p, stubUrls)).toBe("https://docs.example.com/test/latest");
+  });
 
-  it('does not fall through when documentation is set even if homepage exists', () => {
-    const p = pkg({ documentation: 'https://docs.rs/serde', homepage: 'https://serde.rs' })
-    expect(resolveDocsUrl(p, stubUrls)).toBe('https://docs.rs/serde')
-  })
-})
+  it("does not fall through when documentation is set even if homepage exists", () => {
+    const p = pkg({ documentation: "https://docs.rs/serde", homepage: "https://serde.rs" });
+    expect(resolveDocsUrl(p, stubUrls)).toBe("https://docs.rs/serde");
+  });
+});
 
-describe('resolveReadmeUrl', () => {
-  it('returns ecosystem-specific readme URL with version', () => {
-    const p = pkg()
-    expect(resolveReadmeUrl(p, stubUrls, '1.0.0')).toBe('https://readme.example.com/test/1.0.0')
-  })
+describe("resolveReadmeUrl", () => {
+  it("returns ecosystem-specific readme URL with version", () => {
+    const p = pkg();
+    expect(resolveReadmeUrl(p, stubUrls, "1.0.0")).toBe("https://readme.example.com/test/1.0.0");
+  });
 
-  it('returns ecosystem-specific readme URL without version', () => {
-    const p = pkg()
-    expect(resolveReadmeUrl(p, stubUrls)).toBe('https://readme.example.com/test/latest')
-  })
+  it("returns ecosystem-specific readme URL without version", () => {
+    const p = pkg();
+    expect(resolveReadmeUrl(p, stubUrls)).toBe("https://readme.example.com/test/latest");
+  });
 
-  it('uses package name for URL construction', () => {
-    const p = pkg({ name: 'serde' })
-    expect(resolveReadmeUrl(p, stubUrls, '1.0.220')).toBe('https://readme.example.com/serde/1.0.220')
-  })
-})
+  it("uses package name for URL construction", () => {
+    const p = pkg({ name: "serde" });
+    expect(resolveReadmeUrl(p, stubUrls, "1.0.220")).toBe(
+      "https://readme.example.com/serde/1.0.220",
+    );
+  });
+});
 
-describe('fetchDependenciesFromPURL', () => {
-  it('throws InvalidPURLError when PURL has no version', async () => {
-    await expect(fetchDependenciesFromPURL('pkg:npm/lodash')).rejects.toThrow(InvalidPURLError)
-  })
+describe("fetchDependenciesFromPURL", () => {
+  it("throws InvalidPURLError when PURL has no version", async () => {
+    await expect(fetchDependenciesFromPURL("pkg:npm/lodash")).rejects.toThrow(InvalidPURLError);
+  });
 
-  it('includes PURL string in InvalidPURLError', async () => {
-    const purl = 'pkg:npm/lodash'
-    await expect(fetchDependenciesFromPURL(purl)).rejects.toThrow(purl)
-  })
-})
+  it("includes PURL string in InvalidPURLError", async () => {
+    const purl = "pkg:npm/lodash";
+    await expect(fetchDependenciesFromPURL(purl)).rejects.toThrow(purl);
+  });
+});

--- a/test/unit/info-command.test.ts
+++ b/test/unit/info-command.test.ts
@@ -1,4 +1,3 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
 import consola from "consola";
 import type { Package, Registry } from "../../src/core/types.ts";
 import { outputPackageInfo } from "../../src/commands/info.ts";

--- a/test/unit/info-command.test.ts
+++ b/test/unit/info-command.test.ts
@@ -1,98 +1,117 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
-import consola from 'consola'
-import type { Package, Registry } from '../../src/core/types.ts'
-import { outputPackageInfo } from '../../src/commands/info.ts'
+import { afterEach, describe, expect, it, vi } from "vitest";
+import consola from "consola";
+import type { Package, Registry } from "../../src/core/types.ts";
+import { outputPackageInfo } from "../../src/commands/info.ts";
 
 function createPackage(overrides: Partial<Package> = {}): Package {
   return {
-    name: 'serde',
-    description: 'Serialization framework',
-    homepage: '',
-    documentation: '',
-    repository: '',
-    licenses: 'MIT OR Apache-2.0',
+    name: "serde",
+    description: "Serialization framework",
+    homepage: "",
+    documentation: "",
+    repository: "",
+    licenses: "MIT OR Apache-2.0",
     keywords: [],
-    namespace: '',
-    latestVersion: '1.0.220',
+    namespace: "",
+    latestVersion: "1.0.220",
     metadata: {},
     ...overrides,
-  }
+  };
 }
 
 function createRegistry(registryUrl: string, docsUrl: string): Registry {
   return {
-    ecosystem: () => 'cargo',
+    ecosystem: () => "cargo",
     fetchPackage: async () => createPackage(),
     fetchVersions: async () => [],
     fetchDependencies: async () => [],
     fetchMaintainers: async () => [],
     urls: () => ({
       registry: () => registryUrl,
-      download: () => '',
+      download: () => "",
       documentation: () => docsUrl,
-      readme: () => '',
-      purl: () => '',
+      readme: () => "",
+      purl: () => "",
     }),
-  }
+  };
 }
 
 function loggedLines(log: ReturnType<typeof vi.spyOn>): string[] {
-  return log.mock.calls.map(([message]) => String(message))
+  return log.mock.calls.map(([message]) => String(message));
 }
 
-describe('outputPackageInfo', () => {
+describe("outputPackageInfo", () => {
   afterEach(() => {
-    vi.restoreAllMocks()
-  })
+    vi.restoreAllMocks();
+  });
 
-  it('prints docs when documentation url adds new information', () => {
-    const log = vi.spyOn(consola, 'log').mockImplementation(() => undefined)
+  it("prints docs when documentation url adds new information", () => {
+    const log = vi.spyOn(consola, "log").mockImplementation(() => undefined);
     const pkg = createPackage({
-      homepage: 'https://serde.rs',
-      documentation: 'https://docs.rs/serde',
-      repository: 'https://github.com/serde-rs/serde',
-    })
+      homepage: "https://serde.rs",
+      documentation: "https://docs.rs/serde",
+      repository: "https://github.com/serde-rs/serde",
+    });
 
-    outputPackageInfo(pkg, 'serde', createRegistry('https://crates.io/crates/serde', 'https://docs.rs/serde/1.0.220'))
+    outputPackageInfo(
+      pkg,
+      "serde",
+      createRegistry("https://crates.io/crates/serde", "https://docs.rs/serde/1.0.220"),
+    );
 
-    expect(loggedLines(log)).toContain('  \x1b[90mDocs:\x1b[0m       https://docs.rs/serde')
-  })
+    expect(loggedLines(log)).toContain("  \x1b[90mDocs:\x1b[0m       https://docs.rs/serde");
+  });
 
-  it('skips docs when the resolved url falls back to homepage', () => {
-    const log = vi.spyOn(consola, 'log').mockImplementation(() => undefined)
+  it("skips docs when the resolved url falls back to homepage", () => {
+    const log = vi.spyOn(consola, "log").mockImplementation(() => undefined);
     const pkg = createPackage({
-      name: 'requests',
-      homepage: 'https://requests.readthedocs.io',
-      latestVersion: '2.32.0',
-    })
+      name: "requests",
+      homepage: "https://requests.readthedocs.io",
+      latestVersion: "2.32.0",
+    });
 
-    outputPackageInfo(pkg, 'requests', createRegistry('https://pypi.org/project/requests', 'https://pypi.org/project/requests'))
+    outputPackageInfo(
+      pkg,
+      "requests",
+      createRegistry("https://pypi.org/project/requests", "https://pypi.org/project/requests"),
+    );
 
-    expect(loggedLines(log).some(line => line.includes('Docs:'))).toBe(false)
-  })
+    expect(loggedLines(log).some((line) => line.includes("Docs:"))).toBe(false);
+  });
 
-  it('skips docs when the fallback matches the registry page', () => {
-    const log = vi.spyOn(consola, 'log').mockImplementation(() => undefined)
+  it("skips docs when the fallback matches the registry page", () => {
+    const log = vi.spyOn(consola, "log").mockImplementation(() => undefined);
     const pkg = createPackage({
-      name: 'lodash',
-      latestVersion: '4.17.21',
-      licenses: 'MIT',
-    })
+      name: "lodash",
+      latestVersion: "4.17.21",
+      licenses: "MIT",
+    });
 
-    outputPackageInfo(pkg, 'lodash', createRegistry('https://www.npmjs.com/package/lodash', 'https://www.npmjs.com/package/lodash'))
+    outputPackageInfo(
+      pkg,
+      "lodash",
+      createRegistry(
+        "https://www.npmjs.com/package/lodash",
+        "https://www.npmjs.com/package/lodash",
+      ),
+    );
 
-    expect(loggedLines(log).some(line => line.includes('Docs:'))).toBe(false)
-  })
+    expect(loggedLines(log).some((line) => line.includes("Docs:"))).toBe(false);
+  });
 
-  it('skips docs when documentation matches repository', () => {
-    const log = vi.spyOn(consola, 'log').mockImplementation(() => undefined)
+  it("skips docs when documentation matches repository", () => {
+    const log = vi.spyOn(consola, "log").mockImplementation(() => undefined);
     const pkg = createPackage({
-      documentation: 'https://github.com/serde-rs/serde',
-      repository: 'https://github.com/serde-rs/serde',
-    })
+      documentation: "https://github.com/serde-rs/serde",
+      repository: "https://github.com/serde-rs/serde",
+    });
 
-    outputPackageInfo(pkg, 'serde', createRegistry('https://crates.io/crates/serde', 'https://docs.rs/serde/1.0.220'))
+    outputPackageInfo(
+      pkg,
+      "serde",
+      createRegistry("https://crates.io/crates/serde", "https://docs.rs/serde/1.0.220"),
+    );
 
-    expect(loggedLines(log).some(line => line.includes('Docs:'))).toBe(false)
-  })
-})
+    expect(loggedLines(log).some((line) => line.includes("Docs:"))).toBe(false);
+  });
+});

--- a/test/unit/license.test.ts
+++ b/test/unit/license.test.ts
@@ -1,181 +1,181 @@
-import { normalizeLicense, combineLicenses } from '../../src/core/license.ts'
+import { normalizeLicense, combineLicenses } from "../../src/core/license.ts";
 
-describe('license', () => {
-  describe('normalizeLicense', () => {
+describe("license", () => {
+  describe("normalizeLicense", () => {
     it('normalizes "MIT License" to "MIT"', () => {
-      expect(normalizeLicense('MIT License')).toBe('MIT')
-    })
+      expect(normalizeLicense("MIT License")).toBe("MIT");
+    });
 
     it('normalizes "MIT" to "MIT"', () => {
-      expect(normalizeLicense('MIT')).toBe('MIT')
-    })
+      expect(normalizeLicense("MIT")).toBe("MIT");
+    });
 
     it('normalizes "Apache 2.0" to "Apache-2.0"', () => {
-      expect(normalizeLicense('Apache 2.0')).toBe('Apache-2.0')
-    })
+      expect(normalizeLicense("Apache 2.0")).toBe("Apache-2.0");
+    });
 
     it('normalizes "Apache License 2.0" to "Apache-2.0"', () => {
-      expect(normalizeLicense('Apache License 2.0')).toBe('Apache-2.0')
-    })
+      expect(normalizeLicense("Apache License 2.0")).toBe("Apache-2.0");
+    });
 
     it('normalizes "Apache-2.0" to "Apache-2.0"', () => {
-      expect(normalizeLicense('Apache-2.0')).toBe('Apache-2.0')
-    })
+      expect(normalizeLicense("Apache-2.0")).toBe("Apache-2.0");
+    });
 
     it('normalizes "Apache License, Version 2.0" to "Apache-2.0"', () => {
-      expect(normalizeLicense('Apache License, Version 2.0')).toBe('Apache-2.0')
-    })
+      expect(normalizeLicense("Apache License, Version 2.0")).toBe("Apache-2.0");
+    });
 
     it('normalizes "Apache2" to "Apache-2.0"', () => {
-      expect(normalizeLicense('Apache2')).toBe('Apache-2.0')
-    })
+      expect(normalizeLicense("Apache2")).toBe("Apache-2.0");
+    });
 
-    it('normalizes BSD-2-Clause variants', () => {
-      expect(normalizeLicense('BSD-2-Clause')).toBe('BSD-2-Clause')
-      expect(normalizeLicense('BSD 2-Clause')).toBe('BSD-2-Clause')
-      expect(normalizeLicense('Simplified BSD License')).toBe('BSD-2-Clause')
-    })
+    it("normalizes BSD-2-Clause variants", () => {
+      expect(normalizeLicense("BSD-2-Clause")).toBe("BSD-2-Clause");
+      expect(normalizeLicense("BSD 2-Clause")).toBe("BSD-2-Clause");
+      expect(normalizeLicense("Simplified BSD License")).toBe("BSD-2-Clause");
+    });
 
-    it('normalizes BSD-3-Clause variants', () => {
-      expect(normalizeLicense('BSD-3-Clause')).toBe('BSD-3-Clause')
-      expect(normalizeLicense('BSD 3-Clause')).toBe('BSD-3-Clause')
-      expect(normalizeLicense('New BSD License')).toBe('BSD-3-Clause')
-    })
+    it("normalizes BSD-3-Clause variants", () => {
+      expect(normalizeLicense("BSD-3-Clause")).toBe("BSD-3-Clause");
+      expect(normalizeLicense("BSD 3-Clause")).toBe("BSD-3-Clause");
+      expect(normalizeLicense("New BSD License")).toBe("BSD-3-Clause");
+    });
 
-    it('normalizes ISC variants', () => {
-      expect(normalizeLicense('ISC License')).toBe('ISC')
-      expect(normalizeLicense('ISC')).toBe('ISC')
-    })
+    it("normalizes ISC variants", () => {
+      expect(normalizeLicense("ISC License")).toBe("ISC");
+      expect(normalizeLicense("ISC")).toBe("ISC");
+    });
 
-    it('normalizes GPL variants', () => {
-      expect(normalizeLicense('GPL-2.0')).toBe('GPL-2.0-only')
-      expect(normalizeLicense('GPL-3.0')).toBe('GPL-3.0-only')
-      expect(normalizeLicense('GPL-2.0-only')).toBe('GPL-2.0-only')
-      expect(normalizeLicense('GPL-3.0-only')).toBe('GPL-3.0-only')
-    })
+    it("normalizes GPL variants", () => {
+      expect(normalizeLicense("GPL-2.0")).toBe("GPL-2.0-only");
+      expect(normalizeLicense("GPL-3.0")).toBe("GPL-3.0-only");
+      expect(normalizeLicense("GPL-2.0-only")).toBe("GPL-2.0-only");
+      expect(normalizeLicense("GPL-3.0-only")).toBe("GPL-3.0-only");
+    });
 
-    it('normalizes LGPL variants', () => {
-      expect(normalizeLicense('LGPL-2.1')).toBe('LGPL-2.1-only')
-      expect(normalizeLicense('LGPL-3.0')).toBe('LGPL-3.0-only')
-    })
+    it("normalizes LGPL variants", () => {
+      expect(normalizeLicense("LGPL-2.1")).toBe("LGPL-2.1-only");
+      expect(normalizeLicense("LGPL-3.0")).toBe("LGPL-3.0-only");
+    });
 
-    it('normalizes MPL-2.0 variants', () => {
-      expect(normalizeLicense('MPL-2.0')).toBe('MPL-2.0')
-      expect(normalizeLicense('Mozilla Public License 2.0')).toBe('MPL-2.0')
-    })
+    it("normalizes MPL-2.0 variants", () => {
+      expect(normalizeLicense("MPL-2.0")).toBe("MPL-2.0");
+      expect(normalizeLicense("Mozilla Public License 2.0")).toBe("MPL-2.0");
+    });
 
-    it('normalizes Unlicense variants', () => {
-      expect(normalizeLicense('Unlicense')).toBe('Unlicense')
-      expect(normalizeLicense('The Unlicense')).toBe('Unlicense')
-      expect(normalizeLicense('Public Domain')).toBe('Unlicense')
-    })
+    it("normalizes Unlicense variants", () => {
+      expect(normalizeLicense("Unlicense")).toBe("Unlicense");
+      expect(normalizeLicense("The Unlicense")).toBe("Unlicense");
+      expect(normalizeLicense("Public Domain")).toBe("Unlicense");
+    });
 
-    it('normalizes CC0 variants', () => {
-      expect(normalizeLicense('CC0-1.0')).toBe('CC0-1.0')
-      expect(normalizeLicense('CC0')).toBe('CC0-1.0')
-    })
+    it("normalizes CC0 variants", () => {
+      expect(normalizeLicense("CC0-1.0")).toBe("CC0-1.0");
+      expect(normalizeLicense("CC0")).toBe("CC0-1.0");
+    });
 
-    it('normalizes Zlib', () => {
-      expect(normalizeLicense('Zlib')).toBe('Zlib')
-    })
+    it("normalizes Zlib", () => {
+      expect(normalizeLicense("Zlib")).toBe("Zlib");
+    });
 
-    it('normalizes WTFPL', () => {
-      expect(normalizeLicense('WTFPL')).toBe('WTFPL')
-    })
+    it("normalizes WTFPL", () => {
+      expect(normalizeLicense("WTFPL")).toBe("WTFPL");
+    });
 
-    it('normalizes Artistic-2.0', () => {
-      expect(normalizeLicense('Artistic-2.0')).toBe('Artistic-2.0')
-    })
+    it("normalizes Artistic-2.0", () => {
+      expect(normalizeLicense("Artistic-2.0")).toBe("Artistic-2.0");
+    });
 
-    it('normalizes Boost Software License', () => {
-      expect(normalizeLicense('Boost Software License 1.0')).toBe('BSL-1.0')
-      expect(normalizeLicense('BSL-1.0')).toBe('BSL-1.0')
-    })
+    it("normalizes Boost Software License", () => {
+      expect(normalizeLicense("Boost Software License 1.0")).toBe("BSL-1.0");
+      expect(normalizeLicense("BSL-1.0")).toBe("BSL-1.0");
+    });
 
-    it('is case-insensitive', () => {
-      expect(normalizeLicense('mit license')).toBe('MIT')
-      expect(normalizeLicense('MIT LICENSE')).toBe('MIT')
-      expect(normalizeLicense('Apache 2.0')).toBe('Apache-2.0')
-      expect(normalizeLicense('APACHE 2.0')).toBe('Apache-2.0')
-    })
+    it("is case-insensitive", () => {
+      expect(normalizeLicense("mit license")).toBe("MIT");
+      expect(normalizeLicense("MIT LICENSE")).toBe("MIT");
+      expect(normalizeLicense("Apache 2.0")).toBe("Apache-2.0");
+      expect(normalizeLicense("APACHE 2.0")).toBe("Apache-2.0");
+    });
 
-    it('trims whitespace', () => {
-      expect(normalizeLicense('  MIT  ')).toBe('MIT')
-      expect(normalizeLicense('\tApache 2.0\n')).toBe('Apache-2.0')
-    })
+    it("trims whitespace", () => {
+      expect(normalizeLicense("  MIT  ")).toBe("MIT");
+      expect(normalizeLicense("\tApache 2.0\n")).toBe("Apache-2.0");
+    });
 
-    it('returns empty string for null', () => {
-      expect(normalizeLicense(null)).toBe('')
-    })
+    it("returns empty string for null", () => {
+      expect(normalizeLicense(null)).toBe("");
+    });
 
-    it('returns empty string for undefined', () => {
-      expect(normalizeLicense(undefined)).toBe('')
-    })
+    it("returns empty string for undefined", () => {
+      expect(normalizeLicense(undefined)).toBe("");
+    });
 
-    it('returns empty string for empty string', () => {
-      expect(normalizeLicense('')).toBe('')
-    })
+    it("returns empty string for empty string", () => {
+      expect(normalizeLicense("")).toBe("");
+    });
 
-    it('returns empty string for whitespace-only string', () => {
-      expect(normalizeLicense('   ')).toBe('')
-      expect(normalizeLicense('\t\n')).toBe('')
-    })
+    it("returns empty string for whitespace-only string", () => {
+      expect(normalizeLicense("   ")).toBe("");
+      expect(normalizeLicense("\t\n")).toBe("");
+    });
 
-    it('passes through unknown SPDX identifiers', () => {
-      expect(normalizeLicense('Custom-License-1.0')).toBe('Custom-License-1.0')
-      expect(normalizeLicense('Proprietary')).toBe('Proprietary')
-    })
-  })
+    it("passes through unknown SPDX identifiers", () => {
+      expect(normalizeLicense("Custom-License-1.0")).toBe("Custom-License-1.0");
+      expect(normalizeLicense("Proprietary")).toBe("Proprietary");
+    });
+  });
 
-  describe('combineLicenses', () => {
-    it('returns empty string for empty array', () => {
-      expect(combineLicenses([])).toBe('')
-    })
+  describe("combineLicenses", () => {
+    it("returns empty string for empty array", () => {
+      expect(combineLicenses([])).toBe("");
+    });
 
-    it('returns empty string for array of nulls/undefined', () => {
-      expect(combineLicenses([null, undefined])).toBe('')
-    })
+    it("returns empty string for array of nulls/undefined", () => {
+      expect(combineLicenses([null, undefined])).toBe("");
+    });
 
-    it('returns single license', () => {
-      expect(combineLicenses(['MIT'])).toBe('MIT')
-    })
+    it("returns single license", () => {
+      expect(combineLicenses(["MIT"])).toBe("MIT");
+    });
 
-    it('returns single normalized license', () => {
-      expect(combineLicenses(['MIT License'])).toBe('MIT')
-    })
+    it("returns single normalized license", () => {
+      expect(combineLicenses(["MIT License"])).toBe("MIT");
+    });
 
-    it('combines two licenses with AND', () => {
-      expect(combineLicenses(['MIT', 'Apache-2.0'])).toBe('MIT AND Apache-2.0')
-    })
+    it("combines two licenses with AND", () => {
+      expect(combineLicenses(["MIT", "Apache-2.0"])).toBe("MIT AND Apache-2.0");
+    });
 
-    it('combines multiple licenses with AND', () => {
-      expect(combineLicenses(['MIT', 'Apache-2.0', 'ISC'])).toBe('MIT AND Apache-2.0 AND ISC')
-    })
+    it("combines multiple licenses with AND", () => {
+      expect(combineLicenses(["MIT", "Apache-2.0", "ISC"])).toBe("MIT AND Apache-2.0 AND ISC");
+    });
 
-    it('normalizes licenses before combining', () => {
-      expect(combineLicenses(['MIT License', 'Apache 2.0'])).toBe('MIT AND Apache-2.0')
-    })
+    it("normalizes licenses before combining", () => {
+      expect(combineLicenses(["MIT License", "Apache 2.0"])).toBe("MIT AND Apache-2.0");
+    });
 
-    it('filters out null/undefined values', () => {
-      expect(combineLicenses(['MIT', null, 'Apache-2.0', undefined])).toBe('MIT AND Apache-2.0')
-    })
+    it("filters out null/undefined values", () => {
+      expect(combineLicenses(["MIT", null, "Apache-2.0", undefined])).toBe("MIT AND Apache-2.0");
+    });
 
-    it('filters out empty strings', () => {
-      expect(combineLicenses(['MIT', '', 'Apache-2.0'])).toBe('MIT AND Apache-2.0')
-    })
+    it("filters out empty strings", () => {
+      expect(combineLicenses(["MIT", "", "Apache-2.0"])).toBe("MIT AND Apache-2.0");
+    });
 
-    it('filters out whitespace-only strings', () => {
-      expect(combineLicenses(['MIT', '   ', 'Apache-2.0'])).toBe('MIT AND Apache-2.0')
-    })
+    it("filters out whitespace-only strings", () => {
+      expect(combineLicenses(["MIT", "   ", "Apache-2.0"])).toBe("MIT AND Apache-2.0");
+    });
 
-    it('handles all nulls/undefined/empty', () => {
-      expect(combineLicenses([null, undefined, '', '   '])).toBe('')
-    })
+    it("handles all nulls/undefined/empty", () => {
+      expect(combineLicenses([null, undefined, "", "   "])).toBe("");
+    });
 
-    it('combines with normalization and filtering', () => {
-      expect(combineLicenses(['MIT License', null, 'Apache 2.0', undefined, ''])).toBe(
-        'MIT AND Apache-2.0'
-      )
-    })
-  })
-})
+    it("combines with normalization and filtering", () => {
+      expect(combineLicenses(["MIT License", null, "Apache 2.0", undefined, ""])).toBe(
+        "MIT AND Apache-2.0",
+      );
+    });
+  });
+});

--- a/test/unit/lockfile.test.ts
+++ b/test/unit/lockfile.test.ts
@@ -1,6 +1,6 @@
-import { createStorage } from 'unstorage'
-import memoryDriver from 'unstorage/drivers/memory'
-import { describe, expect, it } from 'vitest'
+import { createStorage } from "unstorage";
+import memoryDriver from "unstorage/drivers/memory";
+import { describe, expect, it } from "vitest";
 import {
   DEFAULT_TTL,
   cacheKey,
@@ -11,474 +11,474 @@ import {
   pruneStale,
   readLockfile,
   writeLockfile,
-} from '../../src/cache/lockfile.ts'
-import { computeIntegrity } from '../../src/cache/storage.ts'
-import type { Lockfile, LockfileEntry } from '../../src/cache/lockfile.ts'
+} from "../../src/cache/lockfile.ts";
+import { computeIntegrity } from "../../src/cache/storage.ts";
+import type { Lockfile, LockfileEntry } from "../../src/cache/lockfile.ts";
 
-describe('lockfile', () => {
-  describe('DEFAULT_TTL', () => {
-    it('has correct TTL values for each entry type', () => {
-      expect(DEFAULT_TTL.package).toBe(3600)
-      expect(DEFAULT_TTL.versions).toBe(1800)
-      expect(DEFAULT_TTL.dependencies).toBe(86400)
-      expect(DEFAULT_TTL.maintainers).toBe(86400)
-    })
+describe("lockfile", () => {
+  describe("DEFAULT_TTL", () => {
+    it("has correct TTL values for each entry type", () => {
+      expect(DEFAULT_TTL.package).toBe(3600);
+      expect(DEFAULT_TTL.versions).toBe(1800);
+      expect(DEFAULT_TTL.dependencies).toBe(86400);
+      expect(DEFAULT_TTL.maintainers).toBe(86400);
+    });
 
-    it('contains all required entry types', () => {
-      expect(DEFAULT_TTL).toHaveProperty('package')
-      expect(DEFAULT_TTL).toHaveProperty('versions')
-      expect(DEFAULT_TTL).toHaveProperty('dependencies')
-      expect(DEFAULT_TTL).toHaveProperty('maintainers')
-    })
-  })
+    it("contains all required entry types", () => {
+      expect(DEFAULT_TTL).toHaveProperty("package");
+      expect(DEFAULT_TTL).toHaveProperty("versions");
+      expect(DEFAULT_TTL).toHaveProperty("dependencies");
+      expect(DEFAULT_TTL).toHaveProperty("maintainers");
+    });
+  });
 
-  describe('cacheKey', () => {
-    it('builds key without version', () => {
-      const key = cacheKey('npm', 'lodash', 'package')
-      expect(key).toBe('npm:lodash:package')
-    })
+  describe("cacheKey", () => {
+    it("builds key without version", () => {
+      const key = cacheKey("npm", "lodash", "package");
+      expect(key).toBe("npm:lodash:package");
+    });
 
-    it('builds key with version', () => {
-      const key = cacheKey('npm', 'lodash', 'dependencies', '4.17.21')
-      expect(key).toBe('npm:lodash:dependencies:4.17.21')
-    })
+    it("builds key with version", () => {
+      const key = cacheKey("npm", "lodash", "dependencies", "4.17.21");
+      expect(key).toBe("npm:lodash:dependencies:4.17.21");
+    });
 
-    it('handles different ecosystems', () => {
-      const npmKey = cacheKey('npm', 'pkg', 'versions')
-      const cargoKey = cacheKey('cargo', 'pkg', 'versions')
-      expect(npmKey).not.toBe(cargoKey)
-    })
+    it("handles different ecosystems", () => {
+      const npmKey = cacheKey("npm", "pkg", "versions");
+      const cargoKey = cacheKey("cargo", "pkg", "versions");
+      expect(npmKey).not.toBe(cargoKey);
+    });
 
-    it('handles scoped package names', () => {
-      const key = cacheKey('npm', '@babel/core', 'package')
-      expect(key).toBe('npm:@babel/core:package')
-    })
-  })
+    it("handles scoped package names", () => {
+      const key = cacheKey("npm", "@babel/core", "package");
+      expect(key).toBe("npm:@babel/core:package");
+    });
+  });
 
-  describe('isFresh', () => {
-    it('returns true for entry within TTL', () => {
+  describe("isFresh", () => {
+    it("returns true for entry within TTL", () => {
       const entry: LockfileEntry = {
-        key: 'npm:lodash:package',
-        type: 'package',
+        key: "npm:lodash:package",
+        type: "package",
         fetchedAt: Date.now() - 1000, // 1 second ago
         ttl: 3600,
-        integrity: 'sha256-abc123',
-      }
-      expect(isFresh(entry)).toBe(true)
-    })
+        integrity: "sha256-abc123",
+      };
+      expect(isFresh(entry)).toBe(true);
+    });
 
-    it('returns false for expired entry', () => {
+    it("returns false for expired entry", () => {
       const entry: LockfileEntry = {
-        key: 'npm:lodash:package',
-        type: 'package',
+        key: "npm:lodash:package",
+        type: "package",
         fetchedAt: Date.now() - 4000000, // way in the past
         ttl: 3600,
-        integrity: 'sha256-abc123',
-      }
-      expect(isFresh(entry)).toBe(false)
-    })
+        integrity: "sha256-abc123",
+      };
+      expect(isFresh(entry)).toBe(false);
+    });
 
-    it('returns false at exact expiration time', () => {
-      const now = Date.now()
+    it("returns false at exact expiration time", () => {
+      const now = Date.now();
       const entry: LockfileEntry = {
-        key: 'npm:lodash:package',
-        type: 'package',
+        key: "npm:lodash:package",
+        type: "package",
         fetchedAt: now - 3600000, // exactly 1 hour ago
         ttl: 3600,
-        integrity: 'sha256-abc123',
-      }
+        integrity: "sha256-abc123",
+      };
       // At exact expiration, should be false (not fresh)
-      expect(isFresh(entry)).toBe(false)
-    })
+      expect(isFresh(entry)).toBe(false);
+    });
 
-    it('handles different TTL values', () => {
-      const now = Date.now()
+    it("handles different TTL values", () => {
+      const now = Date.now();
       const shortTTL: LockfileEntry = {
-        key: 'npm:pkg:versions',
-        type: 'versions',
+        key: "npm:pkg:versions",
+        type: "versions",
         fetchedAt: now - 1000,
         ttl: 1800, // 30 min
-        integrity: 'sha256-abc123',
-      }
+        integrity: "sha256-abc123",
+      };
       const longTTL: LockfileEntry = {
-        key: 'npm:pkg:dependencies',
-        type: 'dependencies',
+        key: "npm:pkg:dependencies",
+        type: "dependencies",
         fetchedAt: now - 1000,
         ttl: 86400, // 24 hours
-        integrity: 'sha256-abc123',
-      }
-      expect(isFresh(shortTTL)).toBe(true)
-      expect(isFresh(longTTL)).toBe(true)
-    })
-  })
+        integrity: "sha256-abc123",
+      };
+      expect(isFresh(shortTTL)).toBe(true);
+      expect(isFresh(longTTL)).toBe(true);
+    });
+  });
 
-  describe('getFreshEntry', () => {
-    it('returns entry if fresh', () => {
+  describe("getFreshEntry", () => {
+    it("returns entry if fresh", () => {
       const lockfile: Lockfile = {
         version: 1,
         entries: {
-          'npm:lodash:package': {
-            key: 'npm:lodash:package',
-            type: 'package',
+          "npm:lodash:package": {
+            key: "npm:lodash:package",
+            type: "package",
             fetchedAt: Date.now() - 1000,
             ttl: 3600,
-            integrity: 'sha256-abc123',
+            integrity: "sha256-abc123",
           },
         },
-      }
-      const entry = getFreshEntry(lockfile, 'npm:lodash:package')
-      expect(entry).not.toBeNull()
-      expect(entry?.key).toBe('npm:lodash:package')
-    })
+      };
+      const entry = getFreshEntry(lockfile, "npm:lodash:package");
+      expect(entry).not.toBeNull();
+      expect(entry?.key).toBe("npm:lodash:package");
+    });
 
-    it('returns null if entry does not exist', () => {
-      const lockfile: Lockfile = { version: 1, entries: {} }
-      const entry = getFreshEntry(lockfile, 'npm:nonexistent:package')
-      expect(entry).toBeNull()
-    })
+    it("returns null if entry does not exist", () => {
+      const lockfile: Lockfile = { version: 1, entries: {} };
+      const entry = getFreshEntry(lockfile, "npm:nonexistent:package");
+      expect(entry).toBeNull();
+    });
 
-    it('returns null if entry is stale', () => {
+    it("returns null if entry is stale", () => {
       const lockfile: Lockfile = {
         version: 1,
         entries: {
-          'npm:lodash:package': {
-            key: 'npm:lodash:package',
-            type: 'package',
+          "npm:lodash:package": {
+            key: "npm:lodash:package",
+            type: "package",
             fetchedAt: Date.now() - 4000000,
             ttl: 3600,
-            integrity: 'sha256-abc123',
+            integrity: "sha256-abc123",
           },
         },
-      }
-      const entry = getFreshEntry(lockfile, 'npm:lodash:package')
-      expect(entry).toBeNull()
-    })
+      };
+      const entry = getFreshEntry(lockfile, "npm:lodash:package");
+      expect(entry).toBeNull();
+    });
 
-    it('returns null if entry exists but is not fresh', () => {
-      const now = Date.now()
+    it("returns null if entry exists but is not fresh", () => {
+      const now = Date.now();
       const lockfile: Lockfile = {
         version: 1,
         entries: {
-          'npm:pkg:versions': {
-            key: 'npm:pkg:versions',
-            type: 'versions',
+          "npm:pkg:versions": {
+            key: "npm:pkg:versions",
+            type: "versions",
             fetchedAt: now - 2000000, // expired
             ttl: 1800,
-            integrity: 'sha256-xyz789',
+            integrity: "sha256-xyz789",
           },
         },
-      }
-      const entry = getFreshEntry(lockfile, 'npm:pkg:versions')
-      expect(entry).toBeNull()
-    })
-  })
+      };
+      const entry = getFreshEntry(lockfile, "npm:pkg:versions");
+      expect(entry).toBeNull();
+    });
+  });
 
-  describe('setEntry', () => {
-    it('adds new entry to lockfile', () => {
-      const lockfile: Lockfile = { version: 1, entries: {} }
+  describe("setEntry", () => {
+    it("adds new entry to lockfile", () => {
+      const lockfile: Lockfile = { version: 1, entries: {} };
       const entry: LockfileEntry = {
-        key: 'npm:lodash:package',
-        type: 'package',
+        key: "npm:lodash:package",
+        type: "package",
         fetchedAt: Date.now(),
         ttl: 3600,
-        integrity: 'sha256-abc123',
-      }
-      setEntry(lockfile, entry)
-      expect(lockfile.entries['npm:lodash:package']).toBe(entry)
-    })
+        integrity: "sha256-abc123",
+      };
+      setEntry(lockfile, entry);
+      expect(lockfile.entries["npm:lodash:package"]).toBe(entry);
+    });
 
-    it('overwrites existing entry', () => {
+    it("overwrites existing entry", () => {
       const lockfile: Lockfile = {
         version: 1,
         entries: {
-          'npm:lodash:package': {
-            key: 'npm:lodash:package',
-            type: 'package',
+          "npm:lodash:package": {
+            key: "npm:lodash:package",
+            type: "package",
             fetchedAt: Date.now() - 10000,
             ttl: 3600,
-            integrity: 'sha256-old',
+            integrity: "sha256-old",
           },
         },
-      }
+      };
       const newEntry: LockfileEntry = {
-        key: 'npm:lodash:package',
-        type: 'package',
+        key: "npm:lodash:package",
+        type: "package",
         fetchedAt: Date.now(),
         ttl: 3600,
-        integrity: 'sha256-new',
-      }
-      setEntry(lockfile, newEntry)
-      expect(lockfile.entries['npm:lodash:package']?.integrity).toBe('sha256-new')
-    })
+        integrity: "sha256-new",
+      };
+      setEntry(lockfile, newEntry);
+      expect(lockfile.entries["npm:lodash:package"]?.integrity).toBe("sha256-new");
+    });
 
-    it('preserves other entries', () => {
+    it("preserves other entries", () => {
       const lockfile: Lockfile = {
         version: 1,
         entries: {
-          'npm:lodash:package': {
-            key: 'npm:lodash:package',
-            type: 'package',
+          "npm:lodash:package": {
+            key: "npm:lodash:package",
+            type: "package",
             fetchedAt: Date.now(),
             ttl: 3600,
-            integrity: 'sha256-lodash',
+            integrity: "sha256-lodash",
           },
         },
-      }
+      };
       const newEntry: LockfileEntry = {
-        key: 'npm:react:package',
-        type: 'package',
+        key: "npm:react:package",
+        type: "package",
         fetchedAt: Date.now(),
         ttl: 3600,
-        integrity: 'sha256-react',
-      }
-      setEntry(lockfile, newEntry)
-      expect(Object.keys(lockfile.entries)).toHaveLength(2)
-      expect(lockfile.entries['npm:lodash:package']).toBeDefined()
-      expect(lockfile.entries['npm:react:package']).toBeDefined()
-    })
-  })
+        integrity: "sha256-react",
+      };
+      setEntry(lockfile, newEntry);
+      expect(Object.keys(lockfile.entries)).toHaveLength(2);
+      expect(lockfile.entries["npm:lodash:package"]).toBeDefined();
+      expect(lockfile.entries["npm:react:package"]).toBeDefined();
+    });
+  });
 
-  describe('removeEntry', () => {
-    it('removes entry from lockfile', () => {
+  describe("removeEntry", () => {
+    it("removes entry from lockfile", () => {
       const lockfile: Lockfile = {
         version: 1,
         entries: {
-          'npm:lodash:package': {
-            key: 'npm:lodash:package',
-            type: 'package',
+          "npm:lodash:package": {
+            key: "npm:lodash:package",
+            type: "package",
             fetchedAt: Date.now(),
             ttl: 3600,
-            integrity: 'sha256-abc123',
+            integrity: "sha256-abc123",
           },
         },
-      }
-      removeEntry(lockfile, 'npm:lodash:package')
-      expect(lockfile.entries['npm:lodash:package']).toBeUndefined()
-    })
+      };
+      removeEntry(lockfile, "npm:lodash:package");
+      expect(lockfile.entries["npm:lodash:package"]).toBeUndefined();
+    });
 
-    it('does nothing if entry does not exist', () => {
-      const lockfile: Lockfile = { version: 1, entries: {} }
+    it("does nothing if entry does not exist", () => {
+      const lockfile: Lockfile = { version: 1, entries: {} };
       expect(() => {
-        removeEntry(lockfile, 'npm:nonexistent:package')
-      }).not.toThrow()
-      expect(lockfile.entries).toEqual({})
-    })
+        removeEntry(lockfile, "npm:nonexistent:package");
+      }).not.toThrow();
+      expect(lockfile.entries).toEqual({});
+    });
 
-    it('preserves other entries', () => {
+    it("preserves other entries", () => {
       const lockfile: Lockfile = {
         version: 1,
         entries: {
-          'npm:lodash:package': {
-            key: 'npm:lodash:package',
-            type: 'package',
+          "npm:lodash:package": {
+            key: "npm:lodash:package",
+            type: "package",
             fetchedAt: Date.now(),
             ttl: 3600,
-            integrity: 'sha256-lodash',
+            integrity: "sha256-lodash",
           },
-          'npm:react:package': {
-            key: 'npm:react:package',
-            type: 'package',
+          "npm:react:package": {
+            key: "npm:react:package",
+            type: "package",
             fetchedAt: Date.now(),
             ttl: 3600,
-            integrity: 'sha256-react',
+            integrity: "sha256-react",
           },
         },
-      }
-      removeEntry(lockfile, 'npm:lodash:package')
-      expect(lockfile.entries['npm:react:package']).toBeDefined()
-      expect(lockfile.entries['npm:lodash:package']).toBeUndefined()
-    })
-  })
+      };
+      removeEntry(lockfile, "npm:lodash:package");
+      expect(lockfile.entries["npm:react:package"]).toBeDefined();
+      expect(lockfile.entries["npm:lodash:package"]).toBeUndefined();
+    });
+  });
 
-  describe('pruneStale', () => {
-    it('removes stale entries', () => {
-      const now = Date.now()
+  describe("pruneStale", () => {
+    it("removes stale entries", () => {
+      const now = Date.now();
       const lockfile: Lockfile = {
         version: 1,
         entries: {
-          'npm:fresh:package': {
-            key: 'npm:fresh:package',
-            type: 'package',
+          "npm:fresh:package": {
+            key: "npm:fresh:package",
+            type: "package",
             fetchedAt: now - 1000,
             ttl: 3600,
-            integrity: 'sha256-fresh',
+            integrity: "sha256-fresh",
           },
-          'npm:stale:package': {
-            key: 'npm:stale:package',
-            type: 'package',
+          "npm:stale:package": {
+            key: "npm:stale:package",
+            type: "package",
             fetchedAt: now - 4000000,
             ttl: 3600,
-            integrity: 'sha256-stale',
+            integrity: "sha256-stale",
           },
         },
-      }
-      const removed = pruneStale(lockfile)
-      expect(removed).toBe(1)
-      expect(lockfile.entries['npm:fresh:package']).toBeDefined()
-      expect(lockfile.entries['npm:stale:package']).toBeUndefined()
-    })
+      };
+      const removed = pruneStale(lockfile);
+      expect(removed).toBe(1);
+      expect(lockfile.entries["npm:fresh:package"]).toBeDefined();
+      expect(lockfile.entries["npm:stale:package"]).toBeUndefined();
+    });
 
-    it('returns 0 when no stale entries', () => {
-      const now = Date.now()
+    it("returns 0 when no stale entries", () => {
+      const now = Date.now();
       const lockfile: Lockfile = {
         version: 1,
         entries: {
-          'npm:fresh1:package': {
-            key: 'npm:fresh1:package',
-            type: 'package',
+          "npm:fresh1:package": {
+            key: "npm:fresh1:package",
+            type: "package",
             fetchedAt: now - 1000,
             ttl: 3600,
-            integrity: 'sha256-fresh1',
+            integrity: "sha256-fresh1",
           },
-          'npm:fresh2:package': {
-            key: 'npm:fresh2:package',
-            type: 'package',
+          "npm:fresh2:package": {
+            key: "npm:fresh2:package",
+            type: "package",
             fetchedAt: now - 2000,
             ttl: 3600,
-            integrity: 'sha256-fresh2',
+            integrity: "sha256-fresh2",
           },
         },
-      }
-      const removed = pruneStale(lockfile)
-      expect(removed).toBe(0)
-      expect(Object.keys(lockfile.entries)).toHaveLength(2)
-    })
+      };
+      const removed = pruneStale(lockfile);
+      expect(removed).toBe(0);
+      expect(Object.keys(lockfile.entries)).toHaveLength(2);
+    });
 
-    it('removes all entries when all are stale', () => {
-      const now = Date.now()
+    it("removes all entries when all are stale", () => {
+      const now = Date.now();
       const lockfile: Lockfile = {
         version: 1,
         entries: {
-          'npm:stale1:package': {
-            key: 'npm:stale1:package',
-            type: 'package',
+          "npm:stale1:package": {
+            key: "npm:stale1:package",
+            type: "package",
             fetchedAt: now - 4000000,
             ttl: 3600,
-            integrity: 'sha256-stale1',
+            integrity: "sha256-stale1",
           },
-          'npm:stale2:package': {
-            key: 'npm:stale2:package',
-            type: 'package',
+          "npm:stale2:package": {
+            key: "npm:stale2:package",
+            type: "package",
             fetchedAt: now - 5000000,
             ttl: 3600,
-            integrity: 'sha256-stale2',
+            integrity: "sha256-stale2",
           },
         },
-      }
-      const removed = pruneStale(lockfile)
-      expect(removed).toBe(2)
-      expect(Object.keys(lockfile.entries)).toHaveLength(0)
-    })
+      };
+      const removed = pruneStale(lockfile);
+      expect(removed).toBe(2);
+      expect(Object.keys(lockfile.entries)).toHaveLength(0);
+    });
 
-    it('handles empty lockfile', () => {
-      const lockfile: Lockfile = { version: 1, entries: {} }
-      const removed = pruneStale(lockfile)
-      expect(removed).toBe(0)
-    })
+    it("handles empty lockfile", () => {
+      const lockfile: Lockfile = { version: 1, entries: {} };
+      const removed = pruneStale(lockfile);
+      expect(removed).toBe(0);
+    });
 
-    it('respects different TTL values', () => {
-      const now = Date.now()
+    it("respects different TTL values", () => {
+      const now = Date.now();
       const lockfile: Lockfile = {
         version: 1,
         entries: {
-          'npm:pkg:versions': {
-            key: 'npm:pkg:versions',
-            type: 'versions',
+          "npm:pkg:versions": {
+            key: "npm:pkg:versions",
+            type: "versions",
             fetchedAt: now - 2000000, // expired (TTL 1800)
             ttl: 1800,
-            integrity: 'sha256-versions',
+            integrity: "sha256-versions",
           },
-          'npm:pkg:dependencies': {
-            key: 'npm:pkg:dependencies',
-            type: 'dependencies',
+          "npm:pkg:dependencies": {
+            key: "npm:pkg:dependencies",
+            type: "dependencies",
             fetchedAt: now - 2000000, // fresh (TTL 86400)
             ttl: 86400,
-            integrity: 'sha256-deps',
+            integrity: "sha256-deps",
           },
         },
-      }
-      const removed = pruneStale(lockfile)
-      expect(removed).toBe(1)
-      expect(lockfile.entries['npm:pkg:versions']).toBeUndefined()
-      expect(lockfile.entries['npm:pkg:dependencies']).toBeDefined()
-    })
-  })
+      };
+      const removed = pruneStale(lockfile);
+      expect(removed).toBe(1);
+      expect(lockfile.entries["npm:pkg:versions"]).toBeUndefined();
+      expect(lockfile.entries["npm:pkg:dependencies"]).toBeDefined();
+    });
+  });
 
-  describe('readLockfile / writeLockfile', () => {
-    it('writes and reads lockfile with correct structure', async () => {
-      const storage = createStorage({ driver: memoryDriver() })
+  describe("readLockfile / writeLockfile", () => {
+    it("writes and reads lockfile with correct structure", async () => {
+      const storage = createStorage({ driver: memoryDriver() });
       const lockfile: Lockfile = {
         version: 1,
         entries: {
-          'npm:lodash:package': {
-            key: 'npm:lodash:package',
-            type: 'package',
+          "npm:lodash:package": {
+            key: "npm:lodash:package",
+            type: "package",
             fetchedAt: Date.now(),
             ttl: 3600,
-            integrity: 'sha256-abc123',
+            integrity: "sha256-abc123",
           },
         },
-      }
+      };
 
-      await writeLockfile(lockfile, storage)
+      await writeLockfile(lockfile, storage);
 
-      const read = await readLockfile(storage)
-      expect(read.version).toBe(1)
-      expect(read.entries['npm:lodash:package']).toBeDefined()
-      expect(read.entries['npm:lodash:package']?.integrity).toBe('sha256-abc123')
-    })
+      const read = await readLockfile(storage);
+      expect(read.version).toBe(1);
+      expect(read.entries["npm:lodash:package"]).toBeDefined();
+      expect(read.entries["npm:lodash:package"]?.integrity).toBe("sha256-abc123");
+    });
 
-    it('returns empty lockfile when storage is empty', async () => {
-      const storage = createStorage({ driver: memoryDriver() })
-      const lockfile = await readLockfile(storage)
-      expect(lockfile.version).toBe(1)
-      expect(lockfile.entries).toEqual({})
-    })
+    it("returns empty lockfile when storage is empty", async () => {
+      const storage = createStorage({ driver: memoryDriver() });
+      const lockfile = await readLockfile(storage);
+      expect(lockfile.version).toBe(1);
+      expect(lockfile.entries).toEqual({});
+    });
 
-    it('returns empty lockfile on invalid version', async () => {
-      const storage = createStorage({ driver: memoryDriver() })
-      await storage.setItem('__lockfile__', { version: 999, entries: {} })
-      const lockfile = await readLockfile(storage)
-      expect(lockfile.version).toBe(1)
-      expect(lockfile.entries).toEqual({})
-    })
-  })
+    it("returns empty lockfile on invalid version", async () => {
+      const storage = createStorage({ driver: memoryDriver() });
+      await storage.setItem("__lockfile__", { version: 999, entries: {} });
+      const lockfile = await readLockfile(storage);
+      expect(lockfile.version).toBe(1);
+      expect(lockfile.entries).toEqual({});
+    });
+  });
 
-  describe('computeIntegrity', () => {
-    it('computes sha256 hash of JSON value', () => {
-      const value = { name: 'lodash', version: '4.17.21' }
-      const integrity = computeIntegrity(value)
-      expect(integrity).toMatch(/^sha256-[a-f0-9]{64}$/)
-    })
+  describe("computeIntegrity", () => {
+    it("computes sha256 hash of JSON value", () => {
+      const value = { name: "lodash", version: "4.17.21" };
+      const integrity = computeIntegrity(value);
+      expect(integrity).toMatch(/^sha256-[a-f0-9]{64}$/);
+    });
 
-    it('produces same hash for same value', () => {
-      const value = { name: 'lodash', version: '4.17.21' }
-      const hash1 = computeIntegrity(value)
-      const hash2 = computeIntegrity(value)
-      expect(hash1).toBe(hash2)
-    })
+    it("produces same hash for same value", () => {
+      const value = { name: "lodash", version: "4.17.21" };
+      const hash1 = computeIntegrity(value);
+      const hash2 = computeIntegrity(value);
+      expect(hash1).toBe(hash2);
+    });
 
-    it('produces different hash for different values', () => {
-      const value1 = { name: 'lodash', version: '4.17.21' }
-      const value2 = { name: 'lodash', version: '4.17.22' }
-      const hash1 = computeIntegrity(value1)
-      const hash2 = computeIntegrity(value2)
-      expect(hash1).not.toBe(hash2)
-    })
+    it("produces different hash for different values", () => {
+      const value1 = { name: "lodash", version: "4.17.21" };
+      const value2 = { name: "lodash", version: "4.17.22" };
+      const hash1 = computeIntegrity(value1);
+      const hash2 = computeIntegrity(value2);
+      expect(hash1).not.toBe(hash2);
+    });
 
-    it('handles arrays', () => {
-      const arr = [{ id: 1 }, { id: 2 }]
-      const integrity = computeIntegrity(arr)
-      expect(integrity).toMatch(/^sha256-[a-f0-9]{64}$/)
-    })
+    it("handles arrays", () => {
+      const arr = [{ id: 1 }, { id: 2 }];
+      const integrity = computeIntegrity(arr);
+      expect(integrity).toMatch(/^sha256-[a-f0-9]{64}$/);
+    });
 
-    it('handles primitives', () => {
-      const str = computeIntegrity('hello')
-      const num = computeIntegrity(42)
-      const bool = computeIntegrity(true)
-      expect(str).toMatch(/^sha256-[a-f0-9]{64}$/)
-      expect(num).toMatch(/^sha256-[a-f0-9]{64}$/)
-      expect(bool).toMatch(/^sha256-[a-f0-9]{64}$/)
-    })
-  })
-})
+    it("handles primitives", () => {
+      const str = computeIntegrity("hello");
+      const num = computeIntegrity(42);
+      const bool = computeIntegrity(true);
+      expect(str).toMatch(/^sha256-[a-f0-9]{64}$/);
+      expect(num).toMatch(/^sha256-[a-f0-9]{64}$/);
+      expect(bool).toMatch(/^sha256-[a-f0-9]{64}$/);
+    });
+  });
+});

--- a/test/unit/purl.test.ts
+++ b/test/unit/purl.test.ts
@@ -1,237 +1,262 @@
-import { parsePURL, fullName, buildPURL, createFromPURL } from '../../src/core/purl.ts'
-import { InvalidPURLError } from '../../src/core/errors.ts'
+import { parsePURL, fullName, buildPURL } from "../../src/core/purl.ts";
+import { InvalidPURLError } from "../../src/core/errors.ts";
 
-describe('purl', () => {
-  describe('parsePURL', () => {
-    it('parses simple PURL', () => {
-      const result = parsePURL('pkg:npm/lodash')
+describe("purl", () => {
+  describe("parsePURL", () => {
+    it("parses simple PURL", () => {
+      const result = parsePURL("pkg:npm/lodash");
       expect(result).toEqual({
-        type: 'npm',
-        namespace: '',
-        name: 'lodash',
-        version: '',
+        type: "npm",
+        namespace: "",
+        name: "lodash",
+        version: "",
         qualifiers: {},
-        subpath: '',
-      })
-    })
+        subpath: "",
+      });
+    });
 
-    it('parses scoped package', () => {
-      const result = parsePURL('pkg:npm/%40babel/core@7.0.0')
+    it("parses scoped package", () => {
+      const result = parsePURL("pkg:npm/%40babel/core@7.0.0");
       expect(result).toEqual({
-        type: 'npm',
-        namespace: '@babel',
-        name: 'core',
-        version: '7.0.0',
+        type: "npm",
+        namespace: "@babel",
+        name: "core",
+        version: "7.0.0",
         qualifiers: {},
-        subpath: '',
-      })
-    })
+        subpath: "",
+      });
+    });
 
-    it('parses PURL with version', () => {
-      const result = parsePURL('pkg:cargo/serde@1.0.0')
+    it("parses PURL with version", () => {
+      const result = parsePURL("pkg:cargo/serde@1.0.0");
       expect(result).toEqual({
-        type: 'cargo',
-        namespace: '',
-        name: 'serde',
-        version: '1.0.0',
+        type: "cargo",
+        namespace: "",
+        name: "serde",
+        version: "1.0.0",
         qualifiers: {},
-        subpath: '',
-      })
-    })
+        subpath: "",
+      });
+    });
 
-    it('parses PURL with qualifiers', () => {
-      const result = parsePURL('pkg:npm/lodash?repository_url=https://custom.registry.com')
+    it("parses PURL with qualifiers", () => {
+      const result = parsePURL("pkg:npm/lodash?repository_url=https://custom.registry.com");
       expect(result).toEqual({
-        type: 'npm',
-        namespace: '',
-        name: 'lodash',
-        version: '',
+        type: "npm",
+        namespace: "",
+        name: "lodash",
+        version: "",
         qualifiers: {
-          repository_url: 'https://custom.registry.com',
+          repository_url: "https://custom.registry.com",
         },
-        subpath: '',
-      })
-    })
+        subpath: "",
+      });
+    });
 
-    it('parses PURL with multiple qualifiers', () => {
-      const result = parsePURL('pkg:npm/lodash?arch=x86_64&os=linux')
+    it("parses PURL with multiple qualifiers", () => {
+      const result = parsePURL("pkg:npm/lodash?arch=x86_64&os=linux");
       expect(result).toEqual({
-        type: 'npm',
-        namespace: '',
-        name: 'lodash',
-        version: '',
+        type: "npm",
+        namespace: "",
+        name: "lodash",
+        version: "",
         qualifiers: {
-          arch: 'x86_64',
-          os: 'linux',
+          arch: "x86_64",
+          os: "linux",
         },
-        subpath: '',
-      })
-    })
+        subpath: "",
+      });
+    });
 
-    it('parses PURL with subpath', () => {
-      const result = parsePURL('pkg:npm/lodash#some/path')
+    it("parses PURL with subpath", () => {
+      const result = parsePURL("pkg:npm/lodash#some/path");
       expect(result).toEqual({
-        type: 'npm',
-        namespace: '',
-        name: 'lodash',
-        version: '',
+        type: "npm",
+        namespace: "",
+        name: "lodash",
+        version: "",
         qualifiers: {},
-        subpath: 'some/path',
-      })
-    })
+        subpath: "some/path",
+      });
+    });
 
-    it('parses PURL with all components', () => {
-      const result = parsePURL('pkg:npm/%40babel/core@7.0.0?arch=x86_64#lib/index.js')
+    it("parses PURL with all components", () => {
+      const result = parsePURL("pkg:npm/%40babel/core@7.0.0?arch=x86_64#lib/index.js");
       expect(result).toEqual({
-        type: 'npm',
-        namespace: '@babel',
-        name: 'core',
-        version: '7.0.0',
+        type: "npm",
+        namespace: "@babel",
+        name: "core",
+        version: "7.0.0",
         qualifiers: {
-          arch: 'x86_64',
+          arch: "x86_64",
         },
-        subpath: 'lib/index.js',
-      })
-    })
+        subpath: "lib/index.js",
+      });
+    });
 
-    it('normalizes PyPI package names', () => {
-      const result = parsePURL('pkg:pypi/My_Package')
-      expect(result.name).toBe('my-package')
-    })
+    it("normalizes PyPI package names", () => {
+      const result = parsePURL("pkg:pypi/My_Package");
+      expect(result.name).toBe("my-package");
+    });
 
-    it('normalizes PyPI package names with version', () => {
-      const result = parsePURL('pkg:pypi/Django_REST_Framework@3.14.0')
-      expect(result.name).toBe('django-rest-framework')
-      expect(result.version).toBe('3.14.0')
-    })
+    it("normalizes PyPI package names with version", () => {
+      const result = parsePURL("pkg:pypi/Django_REST_Framework@3.14.0");
+      expect(result.name).toBe("django-rest-framework");
+      expect(result.version).toBe("3.14.0");
+    });
 
-    it('throws on missing pkg: prefix', () => {
-      expect(() => parsePURL('npm/lodash')).toThrow(InvalidPURLError)
-      expect(() => parsePURL('npm/lodash')).toThrow('must start with "pkg:"')
-    })
+    it("throws on missing pkg: prefix", () => {
+      expect(() => parsePURL("npm/lodash")).toThrow(InvalidPURLError);
+      expect(() => parsePURL("npm/lodash")).toThrow('must start with "pkg:"');
+    });
 
-    it('throws on missing type/name separator', () => {
-      expect(() => parsePURL('pkg:lodash')).toThrow(InvalidPURLError)
-      expect(() => parsePURL('pkg:lodash')).toThrow('missing type/name separator')
-    })
+    it("throws on missing type/name separator", () => {
+      expect(() => parsePURL("pkg:lodash")).toThrow(InvalidPURLError);
+      expect(() => parsePURL("pkg:lodash")).toThrow("missing type/name separator");
+    });
 
-    it('throws on empty type', () => {
-      expect(() => parsePURL('pkg:/lodash')).toThrow(InvalidPURLError)
-      expect(() => parsePURL('pkg:/lodash')).toThrow('empty type')
-    })
+    it("throws on empty type", () => {
+      expect(() => parsePURL("pkg:/lodash")).toThrow(InvalidPURLError);
+      expect(() => parsePURL("pkg:/lodash")).toThrow("empty type");
+    });
 
-    it('throws on empty name', () => {
-      expect(() => parsePURL('pkg:npm/')).toThrow(InvalidPURLError)
-      expect(() => parsePURL('pkg:npm/')).toThrow('empty name')
-    })
+    it("throws on empty name", () => {
+      expect(() => parsePURL("pkg:npm/")).toThrow(InvalidPURLError);
+      expect(() => parsePURL("pkg:npm/")).toThrow("empty name");
+    });
 
-    it('decodes URL-encoded components', () => {
-      const result = parsePURL('pkg:npm/my%20package@1.0.0')
-      expect(result.name).toBe('my package')
-      expect(result.version).toBe('1.0.0')
-    })
+    it("decodes URL-encoded components", () => {
+      const result = parsePURL("pkg:npm/my%20package@1.0.0");
+      expect(result.name).toBe("my package");
+      expect(result.version).toBe("1.0.0");
+    });
 
-    it('lowercases type', () => {
-      const result = parsePURL('pkg:NPM/lodash')
-      expect(result.type).toBe('npm')
-    })
-  })
+    it("lowercases type", () => {
+      const result = parsePURL("pkg:NPM/lodash");
+      expect(result.type).toBe("npm");
+    });
+  });
 
-  describe('fullName', () => {
-    it('returns name without namespace', () => {
-      const parsed = parsePURL('pkg:npm/lodash')
-      expect(fullName(parsed)).toBe('lodash')
-    })
+  describe("fullName", () => {
+    it("returns name without namespace", () => {
+      const parsed = parsePURL("pkg:npm/lodash");
+      expect(fullName(parsed)).toBe("lodash");
+    });
 
-    it('returns scoped name with namespace', () => {
-      const parsed = parsePURL('pkg:npm/%40babel/core')
-      expect(fullName(parsed)).toBe('@babel/core')
-    })
+    it("returns scoped name with namespace", () => {
+      const parsed = parsePURL("pkg:npm/%40babel/core");
+      expect(fullName(parsed)).toBe("@babel/core");
+    });
 
-    it('handles custom namespace', () => {
-      const parsed = parsePURL('pkg:npm/%40myorg/mylib')
-      expect(fullName(parsed)).toBe('@myorg/mylib')
-    })
-  })
+    it("handles custom namespace", () => {
+      const parsed = parsePURL("pkg:npm/%40myorg/mylib");
+      expect(fullName(parsed)).toBe("@myorg/mylib");
+    });
+  });
 
-  describe('buildPURL', () => {
-    it('builds simple PURL', () => {
-      expect(buildPURL({ type: 'npm', name: 'lodash' })).toBe('pkg:npm/lodash')
-    })
+  describe("buildPURL", () => {
+    it("builds simple PURL", () => {
+      expect(buildPURL({ type: "npm", name: "lodash" })).toBe("pkg:npm/lodash");
+    });
 
-    it('builds PURL with version', () => {
-      expect(buildPURL({ type: 'npm', name: 'lodash', version: '4.17.21' })).toBe('pkg:npm/lodash@4.17.21')
-    })
+    it("builds PURL with version", () => {
+      expect(buildPURL({ type: "npm", name: "lodash", version: "4.17.21" })).toBe(
+        "pkg:npm/lodash@4.17.21",
+      );
+    });
 
-    it('builds PURL with namespace', () => {
-      expect(buildPURL({ type: 'npm', name: 'core', version: '7.0.0', namespace: '@babel' })).toBe('pkg:npm/%40babel/core@7.0.0')
-    })
+    it("builds PURL with namespace", () => {
+      expect(buildPURL({ type: "npm", name: "core", version: "7.0.0", namespace: "@babel" })).toBe(
+        "pkg:npm/%40babel/core@7.0.0",
+      );
+    });
 
-    it('encodes special characters in name', () => {
-      expect(buildPURL({ type: 'npm', name: 'my package' })).toBe('pkg:npm/my%20package')
-    })
+    it("encodes special characters in name", () => {
+      expect(buildPURL({ type: "npm", name: "my package" })).toBe("pkg:npm/my%20package");
+    });
 
-    it('encodes special characters in namespace', () => {
-      expect(buildPURL({ type: 'npm', name: 'core', namespace: '@my org' })).toBe('pkg:npm/%40my%20org/core')
-    })
+    it("encodes special characters in namespace", () => {
+      expect(buildPURL({ type: "npm", name: "core", namespace: "@my org" })).toBe(
+        "pkg:npm/%40my%20org/core",
+      );
+    });
 
-    it('encodes special characters in version', () => {
-      expect(buildPURL({ type: 'npm', name: 'lodash', version: '1.0.0+build.123' })).toBe('pkg:npm/lodash@1.0.0%2Bbuild.123')
-    })
+    it("encodes special characters in version", () => {
+      expect(buildPURL({ type: "npm", name: "lodash", version: "1.0.0+build.123" })).toBe(
+        "pkg:npm/lodash@1.0.0%2Bbuild.123",
+      );
+    });
 
-    it('builds PURL with qualifiers', () => {
-      expect(buildPURL({ type: 'npm', name: 'lodash', version: '4.17.21', qualifiers: { repository_url: 'https://custom.registry.com' } }))
-        .toBe('pkg:npm/lodash@4.17.21?repository_url=https%3A%2F%2Fcustom.registry.com')
-    })
+    it("builds PURL with qualifiers", () => {
+      expect(
+        buildPURL({
+          type: "npm",
+          name: "lodash",
+          version: "4.17.21",
+          qualifiers: { repository_url: "https://custom.registry.com" },
+        }),
+      ).toBe("pkg:npm/lodash@4.17.21?repository_url=https%3A%2F%2Fcustom.registry.com");
+    });
 
-    it('builds PURL with multiple qualifiers', () => {
-      expect(buildPURL({ type: 'npm', name: 'lodash', qualifiers: { arch: 'x86_64', os: 'linux' } }))
-        .toBe('pkg:npm/lodash?arch=x86_64&os=linux')
-    })
+    it("builds PURL with multiple qualifiers", () => {
+      expect(
+        buildPURL({ type: "npm", name: "lodash", qualifiers: { arch: "x86_64", os: "linux" } }),
+      ).toBe("pkg:npm/lodash?arch=x86_64&os=linux");
+    });
 
-    it('builds PURL with subpath', () => {
-      expect(buildPURL({ type: 'npm', name: 'lodash', subpath: 'lib/index.js' }))
-        .toBe('pkg:npm/lodash#lib/index.js')
-    })
+    it("builds PURL with subpath", () => {
+      expect(buildPURL({ type: "npm", name: "lodash", subpath: "lib/index.js" })).toBe(
+        "pkg:npm/lodash#lib/index.js",
+      );
+    });
 
-    it('builds PURL with all components', () => {
-      expect(buildPURL({ type: 'npm', name: 'core', version: '7.0.0', namespace: '@babel', qualifiers: { arch: 'x86_64' }, subpath: 'lib/index.js' }))
-        .toBe('pkg:npm/%40babel/core@7.0.0?arch=x86_64#lib/index.js')
-    })
+    it("builds PURL with all components", () => {
+      expect(
+        buildPURL({
+          type: "npm",
+          name: "core",
+          version: "7.0.0",
+          namespace: "@babel",
+          qualifiers: { arch: "x86_64" },
+          subpath: "lib/index.js",
+        }),
+      ).toBe("pkg:npm/%40babel/core@7.0.0?arch=x86_64#lib/index.js");
+    });
 
-    it('skips empty qualifiers object', () => {
-      expect(buildPURL({ type: 'npm', name: 'lodash', version: '1.0.0', qualifiers: {} }))
-        .toBe('pkg:npm/lodash@1.0.0')
-    })
+    it("skips empty qualifiers object", () => {
+      expect(buildPURL({ type: "npm", name: "lodash", version: "1.0.0", qualifiers: {} })).toBe(
+        "pkg:npm/lodash@1.0.0",
+      );
+    });
 
-    it('round-trips a simple PURL through parsePURL', () => {
-      const original = 'pkg:npm/lodash'
-      expect(buildPURL(parsePURL(original))).toBe(original)
-    })
+    it("round-trips a simple PURL through parsePURL", () => {
+      const original = "pkg:npm/lodash";
+      expect(buildPURL(parsePURL(original))).toBe(original);
+    });
 
-    it('round-trips a versioned PURL', () => {
-      const original = 'pkg:cargo/serde@1.0.0'
-      expect(buildPURL(parsePURL(original))).toBe(original)
-    })
+    it("round-trips a versioned PURL", () => {
+      const original = "pkg:cargo/serde@1.0.0";
+      expect(buildPURL(parsePURL(original))).toBe(original);
+    });
 
-    it('round-trips a scoped PURL', () => {
-      const original = 'pkg:npm/%40babel/core@7.0.0'
-      expect(buildPURL(parsePURL(original))).toBe(original)
-    })
+    it("round-trips a scoped PURL", () => {
+      const original = "pkg:npm/%40babel/core@7.0.0";
+      expect(buildPURL(parsePURL(original))).toBe(original);
+    });
 
-    it('round-trips a PURL with qualifiers', () => {
-      const original = 'pkg:npm/lodash?repository_url=https%3A%2F%2Fcustom.registry.com'
-      expect(buildPURL(parsePURL(original))).toBe(original)
-    })
+    it("round-trips a PURL with qualifiers", () => {
+      const original = "pkg:npm/lodash?repository_url=https%3A%2F%2Fcustom.registry.com";
+      expect(buildPURL(parsePURL(original))).toBe(original);
+    });
 
-    it('round-trips a PURL with subpath', () => {
-      const original = 'pkg:npm/lodash#lib/index.js'
-      expect(buildPURL(parsePURL(original))).toBe(original)
-    })
+    it("round-trips a PURL with subpath", () => {
+      const original = "pkg:npm/lodash#lib/index.js";
+      expect(buildPURL(parsePURL(original))).toBe(original);
+    });
 
-    it('round-trips a full PURL with all components', () => {
-      const original = 'pkg:npm/%40babel/core@7.0.0?arch=x86_64#lib/index.js'
-      expect(buildPURL(parsePURL(original))).toBe(original)
-    })
-  })
-})
+    it("round-trips a full PURL with all components", () => {
+      const original = "pkg:npm/%40babel/core@7.0.0?arch=x86_64#lib/index.js";
+      expect(buildPURL(parsePURL(original))).toBe(original);
+    });
+  });
+});

--- a/test/unit/registries.test.ts
+++ b/test/unit/registries.test.ts
@@ -1,143 +1,144 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { Client } from '../../src/core/client.ts'
-import { NotFoundError, HTTPError } from '../../src/core/errors.ts'
-import { create } from '../../src/core/registry.ts'
-import '../../src/registries/index.ts'
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Client } from "../../src/core/client.ts";
+import { NotFoundError, HTTPError } from "../../src/core/errors.ts";
+import { create } from "../../src/core/registry.ts";
+import "../../src/registries/index.ts";
 
-describe('Registry Modules', () => {
+describe("Registry Modules", () => {
   beforeEach(() => {
-    vi.clearAllMocks()
-  })
+    vi.clearAllMocks();
+  });
 
   afterEach(() => {
-    vi.restoreAllMocks()
-  })
+    vi.restoreAllMocks();
+  });
 
-  describe('npm registry', () => {
-    it('should fetch and normalize npm package', async () => {
-      const client = new Client()
+  describe("npm registry", () => {
+    it("should fetch and normalize npm package", async () => {
+      const client = new Client();
       const mockResponse = {
-        name: 'lodash',
-        description: 'Lodash modular utilities.',
-        homepage: 'https://lodash.com/',
+        name: "lodash",
+        description: "Lodash modular utilities.",
+        homepage: "https://lodash.com/",
         repository: {
-          type: 'git',
-          url: 'https://github.com/lodash/lodash.git',
+          type: "git",
+          url: "https://github.com/lodash/lodash.git",
         },
-        license: 'MIT',
-        keywords: ['util', 'functional', 'server', 'client', 'browser'],
-        'dist-tags': {
-          latest: '4.17.21',
+        license: "MIT",
+        keywords: ["util", "functional", "server", "client", "browser"],
+        "dist-tags": {
+          latest: "4.17.21",
         },
         versions: {
-          '4.17.21': {
-            name: 'lodash',
-            version: '4.17.21',
-            license: 'MIT',
+          "4.17.21": {
+            name: "lodash",
+            version: "4.17.21",
+            license: "MIT",
             dist: {
-              integrity: 'sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XAx56XwKQ==',
-              shasum: '679591c564c3bffaae8164502b8503b4cc5ae34e',
-              tarball: 'https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz',
+              integrity:
+                "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XAx56XwKQ==",
+              shasum: "679591c564c3bffaae8164502b8503b4cc5ae34e",
+              tarball: "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             },
           },
         },
         time: {
-          '4.17.21': '2021-02-17T17:30:39.963Z',
+          "4.17.21": "2021-02-17T17:30:39.963Z",
         },
-      }
+      };
 
-      vi.spyOn(client, 'getJSON').mockResolvedValueOnce(mockResponse)
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(mockResponse);
 
-      const registry = create('npm', undefined, client)
-      const pkg = await registry.fetchPackage('lodash')
+      const registry = create("npm", undefined, client);
+      const pkg = await registry.fetchPackage("lodash");
 
-      expect(pkg.name).toBe('lodash')
-      expect(pkg.description).toBe('Lodash modular utilities.')
-      expect(pkg.licenses).toBe('MIT')
-      expect(pkg.repository).toContain('github.com/lodash/lodash')
-      expect(pkg.keywords).toContain('util')
-      expect(pkg.latestVersion).toBe('4.17.21')
-      expect(pkg.namespace).toBe('')
-    })
+      expect(pkg.name).toBe("lodash");
+      expect(pkg.description).toBe("Lodash modular utilities.");
+      expect(pkg.licenses).toBe("MIT");
+      expect(pkg.repository).toContain("github.com/lodash/lodash");
+      expect(pkg.keywords).toContain("util");
+      expect(pkg.latestVersion).toBe("4.17.21");
+      expect(pkg.namespace).toBe("");
+    });
 
-    it('should throw NotFoundError for missing npm package', async () => {
-      const client = new Client()
+    it("should throw NotFoundError for missing npm package", async () => {
+      const client = new Client();
 
-      vi.spyOn(client, 'getJSON').mockRejectedValueOnce(
-              new HTTPError(404, 'https://mock/not-found', 'Not Found')
-            )
+      vi.spyOn(client, "getJSON").mockRejectedValueOnce(
+        new HTTPError(404, "https://mock/not-found", "Not Found"),
+      );
 
-      const registry = create('npm', undefined, client)
+      const registry = create("npm", undefined, client);
 
-      await expect(registry.fetchPackage('nonexistent-package-xyz')).rejects.toThrow(
-        NotFoundError
-      )
-    })
+      await expect(registry.fetchPackage("nonexistent-package-xyz")).rejects.toThrow(NotFoundError);
+    });
 
-    it('should fetch npm versions with integrity hashes', async () => {
-      const client = new Client()
+    it("should fetch npm versions with integrity hashes", async () => {
+      const client = new Client();
       const mockResponse = {
-        name: 'lodash',
-        'dist-tags': {
-          latest: '4.17.21',
+        name: "lodash",
+        "dist-tags": {
+          latest: "4.17.21",
         },
         versions: {
-          '4.17.20': {
-            name: 'lodash',
-            version: '4.17.20',
+          "4.17.20": {
+            name: "lodash",
+            version: "4.17.20",
             dist: {
-              integrity: 'sha512-xHjhDr3cJBLUHRv7T7XcUVwrExis2P9KqLDcWQcYNyX4hD0e6lSuQkluyU9OY+bOj7wCZDDu4BDxAstd3/cFTw==',
-              shasum: '718870b8574a11dba7a37366a8e154136f529c0f',
+              integrity:
+                "sha512-xHjhDr3cJBLUHRv7T7XcUVwrExis2P9KqLDcWQcYNyX4hD0e6lSuQkluyU9OY+bOj7wCZDDu4BDxAstd3/cFTw==",
+              shasum: "718870b8574a11dba7a37366a8e154136f529c0f",
             },
           },
-          '4.17.21': {
-            name: 'lodash',
-            version: '4.17.21',
+          "4.17.21": {
+            name: "lodash",
+            version: "4.17.21",
             dist: {
-              integrity: 'sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XAx56XwKQ==',
-              shasum: '679591c564c3bffaae8164502b8503b4cc5ae34e',
+              integrity:
+                "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XAx56XwKQ==",
+              shasum: "679591c564c3bffaae8164502b8503b4cc5ae34e",
             },
             deprecated: false,
           },
         },
         time: {
-          '4.17.20': '2021-02-15T10:00:00.000Z',
-          '4.17.21': '2021-02-17T17:30:39.963Z',
+          "4.17.20": "2021-02-15T10:00:00.000Z",
+          "4.17.21": "2021-02-17T17:30:39.963Z",
         },
-      }
+      };
 
-      vi.spyOn(client, 'getJSON').mockResolvedValueOnce(mockResponse)
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(mockResponse);
 
-      const registry = create('npm', undefined, client)
-      const versions = await registry.fetchVersions('lodash')
+      const registry = create("npm", undefined, client);
+      const versions = await registry.fetchVersions("lodash");
 
-      expect(versions).toHaveLength(2)
-      expect(versions[0].number).toBe('4.17.20')
-      expect(versions[0].integrity).toContain('sha512')
-      expect(versions[1].number).toBe('4.17.21')
-      expect(versions[1].status).toBe('')
-    })
-  })
+      expect(versions).toHaveLength(2);
+      expect(versions[0].number).toBe("4.17.20");
+      expect(versions[0].integrity).toContain("sha512");
+      expect(versions[1].number).toBe("4.17.21");
+      expect(versions[1].status).toBe("");
+    });
+  });
 
-  describe('cargo registry', () => {
-    it('should fetch and normalize cargo crate', async () => {
-      const client = new Client()
+  describe("cargo registry", () => {
+    it("should fetch and normalize cargo crate", async () => {
+      const client = new Client();
       const mockResponse = {
         crate: {
           id: 1,
-          name: 'serde',
-          updated_at: '2024-01-15T10:00:00Z',
-          created_at: '2014-12-20T02:35:07Z',
+          name: "serde",
+          updated_at: "2024-01-15T10:00:00Z",
+          created_at: "2014-12-20T02:35:07Z",
           downloads: 500000000,
           recent_downloads: 5000000,
-          max_version: '1.0.197',
-          max_stable_version: '1.0.197',
-          newest_version: '1.0.197',
-          description: 'A generic serialization/deserialization framework',
-          homepage: 'https://serde.rs',
-          documentation: 'https://docs.rs/serde',
-          repository: 'https://github.com/serde-rs/serde',
-          keywords: ['serialization', 'deserialization'],
+          max_version: "1.0.197",
+          max_stable_version: "1.0.197",
+          newest_version: "1.0.197",
+          description: "A generic serialization/deserialization framework",
+          homepage: "https://serde.rs",
+          documentation: "https://docs.rs/serde",
+          repository: "https://github.com/serde-rs/serde",
+          keywords: ["serialization", "deserialization"],
           categories: [],
           badges: [],
           links: {},
@@ -145,79 +146,77 @@ describe('Registry Modules', () => {
         versions: [
           {
             id: 1,
-            num: '1.0.197',
-            dl_path: '/api/v1/crates/serde/1.0.197/download',
-            readme_path: '/api/v1/crates/serde/1.0.197/readme',
-            created_at: '2024-01-15T10:00:00Z',
-            updated_at: '2024-01-15T10:00:00Z',
+            num: "1.0.197",
+            dl_path: "/api/v1/crates/serde/1.0.197/download",
+            readme_path: "/api/v1/crates/serde/1.0.197/readme",
+            created_at: "2024-01-15T10:00:00Z",
+            updated_at: "2024-01-15T10:00:00Z",
             downloads: 50000000,
             features: {},
             yanked: false,
-            license: 'MIT OR Apache-2.0',
+            license: "MIT OR Apache-2.0",
             links: {},
             crate_size: 100000,
             published_by: {
               id: 1,
-              login: 'dtolnay',
-              name: 'David Tolnay',
-              avatar: 'https://avatars.githubusercontent.com/u/1617736?v=4',
-              url: 'https://github.com/dtolnay',
+              login: "dtolnay",
+              name: "David Tolnay",
+              avatar: "https://avatars.githubusercontent.com/u/1617736?v=4",
+              url: "https://github.com/dtolnay",
             },
-            checksum: 'abc123def456',
+            checksum: "abc123def456",
           },
         ],
-      }
+      };
 
-      vi.spyOn(client, 'getJSON').mockResolvedValueOnce(mockResponse)
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(mockResponse);
 
-      const registry = create('cargo', undefined, client)
-      const pkg = await registry.fetchPackage('serde')
+      const registry = create("cargo", undefined, client);
+      const pkg = await registry.fetchPackage("serde");
 
-      expect(pkg.name).toBe('serde')
-      expect(pkg.description).toBe('A generic serialization/deserialization framework')
-      expect(pkg.repository).toContain('github.com/serde-rs/serde')
-      expect(pkg.latestVersion).toBe('1.0.197')
-      expect(pkg.keywords).toContain('serialization')
-      expect(pkg.namespace).toBe('')
-      expect(pkg.documentation).toBe('https://docs.rs/serde')
-      expect(pkg.metadata.downloads).toBe(500000000)
-      expect(pkg.metadata.recentDownloads).toBe(5000000)
-      expect(pkg.metadata.newestVersion).toBe('1.0.197')
-      expect(pkg.metadata.updatedAt).toBe('2024-01-15T10:00:00Z')
-      expect(pkg.metadata.createdAt).toBe('2014-12-20T02:35:07Z')
-    })
+      expect(pkg.name).toBe("serde");
+      expect(pkg.description).toBe("A generic serialization/deserialization framework");
+      expect(pkg.repository).toContain("github.com/serde-rs/serde");
+      expect(pkg.latestVersion).toBe("1.0.197");
+      expect(pkg.keywords).toContain("serialization");
+      expect(pkg.namespace).toBe("");
+      expect(pkg.documentation).toBe("https://docs.rs/serde");
+      expect(pkg.metadata.downloads).toBe(500000000);
+      expect(pkg.metadata.recentDownloads).toBe(5000000);
+      expect(pkg.metadata.newestVersion).toBe("1.0.197");
+      expect(pkg.metadata.updatedAt).toBe("2024-01-15T10:00:00Z");
+      expect(pkg.metadata.createdAt).toBe("2014-12-20T02:35:07Z");
+    });
 
-    it('should throw NotFoundError for missing cargo crate', async () => {
-      const client = new Client()
+    it("should throw NotFoundError for missing cargo crate", async () => {
+      const client = new Client();
 
-      vi.spyOn(client, 'getJSON').mockRejectedValueOnce(
-              new HTTPError(404, 'https://mock/not-found', 'Not Found')
-            )
+      vi.spyOn(client, "getJSON").mockRejectedValueOnce(
+        new HTTPError(404, "https://mock/not-found", "Not Found"),
+      );
 
-      const registry = create('cargo', undefined, client)
+      const registry = create("cargo", undefined, client);
 
-      await expect(registry.fetchPackage('nonexistent-crate-xyz')).rejects.toThrow(
-        NotFoundError
-      )
-    })
+      await expect(registry.fetchPackage("nonexistent-crate-xyz")).rejects.toThrow(NotFoundError);
+    });
 
-    it('should fetch cargo versions with yanked status', async () => {
-      const client = new Client()
+    it("should fetch cargo versions with yanked status", async () => {
+      const client = new Client();
       const mockResponse = {
         crate: {
           id: 1,
-          name: 'serde',
-          updated_at: '2024-01-15T10:00:00Z',
-          created_at: '2014-12-20T02:35:07Z',
+          name: "serde",
+          updated_at: "2024-01-15T10:00:00Z",
+          created_at: "2014-12-20T02:35:07Z",
           downloads: 500000000,
           recent_downloads: 5000000,
-          max_version: '1.0.197',
-          max_stable_version: '1.0.197',
-          newest_version: '1.0.197',
-          description: 'A generic serialization/deserialization framework',
-          homepage: 'https://serde.rs',
-          documentation: 'https://docs.rs/serde',
-          repository: 'https://github.com/serde-rs/serde',
+          max_version: "1.0.197",
+          max_stable_version: "1.0.197",
+          newest_version: "1.0.197",
+          description: "A generic serialization/deserialization framework",
+          homepage: "https://serde.rs",
+          documentation: "https://docs.rs/serde",
+          repository: "https://github.com/serde-rs/serde",
           keywords: [],
           categories: [],
           badges: [],
@@ -226,475 +225,469 @@ describe('Registry Modules', () => {
         versions: [
           {
             id: 1,
-            num: '1.0.196',
-            dl_path: '/api/v1/crates/serde/1.0.196/download',
-            readme_path: '/api/v1/crates/serde/1.0.196/readme',
-            created_at: '2024-01-10T10:00:00Z',
-            updated_at: '2024-01-10T10:00:00Z',
+            num: "1.0.196",
+            dl_path: "/api/v1/crates/serde/1.0.196/download",
+            readme_path: "/api/v1/crates/serde/1.0.196/readme",
+            created_at: "2024-01-10T10:00:00Z",
+            updated_at: "2024-01-10T10:00:00Z",
             downloads: 40000000,
             features: {},
             yanked: true,
-            license: 'MIT OR Apache-2.0',
+            license: "MIT OR Apache-2.0",
             links: {},
             crate_size: 100000,
             published_by: {
               id: 1,
-              login: 'dtolnay',
-              name: 'David Tolnay',
-              avatar: 'https://avatars.githubusercontent.com/u/1617736?v=4',
-              url: 'https://github.com/dtolnay',
+              login: "dtolnay",
+              name: "David Tolnay",
+              avatar: "https://avatars.githubusercontent.com/u/1617736?v=4",
+              url: "https://github.com/dtolnay",
             },
-            checksum: 'abc123def455',
+            checksum: "abc123def455",
           },
           {
             id: 2,
-            num: '1.0.197',
-            dl_path: '/api/v1/crates/serde/1.0.197/download',
-            readme_path: '/api/v1/crates/serde/1.0.197/readme',
-            created_at: '2024-01-15T10:00:00Z',
-            updated_at: '2024-01-15T10:00:00Z',
+            num: "1.0.197",
+            dl_path: "/api/v1/crates/serde/1.0.197/download",
+            readme_path: "/api/v1/crates/serde/1.0.197/readme",
+            created_at: "2024-01-15T10:00:00Z",
+            updated_at: "2024-01-15T10:00:00Z",
             downloads: 50000000,
             features: {},
             yanked: false,
-            license: 'MIT OR Apache-2.0',
+            license: "MIT OR Apache-2.0",
             links: {},
             crate_size: 100000,
             published_by: {
               id: 1,
-              login: 'dtolnay',
-              name: 'David Tolnay',
-              avatar: 'https://avatars.githubusercontent.com/u/1617736?v=4',
-              url: 'https://github.com/dtolnay',
+              login: "dtolnay",
+              name: "David Tolnay",
+              avatar: "https://avatars.githubusercontent.com/u/1617736?v=4",
+              url: "https://github.com/dtolnay",
             },
-            checksum: 'abc123def456',
+            checksum: "abc123def456",
           },
         ],
-      }
+      };
 
-      vi.spyOn(client, 'getJSON').mockResolvedValueOnce(mockResponse)
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(mockResponse);
 
-      const registry = create('cargo', undefined, client)
-      const versions = await registry.fetchVersions('serde')
+      const registry = create("cargo", undefined, client);
+      const versions = await registry.fetchVersions("serde");
 
-      expect(versions).toHaveLength(2)
-      expect(versions[0].number).toBe('1.0.196')
-      expect(versions[0].status).toBe('yanked')
-      expect(versions[0].integrity).toContain('sha256')
-      expect(versions[1].number).toBe('1.0.197')
-      expect(versions[1].status).toBe('')
-      expect(versions[0].metadata.crateSize).toBe(100000)
-      expect(versions[0].metadata.downloads).toBe(40000000)
-      expect(versions[1].metadata.crateSize).toBe(100000)
-    })
-  })
+      expect(versions).toHaveLength(2);
+      expect(versions[0].number).toBe("1.0.196");
+      expect(versions[0].status).toBe("yanked");
+      expect(versions[0].integrity).toContain("sha256");
+      expect(versions[1].number).toBe("1.0.197");
+      expect(versions[1].status).toBe("");
+      expect(versions[0].metadata.crateSize).toBe(100000);
+      expect(versions[0].metadata.downloads).toBe(40000000);
+      expect(versions[1].metadata.crateSize).toBe(100000);
+    });
+  });
 
-  describe('pypi registry', () => {
-    it('should fetch and normalize pypi package', async () => {
-      const client = new Client()
+  describe("pypi registry", () => {
+    it("should fetch and normalize pypi package", async () => {
+      const client = new Client();
       const mockResponse = {
         info: {
-          name: 'requests',
-          version: '2.31.0',
-          summary: 'Python HTTP for Humans.',
-          description: 'Requests is a simple, yet elegant, HTTP library.',
-          license: 'Apache 2.0',
-          keywords: 'requests, urllib, httplib',
-          author: 'Kenneth Reitz',
-          author_email: 'me@kennethreitz.org',
+          name: "requests",
+          version: "2.31.0",
+          summary: "Python HTTP for Humans.",
+          description: "Requests is a simple, yet elegant, HTTP library.",
+          license: "Apache 2.0",
+          keywords: "requests, urllib, httplib",
+          author: "Kenneth Reitz",
+          author_email: "me@kennethreitz.org",
           project_urls: {
-            Homepage: 'https://requests.readthedocs.io',
-            'Source Code': 'https://github.com/psf/requests',
-            Documentation: 'https://requests.readthedocs.io',
+            Homepage: "https://requests.readthedocs.io",
+            "Source Code": "https://github.com/psf/requests",
+            Documentation: "https://requests.readthedocs.io",
           },
           requires_dist: [
-            'charset-normalizer (<4,>=2)',
-            'idna (<4,>=2.5)',
-            'urllib3 (<3,>=1.21.1)',
-            'certifi (>=2017.4.17)',
+            "charset-normalizer (<4,>=2)",
+            "idna (<4,>=2.5)",
+            "urllib3 (<3,>=1.21.1)",
+            "certifi (>=2017.4.17)",
           ],
         },
         releases: {
-          '2.30.0': [
+          "2.30.0": [
             {
-              filename: 'requests-2.30.0-py3-none-any.whl',
-              url: 'https://files.pythonhosted.org/packages/requests-2.30.0-py3-none-any.whl',
-              upload_time_iso_8601: '2023-05-15T10:00:00Z',
+              filename: "requests-2.30.0-py3-none-any.whl",
+              url: "https://files.pythonhosted.org/packages/requests-2.30.0-py3-none-any.whl",
+              upload_time_iso_8601: "2023-05-15T10:00:00Z",
               yanked: false,
               digests: {
-                sha256: 'abc123def456',
+                sha256: "abc123def456",
               },
             },
           ],
-          '2.31.0': [
+          "2.31.0": [
             {
-              filename: 'requests-2.31.0-py3-none-any.whl',
-              url: 'https://files.pythonhosted.org/packages/requests-2.31.0-py3-none-any.whl',
-              upload_time_iso_8601: '2023-10-15T10:00:00Z',
+              filename: "requests-2.31.0-py3-none-any.whl",
+              url: "https://files.pythonhosted.org/packages/requests-2.31.0-py3-none-any.whl",
+              upload_time_iso_8601: "2023-10-15T10:00:00Z",
               yanked: false,
               digests: {
-                sha256: 'def456ghi789',
+                sha256: "def456ghi789",
               },
             },
           ],
         },
         urls: [],
-      }
+      };
 
-      vi.spyOn(client, 'getJSON').mockResolvedValueOnce(mockResponse)
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(mockResponse);
 
-      const registry = create('pypi', undefined, client)
-      const pkg = await registry.fetchPackage('requests')
+      const registry = create("pypi", undefined, client);
+      const pkg = await registry.fetchPackage("requests");
 
-      expect(pkg.name).toBe('requests')
-      expect(pkg.description).toContain('Python HTTP')
-      expect(pkg.licenses).toBe('Apache-2.0')
-      expect(pkg.repository).toContain('github.com/psf/requests')
-      expect(pkg.latestVersion).toBe('2.31.0')
-      expect(pkg.namespace).toBe('')
-      expect(pkg.documentation).toBe('https://requests.readthedocs.io')
-    })
+      expect(pkg.name).toBe("requests");
+      expect(pkg.description).toContain("Python HTTP");
+      expect(pkg.licenses).toBe("Apache-2.0");
+      expect(pkg.repository).toContain("github.com/psf/requests");
+      expect(pkg.latestVersion).toBe("2.31.0");
+      expect(pkg.namespace).toBe("");
+      expect(pkg.documentation).toBe("https://requests.readthedocs.io");
+    });
 
-    it('should throw NotFoundError for missing pypi package', async () => {
-      const client = new Client()
+    it("should throw NotFoundError for missing pypi package", async () => {
+      const client = new Client();
 
-      vi.spyOn(client, 'getJSON').mockRejectedValueOnce(
-              new HTTPError(404, 'https://mock/not-found', 'Not Found')
-            )
+      vi.spyOn(client, "getJSON").mockRejectedValueOnce(
+        new HTTPError(404, "https://mock/not-found", "Not Found"),
+      );
 
-      const registry = create('pypi', undefined, client)
+      const registry = create("pypi", undefined, client);
 
-      await expect(registry.fetchPackage('nonexistent-package-xyz')).rejects.toThrow(
-        NotFoundError
-      )
-    })
+      await expect(registry.fetchPackage("nonexistent-package-xyz")).rejects.toThrow(NotFoundError);
+    });
 
-    it('should fetch pypi versions with yanked status', async () => {
-      const client = new Client()
+    it("should fetch pypi versions with yanked status", async () => {
+      const client = new Client();
       const mockResponse = {
         info: {
-          name: 'requests',
-          version: '2.31.0',
-          summary: 'Python HTTP for Humans.',
-          description: 'Requests is a simple, yet elegant, HTTP library.',
-          license: 'Apache 2.0',
-          keywords: 'requests, urllib, httplib',
-          author: 'Kenneth Reitz',
-          author_email: 'me@kennethreitz.org',
+          name: "requests",
+          version: "2.31.0",
+          summary: "Python HTTP for Humans.",
+          description: "Requests is a simple, yet elegant, HTTP library.",
+          license: "Apache 2.0",
+          keywords: "requests, urllib, httplib",
+          author: "Kenneth Reitz",
+          author_email: "me@kennethreitz.org",
           project_urls: {
-            Homepage: 'https://requests.readthedocs.io',
+            Homepage: "https://requests.readthedocs.io",
           },
           requires_dist: null,
         },
         releases: {
-          '2.30.0': [
+          "2.30.0": [
             {
-              filename: 'requests-2.30.0-py3-none-any.whl',
-              url: 'https://files.pythonhosted.org/packages/requests-2.30.0-py3-none-any.whl',
-              upload_time_iso_8601: '2023-05-15T10:00:00Z',
+              filename: "requests-2.30.0-py3-none-any.whl",
+              url: "https://files.pythonhosted.org/packages/requests-2.30.0-py3-none-any.whl",
+              upload_time_iso_8601: "2023-05-15T10:00:00Z",
               yanked: false,
               digests: {
-                sha256: 'abc123def456',
+                sha256: "abc123def456",
               },
             },
           ],
-          '2.31.0': [
+          "2.31.0": [
             {
-              filename: 'requests-2.31.0-py3-none-any.whl',
-              url: 'https://files.pythonhosted.org/packages/requests-2.31.0-py3-none-any.whl',
-              upload_time_iso_8601: '2023-10-15T10:00:00Z',
+              filename: "requests-2.31.0-py3-none-any.whl",
+              url: "https://files.pythonhosted.org/packages/requests-2.31.0-py3-none-any.whl",
+              upload_time_iso_8601: "2023-10-15T10:00:00Z",
               yanked: true,
               digests: {
-                sha256: 'def456ghi789',
+                sha256: "def456ghi789",
               },
             },
           ],
         },
         urls: [],
-      }
+      };
 
-      vi.spyOn(client, 'getJSON').mockResolvedValueOnce(mockResponse)
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(mockResponse);
 
-      const registry = create('pypi', undefined, client)
-      const versions = await registry.fetchVersions('requests')
+      const registry = create("pypi", undefined, client);
+      const versions = await registry.fetchVersions("requests");
 
-      expect(versions).toHaveLength(2)
-      expect(versions[0].number).toBe('2.30.0')
-      expect(versions[0].status).toBe('')
-      expect(versions[0].integrity).toContain('sha256')
-      expect(versions[1].number).toBe('2.31.0')
-      expect(versions[1].status).toBe('yanked')
-    })
-  })
+      expect(versions).toHaveLength(2);
+      expect(versions[0].number).toBe("2.30.0");
+      expect(versions[0].status).toBe("");
+      expect(versions[0].integrity).toContain("sha256");
+      expect(versions[1].number).toBe("2.31.0");
+      expect(versions[1].status).toBe("yanked");
+    });
+  });
 
-  describe('rubygems registry', () => {
-    it('should fetch and normalize rubygems gem', async () => {
-      const client = new Client()
+  describe("rubygems registry", () => {
+    it("should fetch and normalize rubygems gem", async () => {
+      const client = new Client();
       const mockResponse = {
-        name: 'rails',
-        description: 'Ruby on Rails is a web-application framework',
-        homepage_uri: 'https://rubyonrails.org',
-        source_code_uri: 'https://github.com/rails/rails',
-        licenses: ['MIT'],
+        name: "rails",
+        description: "Ruby on Rails is a web-application framework",
+        homepage_uri: "https://rubyonrails.org",
+        source_code_uri: "https://github.com/rails/rails",
+        licenses: ["MIT"],
         metadata: {
-          homepage_uri: 'https://rubyonrails.org',
-          source_code_uri: 'https://github.com/rails/rails',
+          homepage_uri: "https://rubyonrails.org",
+          source_code_uri: "https://github.com/rails/rails",
         },
         dependencies: {
           runtime: [
             {
-              name: 'actioncable',
-              requirements: '= 7.0.0',
+              name: "actioncable",
+              requirements: "= 7.0.0",
             },
             {
-              name: 'actionmailbox',
-              requirements: '= 7.0.0',
+              name: "actionmailbox",
+              requirements: "= 7.0.0",
             },
           ],
           development: [
             {
-              name: 'bundler',
-              requirements: '>= 1.15.0',
+              name: "bundler",
+              requirements: ">= 1.15.0",
             },
           ],
         },
-      }
+      };
 
-      vi.spyOn(client, 'getJSON').mockResolvedValueOnce(mockResponse)
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(mockResponse);
 
-      const registry = create('gem', undefined, client)
-      const pkg = await registry.fetchPackage('rails')
+      const registry = create("gem", undefined, client);
+      const pkg = await registry.fetchPackage("rails");
 
-      expect(pkg.name).toBe('rails')
-      expect(pkg.description).toContain('Ruby on Rails')
-      expect(pkg.licenses).toBe('MIT')
-      expect(pkg.repository).toContain('github.com/rails/rails')
-      expect(pkg.namespace).toBe('')
-    })
+      expect(pkg.name).toBe("rails");
+      expect(pkg.description).toContain("Ruby on Rails");
+      expect(pkg.licenses).toBe("MIT");
+      expect(pkg.repository).toContain("github.com/rails/rails");
+      expect(pkg.namespace).toBe("");
+    });
 
-    it('should throw NotFoundError for missing rubygems gem', async () => {
-      const client = new Client()
+    it("should throw NotFoundError for missing rubygems gem", async () => {
+      const client = new Client();
 
-      vi.spyOn(client, 'getJSON').mockRejectedValueOnce(
-              new HTTPError(404, 'https://mock/not-found', 'Not Found')
-            )
+      vi.spyOn(client, "getJSON").mockRejectedValueOnce(
+        new HTTPError(404, "https://mock/not-found", "Not Found"),
+      );
 
-      const registry = create('gem', undefined, client)
+      const registry = create("gem", undefined, client);
 
-      await expect(registry.fetchPackage('nonexistent-gem-xyz')).rejects.toThrow(
-        NotFoundError
-      )
-    })
+      await expect(registry.fetchPackage("nonexistent-gem-xyz")).rejects.toThrow(NotFoundError);
+    });
 
-    it('should fetch rubygems versions with yanked status', async () => {
-      const client = new Client()
+    it("should fetch rubygems versions with yanked status", async () => {
+      const client = new Client();
       const mockResponse = [
         {
-          number: '7.0.0',
-          sha: 'abc123def456',
-          created_at: '2021-12-15T10:00:00Z',
+          number: "7.0.0",
+          sha: "abc123def456",
+          created_at: "2021-12-15T10:00:00Z",
           yanked: false,
         },
         {
-          number: '7.0.1',
-          sha: 'def456ghi789',
-          created_at: '2021-12-20T10:00:00Z',
+          number: "7.0.1",
+          sha: "def456ghi789",
+          created_at: "2021-12-20T10:00:00Z",
           yanked: true,
         },
         {
-          number: '7.0.2',
-          sha: 'ghi789jkl012',
-          created_at: '2021-12-25T10:00:00Z',
+          number: "7.0.2",
+          sha: "ghi789jkl012",
+          created_at: "2021-12-25T10:00:00Z",
           yanked: false,
         },
-      ]
+      ];
 
-      vi.spyOn(client, 'getJSON').mockResolvedValueOnce(mockResponse)
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(mockResponse);
 
-      const registry = create('gem', undefined, client)
-      const versions = await registry.fetchVersions('rails')
+      const registry = create("gem", undefined, client);
+      const versions = await registry.fetchVersions("rails");
 
-      expect(versions).toHaveLength(3)
-      expect(versions[0].number).toBe('7.0.0')
-      expect(versions[0].status).toBe('')
-      expect(versions[0].integrity).toContain('sha256')
-      expect(versions[1].number).toBe('7.0.1')
-      expect(versions[1].status).toBe('yanked')
-      expect(versions[2].number).toBe('7.0.2')
-      expect(versions[2].status).toBe('')
-    })
-  })
+      expect(versions).toHaveLength(3);
+      expect(versions[0].number).toBe("7.0.0");
+      expect(versions[0].status).toBe("");
+      expect(versions[0].integrity).toContain("sha256");
+      expect(versions[1].number).toBe("7.0.1");
+      expect(versions[1].status).toBe("yanked");
+      expect(versions[2].number).toBe("7.0.2");
+      expect(versions[2].status).toBe("");
+    });
+  });
 
-  describe('packagist registry', () => {
-    it('should fetch and normalize packagist package', async () => {
-      const client = new Client()
+  describe("packagist registry", () => {
+    it("should fetch and normalize packagist package", async () => {
+      const client = new Client();
       const mockResponse = {
         package: {
-          name: 'laravel/framework',
-          description: 'The Laravel Framework.',
-          repository: 'https://github.com/laravel/framework',
-          keywords: ['framework', 'laravel'],
+          name: "laravel/framework",
+          description: "The Laravel Framework.",
+          repository: "https://github.com/laravel/framework",
+          keywords: ["framework", "laravel"],
           versions: {
-            '10.0.0': {
-              name: 'laravel/framework',
-              version: '10.0.0',
-              license: ['MIT'],
-              keywords: ['framework', 'laravel'],
+            "10.0.0": {
+              name: "laravel/framework",
+              version: "10.0.0",
+              license: ["MIT"],
+              keywords: ["framework", "laravel"],
               authors: [
                 {
-                  name: 'Taylor Otwell',
-                  email: 'taylor@laravel.com',
-                  homepage: 'https://github.com/taylorotwell',
-                  role: 'creator',
+                  name: "Taylor Otwell",
+                  email: "taylor@laravel.com",
+                  homepage: "https://github.com/taylorotwell",
+                  role: "creator",
                 },
               ],
               require: {
-                'php': '^8.1',
-                'laravel/serializable-closure': '^1.3',
+                php: "^8.1",
+                "laravel/serializable-closure": "^1.3",
               },
-              'require-dev': {
-                'phpunit/phpunit': '^10.0',
+              "require-dev": {
+                "phpunit/phpunit": "^10.0",
               },
               source: {
-                type: 'git',
-                url: 'https://github.com/laravel/framework.git',
-                reference: 'abc123def456',
+                type: "git",
+                url: "https://github.com/laravel/framework.git",
+                reference: "abc123def456",
               },
               dist: {
-                type: 'zip',
-                url: 'https://api.github.com/repos/laravel/framework/zipball/abc123def456',
-                reference: 'abc123def456',
-                shasum: 'abc123def456789',
+                type: "zip",
+                url: "https://api.github.com/repos/laravel/framework/zipball/abc123def456",
+                reference: "abc123def456",
+                shasum: "abc123def456789",
               },
-              time: '2023-02-14T10:00:00Z',
+              time: "2023-02-14T10:00:00Z",
             },
-            '10.1.0': {
-              name: 'laravel/framework',
-              version: '10.1.0',
-              license: ['MIT'],
-              keywords: ['framework', 'laravel'],
+            "10.1.0": {
+              name: "laravel/framework",
+              version: "10.1.0",
+              license: ["MIT"],
+              keywords: ["framework", "laravel"],
               authors: [
                 {
-                  name: 'Taylor Otwell',
-                  email: 'taylor@laravel.com',
-                  homepage: 'https://github.com/taylorotwell',
-                  role: 'creator',
+                  name: "Taylor Otwell",
+                  email: "taylor@laravel.com",
+                  homepage: "https://github.com/taylorotwell",
+                  role: "creator",
                 },
               ],
               require: {
-                'php': '^8.1',
+                php: "^8.1",
               },
-              'require-dev': {},
+              "require-dev": {},
               source: {
-                type: 'git',
-                url: 'https://github.com/laravel/framework.git',
-                reference: 'def456ghi789',
+                type: "git",
+                url: "https://github.com/laravel/framework.git",
+                reference: "def456ghi789",
               },
               dist: {
-                type: 'zip',
-                url: 'https://api.github.com/repos/laravel/framework/zipball/def456ghi789',
-                reference: 'def456ghi789',
-                shasum: 'def456ghi789012',
+                type: "zip",
+                url: "https://api.github.com/repos/laravel/framework/zipball/def456ghi789",
+                reference: "def456ghi789",
+                shasum: "def456ghi789012",
               },
-              time: '2023-03-14T10:00:00Z',
+              time: "2023-03-14T10:00:00Z",
             },
           },
         },
-      }
+      };
 
-      vi.spyOn(client, 'getJSON').mockResolvedValueOnce(mockResponse)
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(mockResponse);
 
-      const registry = create('composer', undefined, client)
-      const pkg = await registry.fetchPackage('laravel/framework')
+      const registry = create("composer", undefined, client);
+      const pkg = await registry.fetchPackage("laravel/framework");
 
-      expect(pkg.name).toBe('laravel/framework')
-      expect(pkg.description).toBe('The Laravel Framework.')
-      expect(pkg.licenses).toBe('MIT')
-      expect(pkg.repository).toContain('github.com/laravel/framework')
-      expect(pkg.namespace).toBe('laravel')
-      expect(pkg.latestVersion).toBe('10.1.0')
-    })
+      expect(pkg.name).toBe("laravel/framework");
+      expect(pkg.description).toBe("The Laravel Framework.");
+      expect(pkg.licenses).toBe("MIT");
+      expect(pkg.repository).toContain("github.com/laravel/framework");
+      expect(pkg.namespace).toBe("laravel");
+      expect(pkg.latestVersion).toBe("10.1.0");
+    });
 
-    it('should throw NotFoundError for missing packagist package', async () => {
-      const client = new Client()
+    it("should throw NotFoundError for missing packagist package", async () => {
+      const client = new Client();
 
-      vi.spyOn(client, 'getJSON').mockRejectedValueOnce(
-              new HTTPError(404, 'https://mock/not-found', 'Not Found')
-            )
+      vi.spyOn(client, "getJSON").mockRejectedValueOnce(
+        new HTTPError(404, "https://mock/not-found", "Not Found"),
+      );
 
-      const registry = create('composer', undefined, client)
+      const registry = create("composer", undefined, client);
 
-      await expect(registry.fetchPackage('nonexistent/package')).rejects.toThrow(
-        NotFoundError
-      )
-    })
+      await expect(registry.fetchPackage("nonexistent/package")).rejects.toThrow(NotFoundError);
+    });
 
-    it('should fetch packagist versions with licenses', async () => {
-      const client = new Client()
+    it("should fetch packagist versions with licenses", async () => {
+      const client = new Client();
       const mockResponse = {
         package: {
-          name: 'laravel/framework',
-          description: 'The Laravel Framework.',
-          repository: 'https://github.com/laravel/framework',
-          keywords: ['framework', 'laravel'],
+          name: "laravel/framework",
+          description: "The Laravel Framework.",
+          repository: "https://github.com/laravel/framework",
+          keywords: ["framework", "laravel"],
           versions: {
-            '10.0.0': {
-              name: 'laravel/framework',
-              version: '10.0.0',
-              license: ['MIT'],
-              keywords: ['framework', 'laravel'],
+            "10.0.0": {
+              name: "laravel/framework",
+              version: "10.0.0",
+              license: ["MIT"],
+              keywords: ["framework", "laravel"],
               authors: [],
               require: {},
-              'require-dev': {},
+              "require-dev": {},
               source: {
-                type: 'git',
-                url: 'https://github.com/laravel/framework.git',
-                reference: 'abc123def456',
+                type: "git",
+                url: "https://github.com/laravel/framework.git",
+                reference: "abc123def456",
               },
               dist: {
-                type: 'zip',
-                url: 'https://api.github.com/repos/laravel/framework/zipball/abc123def456',
-                reference: 'abc123def456',
-                shasum: 'abc123def456789',
+                type: "zip",
+                url: "https://api.github.com/repos/laravel/framework/zipball/abc123def456",
+                reference: "abc123def456",
+                shasum: "abc123def456789",
               },
-              time: '2023-02-14T10:00:00Z',
+              time: "2023-02-14T10:00:00Z",
             },
-            '10.1.0': {
-              name: 'laravel/framework',
-              version: '10.1.0',
-              license: ['MIT', 'Apache-2.0'],
-              keywords: ['framework', 'laravel'],
+            "10.1.0": {
+              name: "laravel/framework",
+              version: "10.1.0",
+              license: ["MIT", "Apache-2.0"],
+              keywords: ["framework", "laravel"],
               authors: [],
               require: {},
-              'require-dev': {},
+              "require-dev": {},
               source: {
-                type: 'git',
-                url: 'https://github.com/laravel/framework.git',
-                reference: 'def456ghi789',
+                type: "git",
+                url: "https://github.com/laravel/framework.git",
+                reference: "def456ghi789",
               },
               dist: {
-                type: 'zip',
-                url: 'https://api.github.com/repos/laravel/framework/zipball/def456ghi789',
-                reference: 'def456ghi789',
-                shasum: 'def456ghi789012',
+                type: "zip",
+                url: "https://api.github.com/repos/laravel/framework/zipball/def456ghi789",
+                reference: "def456ghi789",
+                shasum: "def456ghi789012",
               },
-              time: '2023-03-14T10:00:00Z',
+              time: "2023-03-14T10:00:00Z",
             },
           },
         },
-      }
+      };
 
-      vi.spyOn(client, 'getJSON').mockResolvedValueOnce(mockResponse)
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(mockResponse);
 
-      const registry = create('composer', undefined, client)
-      const versions = await registry.fetchVersions('laravel/framework')
+      const registry = create("composer", undefined, client);
+      const versions = await registry.fetchVersions("laravel/framework");
 
-      expect(versions).toHaveLength(2)
-      expect(versions[0].number).toBe('10.0.0')
-      expect(versions[0].licenses).toBe('MIT')
-      expect(versions[0].integrity).toContain('sha1')
-      expect(versions[1].number).toBe('10.1.0')
-      expect(versions[1].licenses).toContain('MIT')
-      expect(versions[1].licenses).toContain('Apache-2.0')
-    })
-  })
-})
+      expect(versions).toHaveLength(2);
+      expect(versions[0].number).toBe("10.0.0");
+      expect(versions[0].licenses).toBe("MIT");
+      expect(versions[0].integrity).toContain("sha1");
+      expect(versions[1].number).toBe("10.1.0");
+      expect(versions[1].licenses).toContain("MIT");
+      expect(versions[1].licenses).toContain("Apache-2.0");
+    });
+  });
+});

--- a/test/unit/registry.test.ts
+++ b/test/unit/registry.test.ts
@@ -1,133 +1,133 @@
-import { register, create, ecosystems, has } from '../../src/core/registry.ts'
-import { UnknownEcosystemError } from '../../src/core/errors.ts'
-import type { Registry } from '../../src/core/types.ts'
-import type { Client } from '../../src/core/client.ts'
+import { register, create, ecosystems, has } from "../../src/core/registry.ts";
+import { UnknownEcosystemError } from "../../src/core/errors.ts";
+import type { Registry } from "../../src/core/types.ts";
+import type { Client } from "../../src/core/client.ts";
 
-describe('registry', () => {
-  describe('register', () => {
-    it('registers an ecosystem', () => {
-      const mockFactory = (baseURL: string, client: Client): Registry => ({
-        ecosystem: () => 'test-eco',
+describe("registry", () => {
+  describe("register", () => {
+    it("registers an ecosystem", () => {
+      const mockFactory = (_baseURL: string, _client: Client): Registry => ({
+        ecosystem: () => "test-eco",
         fetchPackage: async () => ({
-          name: '',
-          description: '',
-          homepage: '',
-          repository: '',
-          licenses: '',
+          name: "",
+          description: "",
+          homepage: "",
+          repository: "",
+          licenses: "",
           keywords: [],
-          namespace: '',
-          latestVersion: '',
+          namespace: "",
+          latestVersion: "",
           metadata: {},
         }),
         fetchVersions: async () => [],
         fetchDependencies: async () => [],
         fetchMaintainers: async () => [],
         urls: () => ({
-          registry: () => '',
-          download: () => '',
-          documentation: () => '',
-          readme: () => '',
-          purl: () => '',
+          registry: () => "",
+          download: () => "",
+          documentation: () => "",
+          readme: () => "",
+          purl: () => "",
         }),
-      })
+      });
 
-      register('test-eco', 'https://test.example.com', mockFactory)
-      expect(has('test-eco')).toBe(true)
-    })
+      register("test-eco", "https://test.example.com", mockFactory);
+      expect(has("test-eco")).toBe(true);
+    });
 
-    it('allows creating registry after registration', () => {
-      const mockFactory = (baseURL: string, client: Client): Registry => ({
-        ecosystem: () => 'test-eco-2',
+    it("allows creating registry after registration", () => {
+      const mockFactory = (_baseURL: string, _client: Client): Registry => ({
+        ecosystem: () => "test-eco-2",
         fetchPackage: async () => ({
-          name: '',
-          description: '',
-          homepage: '',
-          repository: '',
-          licenses: '',
+          name: "",
+          description: "",
+          homepage: "",
+          repository: "",
+          licenses: "",
           keywords: [],
-          namespace: '',
-          latestVersion: '',
+          namespace: "",
+          latestVersion: "",
           metadata: {},
         }),
         fetchVersions: async () => [],
         fetchDependencies: async () => [],
         fetchMaintainers: async () => [],
         urls: () => ({
-          registry: () => '',
-          download: () => '',
-          documentation: () => '',
-          readme: () => '',
-          purl: () => '',
+          registry: () => "",
+          download: () => "",
+          documentation: () => "",
+          readme: () => "",
+          purl: () => "",
         }),
-      })
+      });
 
-      register('test-eco-2', 'https://test2.example.com', mockFactory)
-      const registry = create('test-eco-2')
-      expect(registry.ecosystem()).toBe('test-eco-2')
-    })
-  })
+      register("test-eco-2", "https://test2.example.com", mockFactory);
+      const registry = create("test-eco-2");
+      expect(registry.ecosystem()).toBe("test-eco-2");
+    });
+  });
 
-  describe('create', () => {
-    it('creates registry for registered ecosystem', () => {
-      const mockFactory = (baseURL: string, client: Client): Registry => ({
-        ecosystem: () => 'test-eco-3',
+  describe("create", () => {
+    it("creates registry for registered ecosystem", () => {
+      const mockFactory = (_baseURL: string, _client: Client): Registry => ({
+        ecosystem: () => "test-eco-3",
         fetchPackage: async () => ({
-          name: '',
-          description: '',
-          homepage: '',
-          repository: '',
-          licenses: '',
+          name: "",
+          description: "",
+          homepage: "",
+          repository: "",
+          licenses: "",
           keywords: [],
-          namespace: '',
-          latestVersion: '',
+          namespace: "",
+          latestVersion: "",
           metadata: {},
         }),
         fetchVersions: async () => [],
         fetchDependencies: async () => [],
         fetchMaintainers: async () => [],
         urls: () => ({
-          registry: () => '',
-          download: () => '',
-          documentation: () => '',
-          readme: () => '',
-          purl: () => '',
+          registry: () => "",
+          download: () => "",
+          documentation: () => "",
+          readme: () => "",
+          purl: () => "",
         }),
-      })
+      });
 
-      register('test-eco-3', 'https://test3.example.com', mockFactory)
-      const registry = create('test-eco-3')
-      expect(registry).toBeDefined()
-      expect(registry.ecosystem()).toBe('test-eco-3')
-    })
+      register("test-eco-3", "https://test3.example.com", mockFactory);
+      const registry = create("test-eco-3");
+      expect(registry).toBeDefined();
+      expect(registry.ecosystem()).toBe("test-eco-3");
+    });
 
-    it('throws UnknownEcosystemError for unregistered ecosystem', () => {
-      expect(() => create('nonexistent-ecosystem')).toThrow(UnknownEcosystemError)
-    })
+    it("throws UnknownEcosystemError for unregistered ecosystem", () => {
+      expect(() => create("nonexistent-ecosystem")).toThrow(UnknownEcosystemError);
+    });
 
-    it('throws UnknownEcosystemError with correct ecosystem name', () => {
+    it("throws UnknownEcosystemError with correct ecosystem name", () => {
       try {
-        create('unknown-eco')
-        expect.fail('Should have thrown')
+        create("unknown-eco");
+        expect.fail("Should have thrown");
       } catch (error) {
-        expect(error).toBeInstanceOf(UnknownEcosystemError)
+        expect(error).toBeInstanceOf(UnknownEcosystemError);
         if (error instanceof UnknownEcosystemError) {
-          expect(error.ecosystem).toBe('unknown-eco')
+          expect(error.ecosystem).toBe("unknown-eco");
         }
       }
-    })
+    });
 
-    it('uses custom baseURL when provided', () => {
-      const mockFactory = (baseURL: string, client: Client): Registry => ({
-        ecosystem: () => 'test-eco-4',
+    it("uses custom baseURL when provided", () => {
+      const mockFactory = (baseURL: string, _client: Client): Registry => ({
+        ecosystem: () => "test-eco-4",
         fetchPackage: async () => ({
-          name: '',
-          description: '',
-          homepage: '',
-          repository: '',
-          licenses: '',
+          name: "",
+          description: "",
+          homepage: "",
+          repository: "",
+          licenses: "",
           keywords: [],
-          namespace: '',
-          latestVersion: '',
+          namespace: "",
+          latestVersion: "",
           metadata: {},
         }),
         fetchVersions: async () => [],
@@ -135,30 +135,30 @@ describe('registry', () => {
         fetchMaintainers: async () => [],
         urls: () => ({
           registry: () => baseURL,
-          download: () => '',
-          documentation: () => '',
-          readme: () => '',
-          purl: () => '',
+          download: () => "",
+          documentation: () => "",
+          readme: () => "",
+          purl: () => "",
         }),
-      })
+      });
 
-      register('test-eco-4', 'https://default.example.com', mockFactory)
-      const registry = create('test-eco-4', 'https://custom.example.com')
-      expect(registry.urls().registry()).toBe('https://custom.example.com')
-    })
+      register("test-eco-4", "https://default.example.com", mockFactory);
+      const registry = create("test-eco-4", "https://custom.example.com");
+      expect(registry.urls().registry()).toBe("https://custom.example.com");
+    });
 
-    it('uses default baseURL when not provided', () => {
-      const mockFactory = (baseURL: string, client: Client): Registry => ({
-        ecosystem: () => 'test-eco-5',
+    it("uses default baseURL when not provided", () => {
+      const mockFactory = (baseURL: string, _client: Client): Registry => ({
+        ecosystem: () => "test-eco-5",
         fetchPackage: async () => ({
-          name: '',
-          description: '',
-          homepage: '',
-          repository: '',
-          licenses: '',
+          name: "",
+          description: "",
+          homepage: "",
+          repository: "",
+          licenses: "",
           keywords: [],
-          namespace: '',
-          latestVersion: '',
+          namespace: "",
+          latestVersion: "",
           metadata: {},
         }),
         fetchVersions: async () => [],
@@ -166,170 +166,170 @@ describe('registry', () => {
         fetchMaintainers: async () => [],
         urls: () => ({
           registry: () => baseURL,
-          download: () => '',
-          documentation: () => '',
-          readme: () => '',
-          purl: () => '',
+          download: () => "",
+          documentation: () => "",
+          readme: () => "",
+          purl: () => "",
         }),
-      })
+      });
 
-      register('test-eco-5', 'https://default.example.com', mockFactory)
-      const registry = create('test-eco-5')
-      expect(registry.urls().registry()).toBe('https://default.example.com')
-    })
-  })
+      register("test-eco-5", "https://default.example.com", mockFactory);
+      const registry = create("test-eco-5");
+      expect(registry.urls().registry()).toBe("https://default.example.com");
+    });
+  });
 
-  describe('ecosystems', () => {
-    it('returns array of registered ecosystem names', () => {
-      const mockFactory = (baseURL: string, client: Client): Registry => ({
-        ecosystem: () => 'test-eco-6',
+  describe("ecosystems", () => {
+    it("returns array of registered ecosystem names", () => {
+      const mockFactory = (_baseURL: string, _client: Client): Registry => ({
+        ecosystem: () => "test-eco-6",
         fetchPackage: async () => ({
-          name: '',
-          description: '',
-          homepage: '',
-          repository: '',
-          licenses: '',
+          name: "",
+          description: "",
+          homepage: "",
+          repository: "",
+          licenses: "",
           keywords: [],
-          namespace: '',
-          latestVersion: '',
+          namespace: "",
+          latestVersion: "",
           metadata: {},
         }),
         fetchVersions: async () => [],
         fetchDependencies: async () => [],
         fetchMaintainers: async () => [],
         urls: () => ({
-          registry: () => '',
-          download: () => '',
-          documentation: () => '',
-          readme: () => '',
-          purl: () => '',
+          registry: () => "",
+          download: () => "",
+          documentation: () => "",
+          readme: () => "",
+          purl: () => "",
         }),
-      })
+      });
 
-      register('test-eco-6', 'https://test6.example.com', mockFactory)
-      const ecos = ecosystems()
-      expect(Array.isArray(ecos)).toBe(true)
-      expect(ecos).toContain('test-eco-6')
-    })
+      register("test-eco-6", "https://test6.example.com", mockFactory);
+      const ecos = ecosystems();
+      expect(Array.isArray(ecos)).toBe(true);
+      expect(ecos).toContain("test-eco-6");
+    });
 
-    it('returns empty array when no ecosystems registered', () => {
+    it("returns empty array when no ecosystems registered", () => {
       // Note: This test may fail if other tests have registered ecosystems
       // In a real test suite, you'd want to reset the registry between tests
-      const ecos = ecosystems()
-      expect(Array.isArray(ecos)).toBe(true)
-    })
-  })
+      const ecos = ecosystems();
+      expect(Array.isArray(ecos)).toBe(true);
+    });
+  });
 
-  describe('has', () => {
-    it('returns true for registered ecosystem', () => {
-      const mockFactory = (baseURL: string, client: Client): Registry => ({
-        ecosystem: () => 'test-eco-7',
+  describe("has", () => {
+    it("returns true for registered ecosystem", () => {
+      const mockFactory = (_baseURL: string, _client: Client): Registry => ({
+        ecosystem: () => "test-eco-7",
         fetchPackage: async () => ({
-          name: '',
-          description: '',
-          homepage: '',
-          repository: '',
-          licenses: '',
+          name: "",
+          description: "",
+          homepage: "",
+          repository: "",
+          licenses: "",
           keywords: [],
-          namespace: '',
-          latestVersion: '',
+          namespace: "",
+          latestVersion: "",
           metadata: {},
         }),
         fetchVersions: async () => [],
         fetchDependencies: async () => [],
         fetchMaintainers: async () => [],
         urls: () => ({
-          registry: () => '',
-          download: () => '',
-          documentation: () => '',
-          readme: () => '',
-          purl: () => '',
+          registry: () => "",
+          download: () => "",
+          documentation: () => "",
+          readme: () => "",
+          purl: () => "",
         }),
-      })
+      });
 
-      register('test-eco-7', 'https://test7.example.com', mockFactory)
-      expect(has('test-eco-7')).toBe(true)
-    })
+      register("test-eco-7", "https://test7.example.com", mockFactory);
+      expect(has("test-eco-7")).toBe(true);
+    });
 
-    it('returns false for unregistered ecosystem', () => {
-      expect(has('definitely-not-registered-ecosystem')).toBe(false)
-    })
+    it("returns false for unregistered ecosystem", () => {
+      expect(has("definitely-not-registered-ecosystem")).toBe(false);
+    });
 
-    it('is case-sensitive', () => {
-      const mockFactory = (baseURL: string, client: Client): Registry => ({
-        ecosystem: () => 'test-eco-8',
+    it("is case-sensitive", () => {
+      const mockFactory = (_baseURL: string, _client: Client): Registry => ({
+        ecosystem: () => "test-eco-8",
         fetchPackage: async () => ({
-          name: '',
-          description: '',
-          homepage: '',
-          repository: '',
-          licenses: '',
+          name: "",
+          description: "",
+          homepage: "",
+          repository: "",
+          licenses: "",
           keywords: [],
-          namespace: '',
-          latestVersion: '',
+          namespace: "",
+          latestVersion: "",
           metadata: {},
         }),
         fetchVersions: async () => [],
         fetchDependencies: async () => [],
         fetchMaintainers: async () => [],
         urls: () => ({
-          registry: () => '',
-          download: () => '',
-          documentation: () => '',
-          readme: () => '',
-          purl: () => '',
+          registry: () => "",
+          download: () => "",
+          documentation: () => "",
+          readme: () => "",
+          purl: () => "",
         }),
-      })
+      });
 
-      register('test-eco-8', 'https://test8.example.com', mockFactory)
-      expect(has('test-eco-8')).toBe(true)
-      expect(has('TEST-ECO-8')).toBe(false)
-      expect(has('Test-Eco-8')).toBe(false)
-    })
-  })
+      register("test-eco-8", "https://test8.example.com", mockFactory);
+      expect(has("test-eco-8")).toBe(true);
+      expect(has("TEST-ECO-8")).toBe(false);
+      expect(has("Test-Eco-8")).toBe(false);
+    });
+  });
 
-  describe('integration', () => {
-    it('register, create, and has work together', () => {
-      const mockFactory = (baseURL: string, client: Client): Registry => ({
-        ecosystem: () => 'integration-test-eco',
+  describe("integration", () => {
+    it("register, create, and has work together", () => {
+      const mockFactory = (_baseURL: string, _client: Client): Registry => ({
+        ecosystem: () => "integration-test-eco",
         fetchPackage: async () => ({
-          name: '',
-          description: '',
-          homepage: '',
-          repository: '',
-          licenses: '',
+          name: "",
+          description: "",
+          homepage: "",
+          repository: "",
+          licenses: "",
           keywords: [],
-          namespace: '',
-          latestVersion: '',
+          namespace: "",
+          latestVersion: "",
           metadata: {},
         }),
         fetchVersions: async () => [],
         fetchDependencies: async () => [],
         fetchMaintainers: async () => [],
         urls: () => ({
-          registry: () => '',
-          download: () => '',
-          documentation: () => '',
-          readme: () => '',
-          purl: () => '',
+          registry: () => "",
+          download: () => "",
+          documentation: () => "",
+          readme: () => "",
+          purl: () => "",
         }),
-      })
+      });
 
       // Before registration
-      expect(has('integration-test-eco')).toBe(false)
+      expect(has("integration-test-eco")).toBe(false);
 
       // Register
-      register('integration-test-eco', 'https://integration.example.com', mockFactory)
+      register("integration-test-eco", "https://integration.example.com", mockFactory);
 
       // After registration
-      expect(has('integration-test-eco')).toBe(true)
+      expect(has("integration-test-eco")).toBe(true);
 
       // Create
-      const registry = create('integration-test-eco')
-      expect(registry.ecosystem()).toBe('integration-test-eco')
+      const registry = create("integration-test-eco");
+      expect(registry.ecosystem()).toBe("integration-test-eco");
 
       // Verify in ecosystems list
-      expect(ecosystems()).toContain('integration-test-eco')
-    })
-  })
-})
+      expect(ecosystems()).toContain("integration-test-eco");
+    });
+  });
+});

--- a/test/unit/repository.test.ts
+++ b/test/unit/repository.test.ts
@@ -91,12 +91,6 @@ describe("repository", () => {
       );
     });
 
-    it("strips .git suffix", () => {
-      expect(normalizeRepositoryURL("https://github.com/foo/bar.git")).toBe(
-        "https://github.com/foo/bar",
-      );
-    });
-
     it("strips trailing slash after .git", () => {
       expect(normalizeRepositoryURL("https://github.com/foo/bar.git/")).toBe(
         "https://github.com/foo/bar.git",

--- a/test/unit/repository.test.ts
+++ b/test/unit/repository.test.ts
@@ -1,178 +1,180 @@
-import { normalizeRepositoryURL } from '../../src/core/repository.ts'
+import { normalizeRepositoryURL } from "../../src/core/repository.ts";
 
-describe('repository', () => {
-  describe('normalizeRepositoryURL', () => {
-    it('returns empty string for null', () => {
-      expect(normalizeRepositoryURL(null)).toBe('')
-    })
+describe("repository", () => {
+  describe("normalizeRepositoryURL", () => {
+    it("returns empty string for null", () => {
+      expect(normalizeRepositoryURL(null)).toBe("");
+    });
 
-    it('returns empty string for undefined', () => {
-      expect(normalizeRepositoryURL(undefined)).toBe('')
-    })
+    it("returns empty string for undefined", () => {
+      expect(normalizeRepositoryURL(undefined)).toBe("");
+    });
 
-    it('returns empty string for empty string', () => {
-      expect(normalizeRepositoryURL('')).toBe('')
-    })
+    it("returns empty string for empty string", () => {
+      expect(normalizeRepositoryURL("")).toBe("");
+    });
 
-    it('returns empty string for whitespace-only string', () => {
-      expect(normalizeRepositoryURL('   ')).toBe('')
-      expect(normalizeRepositoryURL('\t\n')).toBe('')
-    })
+    it("returns empty string for whitespace-only string", () => {
+      expect(normalizeRepositoryURL("   ")).toBe("");
+      expect(normalizeRepositoryURL("\t\n")).toBe("");
+    });
 
-    it('returns empty string for non-string, non-object', () => {
-      expect(normalizeRepositoryURL(123)).toBe('')
-      expect(normalizeRepositoryURL(true)).toBe('')
-      expect(normalizeRepositoryURL([])).toBe('')
-    })
+    it("returns empty string for non-string, non-object", () => {
+      expect(normalizeRepositoryURL(123)).toBe("");
+      expect(normalizeRepositoryURL(true)).toBe("");
+      expect(normalizeRepositoryURL([])).toBe("");
+    });
 
-    it('returns empty string for object without url property', () => {
-      expect(normalizeRepositoryURL({})).toBe('')
-      expect(normalizeRepositoryURL({ type: 'git' })).toBe('')
-    })
+    it("returns empty string for object without url property", () => {
+      expect(normalizeRepositoryURL({})).toBe("");
+      expect(normalizeRepositoryURL({ type: "git" })).toBe("");
+    });
 
-    it('returns empty string for object with non-string url', () => {
-      expect(normalizeRepositoryURL({ url: 123 })).toBe('')
-      expect(normalizeRepositoryURL({ url: null })).toBe('')
-    })
+    it("returns empty string for object with non-string url", () => {
+      expect(normalizeRepositoryURL({ url: 123 })).toBe("");
+      expect(normalizeRepositoryURL({ url: null })).toBe("");
+    });
 
-    it('extracts url from object', () => {
-      expect(normalizeRepositoryURL({ url: 'https://github.com/foo/bar' })).toBe(
-        'https://github.com/foo/bar'
-      )
-    })
+    it("extracts url from object", () => {
+      expect(normalizeRepositoryURL({ url: "https://github.com/foo/bar" })).toBe(
+        "https://github.com/foo/bar",
+      );
+    });
 
-    it('normalizes git+https URLs', () => {
-      expect(normalizeRepositoryURL('git+https://github.com/foo/bar.git')).toBe(
-        'https://github.com/foo/bar'
-      )
-    })
+    it("normalizes git+https URLs", () => {
+      expect(normalizeRepositoryURL("git+https://github.com/foo/bar.git")).toBe(
+        "https://github.com/foo/bar",
+      );
+    });
 
-    it('normalizes git:// URLs to https://', () => {
-      expect(normalizeRepositoryURL('git://github.com/foo/bar')).toBe('https://github.com/foo/bar')
-    })
+    it("normalizes git:// URLs to https://", () => {
+      expect(normalizeRepositoryURL("git://github.com/foo/bar")).toBe("https://github.com/foo/bar");
+    });
 
-    it('normalizes ssh://git@ URLs', () => {
-      expect(normalizeRepositoryURL('ssh://git@github.com/foo/bar.git')).toBe(
-        'https://github.com/foo/bar'
-      )
-    })
+    it("normalizes ssh://git@ URLs", () => {
+      expect(normalizeRepositoryURL("ssh://git@github.com/foo/bar.git")).toBe(
+        "https://github.com/foo/bar",
+      );
+    });
 
-    it('normalizes git@host:user/repo SSH URLs', () => {
-      expect(normalizeRepositoryURL('git@github.com:foo/bar.git')).toBe('https://github.com/foo/bar')
-    })
+    it("normalizes git@host:user/repo SSH URLs", () => {
+      expect(normalizeRepositoryURL("git@github.com:foo/bar.git")).toBe(
+        "https://github.com/foo/bar",
+      );
+    });
 
-    it('normalizes git@host:user/repo without .git', () => {
-      expect(normalizeRepositoryURL('git@github.com:foo/bar')).toBe('https://github.com/foo/bar')
-    })
+    it("normalizes git@host:user/repo without .git", () => {
+      expect(normalizeRepositoryURL("git@github.com:foo/bar")).toBe("https://github.com/foo/bar");
+    });
 
-    it('handles GitHub shorthand', () => {
-      expect(normalizeRepositoryURL('github:foo/bar')).toBe('https://github.com/foo/bar')
-    })
+    it("handles GitHub shorthand", () => {
+      expect(normalizeRepositoryURL("github:foo/bar")).toBe("https://github.com/foo/bar");
+    });
 
-    it('handles GitLab shorthand', () => {
-      expect(normalizeRepositoryURL('gitlab:foo/bar')).toBe('https://gitlab.com/foo/bar')
-    })
+    it("handles GitLab shorthand", () => {
+      expect(normalizeRepositoryURL("gitlab:foo/bar")).toBe("https://gitlab.com/foo/bar");
+    });
 
-    it('handles Bitbucket shorthand', () => {
-      expect(normalizeRepositoryURL('bitbucket:foo/bar')).toBe('https://bitbucket.org/foo/bar')
-    })
+    it("handles Bitbucket shorthand", () => {
+      expect(normalizeRepositoryURL("bitbucket:foo/bar")).toBe("https://bitbucket.org/foo/bar");
+    });
 
-    it('strips .git suffix', () => {
-      expect(normalizeRepositoryURL('https://github.com/foo/bar.git')).toBe(
-        'https://github.com/foo/bar'
-      )
-    })
+    it("strips .git suffix", () => {
+      expect(normalizeRepositoryURL("https://github.com/foo/bar.git")).toBe(
+        "https://github.com/foo/bar",
+      );
+    });
 
-    it('strips trailing slash', () => {
-      expect(normalizeRepositoryURL('https://github.com/foo/bar/')).toBe(
-        'https://github.com/foo/bar'
-      )
-    })
+    it("strips trailing slash", () => {
+      expect(normalizeRepositoryURL("https://github.com/foo/bar/")).toBe(
+        "https://github.com/foo/bar",
+      );
+    });
 
-    it('strips .git suffix', () => {
-      expect(normalizeRepositoryURL('https://github.com/foo/bar.git')).toBe(
-        'https://github.com/foo/bar'
-      )
-    })
+    it("strips .git suffix", () => {
+      expect(normalizeRepositoryURL("https://github.com/foo/bar.git")).toBe(
+        "https://github.com/foo/bar",
+      );
+    });
 
-    it('strips trailing slash after .git', () => {
-      expect(normalizeRepositoryURL('https://github.com/foo/bar.git/')).toBe(
-        'https://github.com/foo/bar.git'
-      )
-    })
+    it("strips trailing slash after .git", () => {
+      expect(normalizeRepositoryURL("https://github.com/foo/bar.git/")).toBe(
+        "https://github.com/foo/bar.git",
+      );
+    });
 
-    it('handles complex SSH URL', () => {
-      expect(normalizeRepositoryURL('ssh://git@gitlab.com:22/group/project.git')).toBe(
-        'https://gitlab.com:22/group/project'
-      )
-    })
+    it("handles complex SSH URL", () => {
+      expect(normalizeRepositoryURL("ssh://git@gitlab.com:22/group/project.git")).toBe(
+        "https://gitlab.com:22/group/project",
+      );
+    });
 
-    it('handles HTTPS URL with port', () => {
-      expect(normalizeRepositoryURL('https://github.com:443/foo/bar.git')).toBe(
-        'https://github.com:443/foo/bar'
-      )
-    })
+    it("handles HTTPS URL with port", () => {
+      expect(normalizeRepositoryURL("https://github.com:443/foo/bar.git")).toBe(
+        "https://github.com:443/foo/bar",
+      );
+    });
 
-    it('handles nested paths', () => {
-      expect(normalizeRepositoryURL('https://github.com/org/group/project.git')).toBe(
-        'https://github.com/org/group/project'
-      )
-    })
+    it("handles nested paths", () => {
+      expect(normalizeRepositoryURL("https://github.com/org/group/project.git")).toBe(
+        "https://github.com/org/group/project",
+      );
+    });
 
-    it('trims whitespace from string input', () => {
-      expect(normalizeRepositoryURL('  https://github.com/foo/bar  ')).toBe(
-        'https://github.com/foo/bar'
-      )
-    })
+    it("trims whitespace from string input", () => {
+      expect(normalizeRepositoryURL("  https://github.com/foo/bar  ")).toBe(
+        "https://github.com/foo/bar",
+      );
+    });
 
-    it('handles git+ prefix with git:// protocol', () => {
-      expect(normalizeRepositoryURL('git+git://github.com/foo/bar')).toBe(
-        'https://github.com/foo/bar'
-      )
-    })
+    it("handles git+ prefix with git:// protocol", () => {
+      expect(normalizeRepositoryURL("git+git://github.com/foo/bar")).toBe(
+        "https://github.com/foo/bar",
+      );
+    });
 
-    it('handles git+ prefix with ssh://', () => {
-      expect(normalizeRepositoryURL('git+ssh://git@github.com/foo/bar.git')).toBe(
-        'https://github.com/foo/bar'
-      )
-    })
+    it("handles git+ prefix with ssh://", () => {
+      expect(normalizeRepositoryURL("git+ssh://git@github.com/foo/bar.git")).toBe(
+        "https://github.com/foo/bar",
+      );
+    });
 
-    it('preserves HTTPS URLs without modification', () => {
-      expect(normalizeRepositoryURL('https://github.com/foo/bar')).toBe(
-        'https://github.com/foo/bar'
-      )
-    })
+    it("preserves HTTPS URLs without modification", () => {
+      expect(normalizeRepositoryURL("https://github.com/foo/bar")).toBe(
+        "https://github.com/foo/bar",
+      );
+    });
 
-    it('preserves HTTP URLs', () => {
-      expect(normalizeRepositoryURL('http://github.com/foo/bar')).toBe('http://github.com/foo/bar')
-    })
+    it("preserves HTTP URLs", () => {
+      expect(normalizeRepositoryURL("http://github.com/foo/bar")).toBe("http://github.com/foo/bar");
+    });
 
-    it('handles object with extra properties', () => {
+    it("handles object with extra properties", () => {
       expect(
         normalizeRepositoryURL({
-          url: 'https://github.com/foo/bar.git',
-          type: 'git',
-          directory: 'packages/core',
-        })
-      ).toBe('https://github.com/foo/bar')
-    })
+          url: "https://github.com/foo/bar.git",
+          type: "git",
+          directory: "packages/core",
+        }),
+      ).toBe("https://github.com/foo/bar");
+    });
 
-    it('handles complex real-world example', () => {
-      expect(normalizeRepositoryURL('git+https://github.com/babel/babel.git')).toBe(
-        'https://github.com/babel/babel'
-      )
-    })
+    it("handles complex real-world example", () => {
+      expect(normalizeRepositoryURL("git+https://github.com/babel/babel.git")).toBe(
+        "https://github.com/babel/babel",
+      );
+    });
 
-    it('handles GitLab SSH URL', () => {
-      expect(normalizeRepositoryURL('git@gitlab.com:group/project.git')).toBe(
-        'https://gitlab.com/group/project'
-      )
-    })
+    it("handles GitLab SSH URL", () => {
+      expect(normalizeRepositoryURL("git@gitlab.com:group/project.git")).toBe(
+        "https://gitlab.com/group/project",
+      );
+    });
 
-    it('handles Bitbucket SSH URL', () => {
-      expect(normalizeRepositoryURL('git@bitbucket.org:user/repo.git')).toBe(
-        'https://bitbucket.org/user/repo'
-      )
-    })
-  })
-})
+    it("handles Bitbucket SSH URL", () => {
+      expect(normalizeRepositoryURL("git@bitbucket.org:user/repo.git")).toBe(
+        "https://bitbucket.org/user/repo",
+      );
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,17 +1,17 @@
-import { defineConfig } from 'vitest/config'
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
     globals: true,
-    reporters: 'dot',
+    reporters: "dot",
     projects: [
-      { test: { name: 'unit', include: ['test/unit/**/*.test.ts'], globals: true } },
-      { test: { name: 'e2e', include: ['test/e2e/**/*.test.ts'], globals: true } },
+      { test: { name: "unit", include: ["test/unit/**/*.test.ts"], globals: true } },
+      { test: { name: "e2e", include: ["test/e2e/**/*.test.ts"], globals: true } },
     ],
     coverage: {
-      provider: 'v8',
-      include: ['src/**/*.ts'],
-      exclude: ['src/**/types.ts', 'src/**/*.test.ts'],
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/types.ts", "src/**/*.test.ts"],
     },
   },
-})
+});


### PR DESCRIPTION
Adds oxlint + oxfmt as the linter/formatter pair, with editorconfig for basic editor consistency. Ran both across the whole codebase and fixed all warnings (unused imports/params in tests).

Closes #16

Co-Authored-By: Aei <256851514+aeitwoen@users.noreply.github.com>