### PR TITLE
fix(cli): use dynamic ecosystem list in unknown-ecosystem error

### DIFF
--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -1,7 +1,7 @@
 import consola from "consola";
 import type { Registry } from "../core/types.ts";
 import { createFromPURL, parsePURL, fullName } from "../core/purl.ts";
-import { create } from "../core/registry.ts";
+import { create, ecosystems } from "../core/registry.ts";
 import { NotFoundError, UnknownEcosystemError, InvalidPURLError } from "../core/errors.ts";
 import { CachedRegistry } from "../cache/cached-registry.ts";
 import "../registries/index.ts";
@@ -53,7 +53,7 @@ export async function withErrorHandling(fn: () => Promise<void>): Promise<void> 
     }
     if (error instanceof UnknownEcosystemError) {
       consola.error(`Unknown ecosystem: ${error.ecosystem}`);
-      consola.info("Supported: npm, cargo, pypi, gem, composer");
+      consola.info(`Supported: ${ecosystems().join(", ")}`);
       process.exit(1);
     }
     if (error instanceof InvalidPURLError) {


### PR DESCRIPTION
The "Supported: npm, cargo, pypi, gem, composer" string in the unknown-ecosystem error was hardcoded and already missing alpm. Replaced it with `ecosystems()` from registry.ts so the list stays in sync automatically as new registries are added.

## Test plan

- [x] Full suite (321 tests) passes
- [x] `tsc --noEmit` clean