### PR TITLE
Make root helper imports just work

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,6 @@ For more control, create a registry instance directly:
 
 ```ts
 import { create } from "regxa";
-import "regxa/registries"; // registers all built-in ecosystems
 
 const npm = create("npm");
 const pkg = await npm.fetchPackage("lodash");
@@ -159,7 +158,6 @@ Wrap any registry with caching:
 
 ```ts
 import { createCached } from "regxa";
-import "regxa/registries";
 
 const npm = createCached("npm");
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,12 @@
     "dist"
   ],
   "type": "module",
-  "sideEffects": false,
+  "sideEffects": [
+    "./src/index.ts",
+    "./src/registries/index.ts",
+    "./dist/index.mjs",
+    "./dist/registries/index.mjs"
+  ],
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
   "exports": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import "./registries/index.ts";
+
 // Core API
 export { Client, defaultClient } from "./core/client.ts";
 export { register, create, ecosystems, has } from "./core/registry.ts";

--- a/test/unit/helpers.test.ts
+++ b/test/unit/helpers.test.ts
@@ -178,3 +178,15 @@ describe("fetchDependenciesFromPURL", () => {
     await expect(fetchDependenciesFromPURL(purl)).rejects.toThrow(purl);
   });
 });
+
+describe("root entrypoint registry initialization", () => {
+  it("registers built-in ecosystems via side effects", async () => {
+    vi.resetModules();
+
+    const { has } = await import("../../src/core/registry.ts");
+    expect(has("npm")).toBe(false);
+
+    await import("../../src/index.ts");
+    expect(has("npm")).toBe(true);
+  });
+});

--- a/test/unit/helpers.test.ts
+++ b/test/unit/helpers.test.ts
@@ -182,11 +182,16 @@ describe("fetchDependenciesFromPURL", () => {
 describe("root entrypoint registry initialization", () => {
   it("registers built-in ecosystems via side effects", async () => {
     vi.resetModules();
+    const ecosystems = ["npm", "cargo", "pypi", "gem", "composer", "alpm"] as const;
 
     const { has } = await import("../../src/core/registry.ts");
-    expect(has("npm")).toBe(false);
+    for (const ecosystem of ecosystems) {
+      expect(has(ecosystem)).toBe(false);
+    }
 
     await import("../../src/index.ts");
-    expect(has("npm")).toBe(true);
+    for (const ecosystem of ecosystems) {
+      expect(has(ecosystem)).toBe(true);
+    }
   });
 });


### PR DESCRIPTION
## Summary
Root helper usage from `regxa` could throw `UnknownEcosystemError` because registry side effects were not initialized on the root import path. I hit this while validating the quick-start examples and fixed it so default imports behave as documented.

Closes #22

## Changes
- initialize built-in registries from `src/index.ts`
- add a regression test that verifies root import triggers registration side effects
- update package side-effect metadata so bundlers keep this initialization path
- remove redundant `regxa/registries` imports from root API README examples

## Testing
- pnpm test:run
- pnpm typecheck
- pnpm build

---
Co-Authored-By: Ori <18102267+oritwoen@users.noreply.github.com>