### PR TITLE
fix(cache): namespace storage keys by ecosystem

### DIFF
--- a/src/cache/cached-registry.ts
+++ b/src/cache/cached-registry.ts
@@ -6,7 +6,7 @@ import type {
   URLBuilder,
   Version,
 } from "../core/types.ts";
-import { getEcosystemStorage, getStorage, computeIntegrity } from "./storage.ts";
+import { getStorage, computeIntegrity } from "./storage.ts";
 import {
   readLockfile,
   writeLockfile,
@@ -32,7 +32,7 @@ export class CachedRegistry implements Registry {
 
   constructor(inner: Registry, storage?: Storage) {
     this.inner = inner;
-    this.storage = storage ?? getEcosystemStorage(inner.ecosystem());
+    this.storage = storage ?? getStorage();
     this.lockfileStorage = storage ?? getStorage();
   }
 
@@ -91,7 +91,7 @@ export class CachedRegistry implements Registry {
   ): Promise<T> {
     const eco = this.inner.ecosystem();
     const key = cacheKey(eco, name, type, version);
-    const storageKey = version ? `${name}:${type}:${version}` : `${name}:${type}`;
+    const storageKey = key;
 
     // 1. Check lockfile
     const lockfile = await readLockfile(this.lockfileStorage);

--- a/test/unit/cached-registry.test.ts
+++ b/test/unit/cached-registry.test.ts
@@ -579,6 +579,56 @@ describe("CachedRegistry", () => {
     });
   });
 
+  describe("ecosystem isolation", () => {
+    it("does not collide when two ecosystems cache the same package name", async () => {
+      const npmInner = createMockRegistry("npm", {
+        fetchPackage: async () => ({
+          name: "json",
+          description: "npm json package",
+          homepage: "",
+          documentation: "",
+          repository: "",
+          licenses: "MIT",
+          keywords: [],
+          namespace: "",
+          latestVersion: "1.0.0",
+          metadata: {},
+        }),
+      });
+      const cargoInner = createMockRegistry("cargo", {
+        fetchPackage: async () => ({
+          name: "json",
+          description: "cargo json crate",
+          homepage: "",
+          documentation: "",
+          repository: "",
+          licenses: "Apache-2.0",
+          keywords: [],
+          namespace: "",
+          latestVersion: "0.12.4",
+          metadata: {},
+        }),
+      });
+
+      const npmCached = new CachedRegistry(npmInner);
+      const cargoCached = new CachedRegistry(cargoInner);
+
+      const npmPkg = await npmCached.fetchPackage("json");
+      const cargoPkg = await cargoCached.fetchPackage("json");
+
+      expect(npmPkg.description).toBe("npm json package");
+      expect(npmPkg.licenses).toBe("MIT");
+      expect(cargoPkg.description).toBe("cargo json crate");
+      expect(cargoPkg.licenses).toBe("Apache-2.0");
+
+      const npmAgain = await npmCached.fetchPackage("json");
+      const cargoAgain = await cargoCached.fetchPackage("json");
+
+      expect(npmAgain.description).toBe("npm json package");
+      expect(cargoAgain.description).toBe("cargo json crate");
+    });
+  });
+
   describe("error handling", () => {
     it("propagates fetch errors", async () => {
       const inner = createMockRegistry("npm", {


### PR DESCRIPTION
The `storageKey` in `CachedRegistry.cached()` didn't include the ecosystem, so it was built as `lodash:package` while the lockfile key was correctly `npm:lodash:package`. With default storage this was masked by `getEcosystemStorage()` wrapping the storage in `prefixStorage`, but when passing custom storage (Cloudflare KV, Redis, etc.), two registries caching the same package name would silently overwrite each other's data.

I hit this while testing a shared Cloudflare KV setup where both npm and PyPI registries used the same storage instance. Fetching `json` from npm, then `json` from PyPI, returned the PyPI result for both.

The fix reuses the lockfile's `cacheKey` (which already includes the ecosystem) as the storage key, and drops the ecosystem-prefixed storage wrapper since the key itself now provides the namespace. Existing caches will miss once and rebuild on the next fetch.

Partially addresses #18 (item 2: cache storageKey not namespaced by ecosystem).

**Changes:**
- `storageKey` now equals `cacheKey(eco, name, type, version)` instead of omitting the ecosystem
- Constructor uses `getStorage()` directly instead of `getEcosystemStorage()` (no double-prefixing)
- Added test verifying two ecosystems with the same package name don't collide