### PR TITLE
fix(client): handle HTTP-date format in Retry-After header

### DIFF
--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -19,14 +19,15 @@ const DEFAULT_USER_AGENT = "regxa/0.1.0";
  */
 export function parseRetryAfter(header: string | null | undefined): number {
   if (!header) return 60;
+  const trimmed = header.trim();
+  if (!trimmed) return 60;
 
-  const numeric = Number.parseInt(header, 10);
-  if (!Number.isNaN(numeric) && numeric >= 0) return numeric;
+  if (/^\d+$/.test(trimmed)) return Number(trimmed);
 
-  const timestamp = Date.parse(header);
+  const timestamp = /[a-z]/i.test(trimmed) ? Date.parse(trimmed) : NaN;
   if (!Number.isNaN(timestamp)) {
     const seconds = Math.ceil((timestamp - Date.now()) / 1000);
-    return seconds > 0 ? seconds : 60;
+    return Math.max(seconds, 0);
   }
 
   return 60;

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -8,6 +8,30 @@ const DEFAULT_BASE_DELAY = 50;
 const DEFAULT_TIMEOUT = 30_000;
 const DEFAULT_USER_AGENT = "regxa/0.1.0";
 
+/**
+ * Parse a `Retry-After` header into seconds.
+ *
+ * Handles two formats (RFC 7231 §7.1.3):
+ * - **Numeric**: `"120"` → 120
+ * - **HTTP-date**: `"Wed, 21 Oct 2025 07:28:00 GMT"` → seconds until that time
+ *
+ * Returns 60 when the header is absent, empty, or unparseable.
+ */
+export function parseRetryAfter(header: string | null | undefined): number {
+  if (!header) return 60;
+
+  const numeric = Number.parseInt(header, 10);
+  if (!Number.isNaN(numeric) && numeric >= 0) return numeric;
+
+  const timestamp = Date.parse(header);
+  if (!Number.isNaN(timestamp)) {
+    const seconds = Math.ceil((timestamp - Date.now()) / 1000);
+    return seconds > 0 ? seconds : 60;
+  }
+
+  return 60;
+}
+
 /** HTTP client with retry, backoff, rate limiting, and timeout. */
 export class Client {
   readonly maxRetries: number;
@@ -56,11 +80,7 @@ export class Client {
     } catch (error) {
       if (error instanceof FetchError) {
         if (error.statusCode === 429) {
-          const retryAfter = Number.parseInt(
-            error.response?.headers.get("Retry-After") ?? "60",
-            10,
-          );
-          throw new RateLimitError(retryAfter);
+          throw new RateLimitError(parseRetryAfter(error.response?.headers.get("Retry-After")));
         }
 
         const body = typeof error.data === "string" ? error.data : JSON.stringify(error.data ?? "");

--- a/test/unit/client.test.ts
+++ b/test/unit/client.test.ts
@@ -23,10 +23,13 @@ describe("parseRetryAfter", () => {
 
   it("parses HTTP-date in the future", () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date("2025-01-01T00:00:00Z"));
-    const result = parseRetryAfter("Wed, 01 Jan 2025 00:01:30 GMT");
-    expect(result).toBe(90);
-    vi.useRealTimers();
+    try {
+      vi.setSystemTime(new Date("2025-01-01T00:00:00Z"));
+      const result = parseRetryAfter("Wed, 01 Jan 2025 00:01:30 GMT");
+      expect(result).toBe(90);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("returns 0 for HTTP-date in the past", () => {

--- a/test/unit/client.test.ts
+++ b/test/unit/client.test.ts
@@ -1,0 +1,42 @@
+import { parseRetryAfter } from "../../src/core/client.ts";
+
+describe("parseRetryAfter", () => {
+  it("parses numeric seconds", () => {
+    expect(parseRetryAfter("120")).toBe(120);
+  });
+
+  it("parses zero", () => {
+    expect(parseRetryAfter("0")).toBe(0);
+  });
+
+  it("returns 60 for null", () => {
+    expect(parseRetryAfter(null)).toBe(60);
+  });
+
+  it("returns 60 for undefined", () => {
+    expect(parseRetryAfter(undefined)).toBe(60);
+  });
+
+  it("returns 60 for empty string", () => {
+    expect(parseRetryAfter("")).toBe(60);
+  });
+
+  it("parses HTTP-date in the future", () => {
+    const future = new Date(Date.now() + 90_000);
+    const result = parseRetryAfter(future.toUTCString());
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThanOrEqual(90);
+  });
+
+  it("falls back to 60 for HTTP-date in the past", () => {
+    expect(parseRetryAfter("Wed, 21 Oct 2015 07:28:00 GMT")).toBe(60);
+  });
+
+  it("returns 60 for garbage input", () => {
+    expect(parseRetryAfter("not-a-number-or-date")).toBe(60);
+  });
+
+  it("handles large numeric values", () => {
+    expect(parseRetryAfter("3600")).toBe(3600);
+  });
+});

--- a/test/unit/client.test.ts
+++ b/test/unit/client.test.ts
@@ -22,10 +22,11 @@ describe("parseRetryAfter", () => {
   });
 
   it("parses HTTP-date in the future", () => {
-    const future = new Date(Date.now() + 90_000);
-    const result = parseRetryAfter(future.toUTCString());
-    expect(result).toBeGreaterThan(0);
-    expect(result).toBeLessThanOrEqual(90);
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-01-01T00:00:00Z"));
+    const result = parseRetryAfter("Wed, 01 Jan 2025 00:01:30 GMT");
+    expect(result).toBe(90);
+    vi.useRealTimers();
   });
 
   it("returns 0 for HTTP-date in the past", () => {
@@ -38,6 +39,10 @@ describe("parseRetryAfter", () => {
 
   it("handles large numeric values", () => {
     expect(parseRetryAfter("3600")).toBe(3600);
+  });
+
+  it("treats leading zeros as decimal", () => {
+    expect(parseRetryAfter("0120")).toBe(120);
   });
 
   it("rejects partial numeric like '120s'", () => {

--- a/test/unit/client.test.ts
+++ b/test/unit/client.test.ts
@@ -28,8 +28,8 @@ describe("parseRetryAfter", () => {
     expect(result).toBeLessThanOrEqual(90);
   });
 
-  it("falls back to 60 for HTTP-date in the past", () => {
-    expect(parseRetryAfter("Wed, 21 Oct 2015 07:28:00 GMT")).toBe(60);
+  it("returns 0 for HTTP-date in the past", () => {
+    expect(parseRetryAfter("Wed, 21 Oct 2015 07:28:00 GMT")).toBe(0);
   });
 
   it("returns 60 for garbage input", () => {
@@ -38,5 +38,17 @@ describe("parseRetryAfter", () => {
 
   it("handles large numeric values", () => {
     expect(parseRetryAfter("3600")).toBe(3600);
+  });
+
+  it("rejects partial numeric like '120s'", () => {
+    expect(parseRetryAfter("120s")).toBe(60);
+  });
+
+  it("rejects decimal like '1.5'", () => {
+    expect(parseRetryAfter("1.5")).toBe(60);
+  });
+
+  it("returns 60 for whitespace-only", () => {
+    expect(parseRetryAfter("   ")).toBe(60);
   });
 });


### PR DESCRIPTION
The `Retry-After` handler in `Client.getJSON` runs `Number.parseInt` on the raw header value. Numeric strings like `"120"` work fine, but RFC 7231 also allows HTTP-date values (`"Wed, 21 Oct 2025 07:28:00 GMT"`), and parseInt returns NaN for those. That NaN ends up in `RateLimitError.retryAfter`, which breaks the error message and any consumer code that reads the field.

Extracted a `parseRetryAfter()` function that tries numeric first, then `Date.parse` for HTTP-date, and falls back to 60s when neither works. The registries regxa targets all use numeric values today, but the NaN fallthrough was still a bug waiting to happen.

Addresses item 3 from #18.