### PR TITLE
fix(cache): don't discard fetched data on storage write failure

### DIFF
--- a/src/cache/cached-registry.ts
+++ b/src/cache/cached-registry.ts
@@ -113,10 +113,7 @@ export class CachedRegistry implements Registry {
     // 3. Fetch fresh data
     const value = await fetcher();
 
-    // Store to storage
-    await this.storage.setItem(storageKey, value as Record<string, unknown>);
-
-    // Update lockfile entry
+    // Persist to cache (best-effort — storage failures must not discard fetched data)
     const meta = extraMeta ? extraMeta(value) : {};
     const newEntry: LockfileEntry = {
       key,
@@ -126,8 +123,14 @@ export class CachedRegistry implements Registry {
       integrity: computeIntegrity(value),
       ...("latestVersion" in meta ? { latestVersion: meta["latestVersion"] as string } : {}),
     };
-    setEntry(lockfile, newEntry);
-    await writeLockfile(lockfile, this.lockfileStorage);
+    try {
+      await this.storage.setItem(storageKey, value as Record<string, unknown>);
+      setEntry(lockfile, newEntry);
+      await writeLockfile(lockfile, this.lockfileStorage);
+    } catch {
+      // Storage I/O failed (disk full, permissions, remote driver timeout, etc.).
+      // The data was already fetched successfully — return it anyway.
+    }
 
     return value;
   }

--- a/test/unit/cached-registry.test.ts
+++ b/test/unit/cached-registry.test.ts
@@ -641,6 +641,36 @@ describe("CachedRegistry", () => {
       await expect(cached.fetchPackage("pkg")).rejects.toThrow("Network error");
     });
 
+    it("returns fetched data when storage write fails", async () => {
+      const inner = createMockRegistry("npm", {
+        fetchPackage: async () => ({
+          name: "pkg",
+          description: "Package",
+          homepage: "",
+          repository: "",
+          licenses: "MIT",
+          keywords: [],
+          namespace: "",
+          latestVersion: "1.0.0",
+          metadata: {},
+        }),
+      });
+
+      const failingStorage = {
+        getItem: async () => null,
+        setItem: async () => {
+          throw new Error("Disk full");
+        },
+        clear: async () => {},
+        dispose: async () => {},
+      } as unknown as import("unstorage").Storage;
+
+      const cached = new CachedRegistry(inner, failingStorage);
+      const pkg = await cached.fetchPackage("pkg");
+      expect(pkg.name).toBe("pkg");
+      expect(pkg.latestVersion).toBe("1.0.0");
+    });
+
     it("handles AbortSignal", async () => {
       const inner = createMockRegistry("npm", {
         fetchPackage: async (name, signal) => {


### PR DESCRIPTION
Closes #33

`cached()` fetches registry data, then persists it to storage and updates the lockfile. If either write throws (disk full, permissions, remote driver timeout on something like Cloudflare KV), the exception bubbles up and the caller never gets the data that was already sitting in memory.

The fix wraps only the two storage I/O calls in try-catch. Pure computation (entry construction, integrity hashing) stays outside the catch so programming errors there still surface normally. On storage failure, the caller gets fresh data and next request just refetches.

`readLockfile()` already had this resilience pattern (try-catch with empty-lockfile fallback). The write side was missing it.

## Test plan

- [x] New test: `returns fetched data when storage write fails` - passes a storage mock that throws on `setItem`, verifies `fetchPackage` still returns the result
- [x] All 23 existing cached-registry tests pass
- [x] `tsc --noEmit` clean