### PR TITLE
fix(pypi): apply full PEP 503 normalization to package names

### DIFF
--- a/src/core/purl.ts
+++ b/src/core/purl.ts
@@ -97,7 +97,7 @@ export function parsePURL(purlStr: string): ParsedPURL {
 
   // Ecosystem-specific normalization per PURL spec
   if (type === "pypi") {
-    name = name.toLowerCase().replace(/_/g, "-");
+    name = name.toLowerCase().replace(/[-_.]+/g, "-");
   }
 
   if (type === "alpm") {

--- a/src/registries/pypi.ts
+++ b/src/registries/pypi.ts
@@ -225,7 +225,7 @@ class PyPIRegistry implements Registry {
 
   /** Normalize package name per PEP 503. */
   private normalizeName(name: string): string {
-    return name.toLowerCase().replace(/_/g, "-");
+    return name.toLowerCase().replace(/[-_.]+/g, "-");
   }
 
   /** Extract repository URL from project_urls. */
@@ -289,7 +289,7 @@ class PyPIRegistry implements Registry {
     }
 
     return {
-      name: depName,
+      name: this.normalizeName(depName),
       requirements: versionSpec,
       scope,
       optional,

--- a/test/unit/purl.test.ts
+++ b/test/unit/purl.test.ts
@@ -105,6 +105,14 @@ describe("purl", () => {
       expect(result.version).toBe("3.14.0");
     });
 
+    it("normalizes PyPI dots and separator runs per PEP 503", () => {
+      expect(parsePURL("pkg:pypi/my.package").name).toBe("my-package");
+      expect(parsePURL("pkg:pypi/my..package").name).toBe("my-package");
+      expect(parsePURL("pkg:pypi/my--package").name).toBe("my-package");
+      expect(parsePURL("pkg:pypi/my_-_package").name).toBe("my-package");
+      expect(parsePURL("pkg:pypi/Babel.js").name).toBe("babel-js");
+    });
+
     it("throws on missing pkg: prefix", () => {
       expect(() => parsePURL("npm/lodash")).toThrow(InvalidPURLError);
       expect(() => parsePURL("npm/lodash")).toThrow('must start with "pkg:"');


### PR DESCRIPTION
Package name normalization only replaced underscores with hyphens, but PEP 503 specifies collapsing any run of `[-_.]` into a single hyphen. A package like `zope.interface` or `my--package` would pass through with dots and double hyphens intact, which breaks cache key consistency and can cause duplicate entries for the same package.

The regex in both `purl.ts` and `pypi.ts` now matches the reference implementation from PEP 503: `re.sub(r"[-_.]+", "-", name).lower()`. Also normalized dependency names coming out of `parsePEP508`, so `requires_dist` entries like `zope.interface>=5.0` produce `zope-interface` instead of the raw dotted form.

## Test plan

- [x] New test: dots, double-dots, double-hyphens, mixed separators (`my_-_package`) all collapse to single hyphen
- [x] Full test suite (320 tests) passes
- [x] `tsc --noEmit` clean