### PR TITLE
fix(rubygems): use v2 API for version-specific dependencies

### DIFF
--- a/src/registries/rubygems.ts
+++ b/src/registries/rubygems.ts
@@ -137,7 +137,7 @@ class RubyGemsRegistry implements Registry {
     version: string,
     signal?: AbortSignal,
   ): Promise<Dependency[]> {
-    const url = `${this.baseURL}/api/v1/gems/${name}.json`;
+    const url = `${this.baseURL}/api/v2/rubygems/${name}/versions/${version}.json`;
 
     try {
       const data = await this.client.getJSON<RubyGemsGemResponse>(url, signal);

--- a/test/unit/registries.test.ts
+++ b/test/unit/registries.test.ts
@@ -517,6 +517,54 @@ describe("Registry Modules", () => {
       expect(versions[2].number).toBe("7.0.2");
       expect(versions[2].status).toBe("");
     });
+
+    it("should fetch version-specific dependencies via v2 API", async () => {
+      const client = new Client();
+      const mockResponse = {
+        name: "rails",
+        version: "5.0.0",
+        description: "Ruby on Rails is a web-application framework",
+        licenses: ["MIT"],
+        dependencies: {
+          runtime: [
+            { name: "actioncable", requirements: "= 5.0.0" },
+            { name: "activesupport", requirements: "= 5.0.0" },
+          ],
+          development: [{ name: "bundler", requirements: ">= 1.15.0" }],
+        },
+      };
+
+      const spy = vi.spyOn(client, "getJSON").mockResolvedValueOnce(mockResponse);
+
+      const registry = create("gem", undefined, client);
+      const deps = await registry.fetchDependencies("rails", "5.0.0");
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringContaining("/api/v2/rubygems/rails/versions/5.0.0.json"),
+        undefined,
+      );
+
+      expect(deps).toHaveLength(3);
+      expect(deps[0].name).toBe("actioncable");
+      expect(deps[0].requirements).toBe("= 5.0.0");
+      expect(deps[0].scope).toBe("runtime");
+      expect(deps[1].name).toBe("activesupport");
+      expect(deps[1].scope).toBe("runtime");
+      expect(deps[2].name).toBe("bundler");
+      expect(deps[2].scope).toBe("development");
+    });
+
+    it("should throw NotFoundError for missing gem version", async () => {
+      const client = new Client();
+
+      vi.spyOn(client, "getJSON").mockRejectedValueOnce(
+        new HTTPError(404, "https://mock/not-found", "Not Found"),
+      );
+
+      const registry = create("gem", undefined, client);
+
+      await expect(registry.fetchDependencies("rails", "0.0.0")).rejects.toThrow(NotFoundError);
+    });
   });
 
   describe("packagist registry", () => {


### PR DESCRIPTION
`fetchDependencies` was hitting the v1 gem endpoint (`/api/v1/gems/{name}.json`) which always returns the **latest** version's dependency data, silently ignoring the `version` parameter. If you asked for `rails@5.0.0` dependencies, you'd get back whatever the current release ships with - no error, no warning, just wrong data.

Every other registry handles this correctly (npm indexes into the version map, cargo/pypi hit version-specific endpoints, packagist looks up the version key). RubyGems was the only adapter returning the wrong answer.

The fix switches to the [v2 API](https://guides.rubygems.org/rubygems-org-api-v2/) endpoint `/api/v2/rubygems/{name}/versions/{version}.json`, which returns dependency data for the exact version requested. The response shape is the same as v1, so no parsing changes needed - just the URL.

**Changes:**
- `src/registries/rubygems.ts`: one-line URL change from v1 to v2 endpoint
- `test/unit/registries.test.ts`: two new tests verifying version-specific fetch and 404 handling

Closes #15