### PR TITLE
fix(purl): throw InvalidPURLError for malformed percent-encoding

### DIFF
--- a/src/core/purl.ts
+++ b/src/core/purl.ts
@@ -3,6 +3,15 @@ import type { Client } from "./client.ts";
 import { create } from "./registry.ts";
 import { InvalidPURLError } from "./errors.ts";
 
+/** Decode a percent-encoded PURL component, throwing InvalidPURLError on malformed sequences. */
+function decodePURLComponent(purlStr: string, value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    throw new InvalidPURLError(purlStr, "malformed percent-encoding");
+  }
+}
+
 /**
  * Parse a PURL string into its components.
  *
@@ -24,7 +33,7 @@ export function parsePURL(purlStr: string): ParsedPURL {
     subpath = remainder
       .slice(hashIdx + 1)
       .split("/")
-      .map((s) => decodeURIComponent(s))
+      .map((s) => decodePURLComponent(purlStr, s))
       .join("/");
     remainder = remainder.slice(0, hashIdx);
   }
@@ -38,7 +47,8 @@ export function parsePURL(purlStr: string): ParsedPURL {
     for (const pair of queryStr.split("&")) {
       const eqIdx = pair.indexOf("=");
       if (eqIdx !== -1) {
-        qualifiers[decodeURIComponent(pair.slice(0, eqIdx))] = decodeURIComponent(
+        qualifiers[decodePURLComponent(purlStr, pair.slice(0, eqIdx))] = decodePURLComponent(
+          purlStr,
           pair.slice(eqIdx + 1),
         );
       }
@@ -49,7 +59,7 @@ export function parsePURL(purlStr: string): ParsedPURL {
   let version = "";
   const atIdx = remainder.indexOf("@");
   if (atIdx !== -1) {
-    version = decodeURIComponent(remainder.slice(atIdx + 1));
+    version = decodePURLComponent(purlStr, remainder.slice(atIdx + 1));
     remainder = remainder.slice(0, atIdx);
   }
 
@@ -78,11 +88,11 @@ export function parsePURL(purlStr: string): ParsedPURL {
     namespace = rest
       .slice(0, lastSlashIdx)
       .split("/")
-      .map((s) => decodeURIComponent(s))
+      .map((s) => decodePURLComponent(purlStr, s))
       .join("/");
-    name = decodeURIComponent(rest.slice(lastSlashIdx + 1));
+    name = decodePURLComponent(purlStr, rest.slice(lastSlashIdx + 1));
   } else {
-    name = decodeURIComponent(rest);
+    name = decodePURLComponent(purlStr, rest);
   }
 
   // Ecosystem-specific normalization per PURL spec

--- a/test/unit/purl.test.ts
+++ b/test/unit/purl.test.ts
@@ -135,6 +135,31 @@ describe("purl", () => {
       const result = parsePURL("pkg:NPM/lodash");
       expect(result.type).toBe("npm");
     });
+
+    it("throws InvalidPURLError for malformed percent-encoding in name", () => {
+      expect(() => parsePURL("pkg:npm/foo%ZZbar")).toThrow(InvalidPURLError);
+      expect(() => parsePURL("pkg:npm/foo%ZZbar")).toThrow("malformed percent-encoding");
+    });
+
+    it("throws InvalidPURLError for truncated percent-encoding", () => {
+      expect(() => parsePURL("pkg:npm/foo%")).toThrow(InvalidPURLError);
+    });
+
+    it("throws InvalidPURLError for malformed percent-encoding in version", () => {
+      expect(() => parsePURL("pkg:npm/lodash@1.0%GG")).toThrow(InvalidPURLError);
+    });
+
+    it("throws InvalidPURLError for malformed percent-encoding in namespace", () => {
+      expect(() => parsePURL("pkg:npm/%ZZ/core")).toThrow(InvalidPURLError);
+    });
+
+    it("throws InvalidPURLError for malformed percent-encoding in qualifiers", () => {
+      expect(() => parsePURL("pkg:npm/lodash?key=val%ZZ")).toThrow(InvalidPURLError);
+    });
+
+    it("throws InvalidPURLError for malformed percent-encoding in subpath", () => {
+      expect(() => parsePURL("pkg:npm/lodash#path/%ZZ")).toThrow(InvalidPURLError);
+    });
   });
 
   describe("fullName", () => {

--- a/test/unit/purl.test.ts
+++ b/test/unit/purl.test.ts
@@ -156,6 +156,10 @@ describe("purl", () => {
     it("throws InvalidPURLError for malformed percent-encoding in qualifiers", () => {
       expect(() => parsePURL("pkg:npm/lodash?key=val%ZZ")).toThrow(InvalidPURLError);
     });
+    it("throws InvalidPURLError for malformed percent-encoding in qualifier key", () => {
+      expect(() => parsePURL("pkg:npm/lodash?ke%ZZy=value")).toThrow(InvalidPURLError);
+    });
+    });
 
     it("throws InvalidPURLError for malformed percent-encoding in subpath", () => {
       expect(() => parsePURL("pkg:npm/lodash#path/%ZZ")).toThrow(InvalidPURLError);

--- a/test/unit/purl.test.ts
+++ b/test/unit/purl.test.ts
@@ -156,9 +156,9 @@ describe("purl", () => {
     it("throws InvalidPURLError for malformed percent-encoding in qualifiers", () => {
       expect(() => parsePURL("pkg:npm/lodash?key=val%ZZ")).toThrow(InvalidPURLError);
     });
+
     it("throws InvalidPURLError for malformed percent-encoding in qualifier key", () => {
       expect(() => parsePURL("pkg:npm/lodash?ke%ZZy=value")).toThrow(InvalidPURLError);
-    });
     });
 
     it("throws InvalidPURLError for malformed percent-encoding in subpath", () => {


### PR DESCRIPTION
`parsePURL` calls `decodeURIComponent` in six places (name, namespace, version, qualifiers, subpath) but never catches the `URIError` it throws on broken sequences like `%ZZ` or a trailing `%`. That means malformed input bypasses the typed error hierarchy - consumers catching `InvalidPURLError` won't see it, and the error message is a raw V8 `URIError: URI malformed` instead of something useful.

Adds a `decodePURLComponent` helper that catches decode failures and re-throws as `InvalidPURLError` with the original PURL string. Six new tests cover each component position.