### PR TITLE
fix(cargo): use latest stable version license instead of newest version

### DIFF
--- a/src/registries/cargo.ts
+++ b/src/registries/cargo.ts
@@ -130,7 +130,9 @@ class CargoRegistry implements Registry {
         homepage: crateData.homepage || "",
         documentation: crateData.documentation || "",
         repository: normalizeRepositoryURL(crateData.repository || ""),
-        licenses: normalizeLicense(latestVersionData?.license || data.versions[0]?.license || ""),
+        licenses: normalizeLicense(
+          latestVersionData ? latestVersionData.license : (data.versions[0]?.license ?? ""),
+        ),
         keywords: crateData.keywords,
         namespace: "",
         latestVersion,

--- a/src/registries/cargo.ts
+++ b/src/registries/cargo.ts
@@ -122,6 +122,7 @@ class CargoRegistry implements Registry {
       const data = await this.client.getJSON<CratesPackageResponse>(url, signal);
       const crateData = data.crate;
       const latestVersion = crateData.max_stable_version || crateData.max_version;
+      const latestVersionData = data.versions.find((v) => v.num === latestVersion);
 
       return {
         name: crateData.name,
@@ -129,7 +130,7 @@ class CargoRegistry implements Registry {
         homepage: crateData.homepage || "",
         documentation: crateData.documentation || "",
         repository: normalizeRepositoryURL(crateData.repository || ""),
-        licenses: normalizeLicense(data.versions[0]?.license || ""),
+        licenses: normalizeLicense(latestVersionData?.license || data.versions[0]?.license || ""),
         keywords: crateData.keywords,
         namespace: "",
         latestVersion,

--- a/test/unit/registries.test.ts
+++ b/test/unit/registries.test.ts
@@ -188,6 +188,85 @@ describe("Registry Modules", () => {
       expect(pkg.metadata.createdAt).toBe("2014-12-20T02:35:07Z");
     });
 
+    it("should use license from latest stable version, not newest version", async () => {
+      const client = new Client();
+      const mockResponse = {
+        crate: {
+          id: 1,
+          name: "example",
+          updated_at: "2024-02-01T10:00:00Z",
+          created_at: "2024-01-01T10:00:00Z",
+          downloads: 1000,
+          recent_downloads: 100,
+          max_version: "2.0.0-alpha.1",
+          max_stable_version: "1.0.0",
+          newest_version: "2.0.0-alpha.1",
+          description: "Example crate",
+          homepage: "",
+          documentation: "",
+          repository: "",
+          keywords: [],
+          categories: [],
+          badges: [],
+          links: {},
+        },
+        versions: [
+          {
+            id: 2,
+            num: "2.0.0-alpha.1",
+            dl_path: "/api/v1/crates/example/2.0.0-alpha.1/download",
+            readme_path: "/api/v1/crates/example/2.0.0-alpha.1/readme",
+            created_at: "2024-02-01T10:00:00Z",
+            updated_at: "2024-02-01T10:00:00Z",
+            downloads: 100,
+            features: {},
+            yanked: false,
+            license: "MIT",
+            links: {},
+            crate_size: 50000,
+            published_by: {
+              id: 1,
+              login: "author",
+              name: "Author",
+              avatar: "",
+              url: "",
+            },
+            checksum: "aaa111",
+          },
+          {
+            id: 1,
+            num: "1.0.0",
+            dl_path: "/api/v1/crates/example/1.0.0/download",
+            readme_path: "/api/v1/crates/example/1.0.0/readme",
+            created_at: "2024-01-01T10:00:00Z",
+            updated_at: "2024-01-01T10:00:00Z",
+            downloads: 900,
+            features: {},
+            yanked: false,
+            license: "MIT OR Apache-2.0",
+            links: {},
+            crate_size: 50000,
+            published_by: {
+              id: 1,
+              login: "author",
+              name: "Author",
+              avatar: "",
+              url: "",
+            },
+            checksum: "bbb222",
+          },
+        ],
+      };
+
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(mockResponse);
+
+      const registry = create("cargo", undefined, client);
+      const pkg = await registry.fetchPackage("example");
+
+      expect(pkg.latestVersion).toBe("1.0.0");
+      expect(pkg.licenses).toBe("MIT OR Apache-2.0");
+    });
+
     it("should throw NotFoundError for missing cargo crate", async () => {
       const client = new Client();
 


### PR DESCRIPTION
`fetchPackage` was picking the license from `data.versions[0]` - the first element in the crates.io API response array. The API returns versions newest-first, so this grabs whatever was published most recently, not the version that `latestVersion` actually points to.

When a crate has a pre-release newer than the latest stable (e.g. `2.0.0-alpha.1` after `1.0.0`), the license would come from the pre-release instead of the stable version. If the author changed or simplified the license for the alpha, `fetchPackage` would report the wrong license for the crate.

The fix finds the version entry matching `latestVersion` and uses its license, falling back to `versions[0]` only if the match isn't found. This matches how the npm registry already does it - keying into `data.versions[latestVersion]` rather than blindly using the first array element.

Added a test with a crate where `max_stable_version` differs from the newest version and each has a different license.