### PR TITLE
fix(pypi): parse PEP 508 markers properly for scope classification

### DIFF
--- a/src/registries/pypi.ts
+++ b/src/registries/pypi.ts
@@ -252,34 +252,39 @@ class PyPIRegistry implements Registry {
       .filter(Boolean);
   }
 
-  /** Parse PEP 508 dependency string. */
+  /** Parse PEP 508 dependency string into a normalized Dependency. */
   private parsePEP508(depStr: string): Dependency | null {
-    // Basic parsing: "name (version_spec) ; extras"
-    // For now, extract just the name and requirements
-    const parts = depStr.split(";");
-    const mainPart = parts[0]!.trim();
+    // PEP 508 format: name [extras] (version_spec) ; markers
+    const semiIdx = depStr.indexOf(";");
+    const mainPart = semiIdx === -1 ? depStr.trim() : depStr.slice(0, semiIdx).trim();
+    const markerStr = semiIdx === -1 ? "" : depStr.slice(semiIdx + 1).trim();
 
-    // Extract name and version spec
-    const match = mainPart.match(/^([a-zA-Z0-9._-]+)\s*(.*)$/);
+    // Extract name, skip [extras] bracket group, capture version spec
+    const match = mainPart.match(/^([a-zA-Z0-9._-]+)\s*(?:\[.*?\])?\s*(.*)$/);
     if (!match) return null;
 
     const depName = match[1]!;
-    const versionSpec = match[2]!.trim();
+    let versionSpec = match[2]!.trim();
 
-    // Determine scope based on extras (simplified)
+    // Strip surrounding parentheses: "(<4,>=2)" -> "<4,>=2"
+    if (versionSpec.startsWith("(") && versionSpec.endsWith(")")) {
+      versionSpec = versionSpec.slice(1, -1).trim();
+    }
+
+    // Only `extra == "..."` markers affect scope. Platform markers don't.
     let scope: "runtime" | "development" | "test" | "build" | "optional" = "runtime";
     let optional = false;
 
-    if (parts.length > 1) {
-      const extras = parts[1]!.toLowerCase();
-      if (extras.includes("extra")) {
+    if (markerStr) {
+      const extraMatch = markerStr.match(/extra\s*==\s*["']([^"']+)["']/);
+      if (extraMatch) {
         optional = true;
-      }
-      if (extras.includes("dev")) {
-        scope = "development";
-      }
-      if (extras.includes("test")) {
-        scope = "test";
+        const extraName = extraMatch[1]!.toLowerCase();
+        if (/^dev(elop(ment)?)?$/.test(extraName)) {
+          scope = "development";
+        } else if (/^test(s|ing)?$/.test(extraName)) {
+          scope = "test";
+        }
       }
     }
 

--- a/test/unit/registries.test.ts
+++ b/test/unit/registries.test.ts
@@ -444,6 +444,167 @@ describe("Registry Modules", () => {
       await expect(registry.fetchPackage("nonexistent-package-xyz")).rejects.toThrow(NotFoundError);
     });
 
+    it("should parse PEP 508 dependencies with version specs", async () => {
+      const client = new Client();
+      const mockResponse = {
+        info: {
+          name: "requests",
+          version: "2.31.0",
+          summary: "",
+          description: "",
+          license: "",
+          keywords: "",
+          author: "",
+          author_email: "",
+          project_urls: {},
+          requires_dist: [
+            "charset-normalizer (<4,>=2)",
+            "idna (<4,>=2.5)",
+            "urllib3 (<3,>=1.21.1)",
+            "certifi (>=2017.4.17)",
+          ],
+        },
+        releases: {},
+        urls: [],
+      };
+
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(mockResponse);
+
+      const registry = create("pypi", undefined, client);
+      const deps = await registry.fetchDependencies("requests", "2.31.0");
+
+      expect(deps).toHaveLength(4);
+      expect(deps[0].name).toBe("charset-normalizer");
+      expect(deps[0].requirements).toBe("<4,>=2");
+      expect(deps[0].scope).toBe("runtime");
+      expect(deps[0].optional).toBe(false);
+      expect(deps[1].name).toBe("idna");
+      expect(deps[1].requirements).toBe("<4,>=2.5");
+    });
+
+    it("should not misclassify platform markers as test/dev scope", async () => {
+      const client = new Client();
+      const mockResponse = {
+        info: {
+          name: "example",
+          version: "1.0.0",
+          summary: "",
+          description: "",
+          license: "",
+          keywords: "",
+          author: "",
+          author_email: "",
+          project_urls: {},
+          requires_dist: [
+            'colorama ; sys_platform == "win32"',
+            'importlib-metadata ; python_version < "3.8"',
+            'extra-pkg ; extra == "latest"',
+          ],
+        },
+        releases: {},
+        urls: [],
+      };
+
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(mockResponse);
+
+      const registry = create("pypi", undefined, client);
+      const deps = await registry.fetchDependencies("example", "1.0.0");
+
+      expect(deps).toHaveLength(3);
+
+      expect(deps[0].name).toBe("colorama");
+      expect(deps[0].scope).toBe("runtime");
+      expect(deps[0].optional).toBe(false);
+
+      expect(deps[1].name).toBe("importlib-metadata");
+      expect(deps[1].scope).toBe("runtime");
+      expect(deps[1].optional).toBe(false);
+
+      expect(deps[2].name).toBe("extra-pkg");
+      expect(deps[2].scope).toBe("runtime");
+      expect(deps[2].optional).toBe(true);
+    });
+
+    it("should classify extra markers into correct scopes", async () => {
+      const client = new Client();
+      const mockResponse = {
+        info: {
+          name: "example",
+          version: "1.0.0",
+          summary: "",
+          description: "",
+          license: "",
+          keywords: "",
+          author: "",
+          author_email: "",
+          project_urls: {},
+          requires_dist: [
+            'pytest (>=3.0) ; extra == "testing"',
+            'sphinx ; extra == "docs"',
+            'black ; extra == "dev"',
+            'mypy ; extra == "development"',
+          ],
+        },
+        releases: {},
+        urls: [],
+      };
+
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(mockResponse);
+
+      const registry = create("pypi", undefined, client);
+      const deps = await registry.fetchDependencies("example", "1.0.0");
+
+      expect(deps).toHaveLength(4);
+
+      expect(deps[0].name).toBe("pytest");
+      expect(deps[0].requirements).toBe(">=3.0");
+      expect(deps[0].scope).toBe("test");
+      expect(deps[0].optional).toBe(true);
+
+      expect(deps[1].name).toBe("sphinx");
+      expect(deps[1].scope).toBe("runtime");
+      expect(deps[1].optional).toBe(true);
+
+      expect(deps[2].name).toBe("black");
+      expect(deps[2].scope).toBe("development");
+      expect(deps[2].optional).toBe(true);
+
+      expect(deps[3].name).toBe("mypy");
+      expect(deps[3].scope).toBe("development");
+      expect(deps[3].optional).toBe(true);
+    });
+
+    it("should handle dependencies with extras in brackets", async () => {
+      const client = new Client();
+      const mockResponse = {
+        info: {
+          name: "example",
+          version: "1.0.0",
+          summary: "",
+          description: "",
+          license: "",
+          keywords: "",
+          author: "",
+          author_email: "",
+          project_urls: {},
+          requires_dist: ["requests[security] (>=2.25.0)", "urllib3"],
+        },
+        releases: {},
+        urls: [],
+      };
+
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(mockResponse);
+
+      const registry = create("pypi", undefined, client);
+      const deps = await registry.fetchDependencies("example", "1.0.0");
+
+      expect(deps).toHaveLength(2);
+      expect(deps[0].name).toBe("requests");
+      expect(deps[0].requirements).toBe(">=2.25.0");
+      expect(deps[1].name).toBe("urllib3");
+      expect(deps[1].requirements).toBe("");
+    });
+
     it("should fetch pypi versions with yanked status", async () => {
       const client = new Client();
       const mockResponse = {


### PR DESCRIPTION
The PEP 508 parser was using substring matching on environment markers to guess dependency scope. `extra == "latest"` got classified as test scope because the marker string contains "test". Platform markers like `sys_platform == "win32"` were also incorrectly affecting scope since "win32" doesn't contain "dev" or "test" but other platform values could.

The fix switches to proper `extra == "..."` marker extraction so only the extra name itself determines scope. Platform and python version markers are left alone - they don't change whether something is a dev or test dependency.

While in there, version specs now get their parentheses stripped (`(<4,>=2)` becomes `<4,>=2`) for consistency with how the other registries store version constraints, and `[extras]` bracket groups in package names are handled instead of leaking into the version spec.

Closes #24