### PR TITLE
fix(registries): use buildPURL for proper percent-encoding in urls().purl()

### DIFF
--- a/src/registries/alpm.ts
+++ b/src/registries/alpm.ts
@@ -11,6 +11,7 @@ import type {
 import { register } from "../core/registry.ts";
 import { HTTPError, NotFoundError } from "../core/errors.ts";
 import { combineLicenses } from "../core/license.ts";
+import { buildPURL } from "../core/purl.ts";
 
 const AUR_BASE_URL = "https://aur.archlinux.org";
 
@@ -172,8 +173,7 @@ class AlpmRegistry implements Registry {
       },
       purl: (name: string, version?: string) => {
         const { namespace, pkgName } = this.parseName(name);
-        const versionSuffix = version ? `@${version}` : "";
-        return `pkg:alpm/${namespace}/${pkgName}${versionSuffix}`;
+        return buildPURL({ type: "alpm", namespace, name: pkgName, version });
       },
     };
   }

--- a/src/registries/cargo.ts
+++ b/src/registries/cargo.ts
@@ -12,6 +12,7 @@ import { register } from "../core/registry.ts";
 import { HTTPError, NotFoundError } from "../core/errors.ts";
 import { normalizeLicense } from "../core/license.ts";
 import { normalizeRepositoryURL } from "../core/repository.ts";
+import { buildPURL } from "../core/purl.ts";
 
 /** Crates.io API response for a single crate. */
 interface CratesPackageResponse {
@@ -272,8 +273,7 @@ class CargoRegistry implements Registry {
           : `https://crates.io/crates/${name}`;
       },
       purl: (name: string, version?: string) => {
-        const versionSuffix = version ? `@${version}` : "";
-        return `pkg:cargo/${name}${versionSuffix}`;
+        return buildPURL({ type: "cargo", name, version });
       },
     };
   }

--- a/src/registries/npm.ts
+++ b/src/registries/npm.ts
@@ -12,6 +12,7 @@ import { register } from "../core/registry.ts";
 import { HTTPError, NotFoundError } from "../core/errors.ts";
 import { normalizeLicense } from "../core/license.ts";
 import { normalizeRepositoryURL } from "../core/repository.ts";
+import { buildPURL } from "../core/purl.ts";
 
 /** npm registry API response for a single package. */
 interface NpmPackageResponse {
@@ -329,8 +330,9 @@ class NpmRegistry implements Registry {
         return `https://cdn.jsdelivr.net/npm/${name}${ver}/README.md`;
       },
       purl: (name: string, version?: string) => {
-        const versionSuffix = version ? `@${version}` : "";
-        return `pkg:npm/${name}${versionSuffix}`;
+        const namespace = this.extractNamespace(name);
+        const bareName = namespace ? name.slice(namespace.length + 1) : name;
+        return buildPURL({ type: "npm", namespace, name: bareName, version });
       },
     };
   }

--- a/src/registries/packagist.ts
+++ b/src/registries/packagist.ts
@@ -12,6 +12,7 @@ import { register } from "../core/registry.ts";
 import { HTTPError, NotFoundError, InvalidPURLError } from "../core/errors.ts";
 import { combineLicenses } from "../core/license.ts";
 import { normalizeRepositoryURL } from "../core/repository.ts";
+import { buildPURL } from "../core/purl.ts";
 
 /** Packagist API response for a single package. */
 interface PackagistPackageResponse {
@@ -248,8 +249,8 @@ class PackagistRegistry implements Registry {
         return `https://packagist.org/packages/${vendor}/${pkg}`;
       },
       purl: (name: string, version?: string) => {
-        const versionSuffix = version ? `@${version}` : "";
-        return `pkg:composer/${name}${versionSuffix}`;
+        const [vendor, pkg] = this.parseName(name);
+        return buildPURL({ type: "composer", namespace: vendor, name: pkg, version });
       },
     };
   }

--- a/src/registries/pypi.ts
+++ b/src/registries/pypi.ts
@@ -12,6 +12,7 @@ import { register } from "../core/registry.ts";
 import { HTTPError, NotFoundError } from "../core/errors.ts";
 import { normalizeLicense } from "../core/license.ts";
 import { normalizeRepositoryURL } from "../core/repository.ts";
+import { buildPURL } from "../core/purl.ts";
 
 /** PyPI JSON API response for a package. */
 interface PyPIPackageResponse {
@@ -216,9 +217,7 @@ class PyPIRegistry implements Registry {
           : `https://pypi.org/project/${normalized}/`;
       },
       purl: (name: string, version?: string) => {
-        const normalized = this.normalizeName(name);
-        const versionSuffix = version ? `@${version}` : "";
-        return `pkg:pypi/${normalized}${versionSuffix}`;
+        return buildPURL({ type: "pypi", name: this.normalizeName(name), version });
       },
     };
   }

--- a/src/registries/rubygems.ts
+++ b/src/registries/rubygems.ts
@@ -12,6 +12,7 @@ import { register } from "../core/registry.ts";
 import { HTTPError, NotFoundError } from "../core/errors.ts";
 import { combineLicenses, normalizeLicense } from "../core/license.ts";
 import { normalizeRepositoryURL } from "../core/repository.ts";
+import { buildPURL } from "../core/purl.ts";
 
 /** RubyGems API response for a single gem. */
 interface RubyGemsGemResponse {
@@ -221,8 +222,7 @@ class RubyGemsRegistry implements Registry {
         return version ? `${base}/versions/${version}` : base;
       },
       purl: (name: string, version?: string) => {
-        const versionSuffix = version ? `@${version}` : "";
-        return `pkg:gem/${name}${versionSuffix}`;
+        return buildPURL({ type: "gem", name, version });
       },
     };
   }

--- a/test/unit/registries.test.ts
+++ b/test/unit/registries.test.ts
@@ -118,6 +118,14 @@ describe("Registry Modules", () => {
       expect(versions[1].number).toBe("4.17.21");
       expect(versions[1].status).toBe("");
     });
+
+    it("should produce valid PURL for scoped packages", () => {
+      const registry = create("npm");
+      const urls = registry.urls();
+      expect(urls.purl("@babel/core", "7.0.0")).toBe("pkg:npm/%40babel/core@7.0.0");
+      expect(urls.purl("@babel/core")).toBe("pkg:npm/%40babel/core");
+      expect(urls.purl("lodash", "4.17.21")).toBe("pkg:npm/lodash@4.17.21");
+    });
   });
 
   describe("cargo registry", () => {


### PR DESCRIPTION
## Summary

- `urls().purl()` in every registry manually built PURL strings without percent-encoding
- For npm scoped packages like `@babel/core`, the output `pkg:npm/@babel/core` can't round-trip through `parsePURL` because the `@` gets mistaken for a version separator
- Switched all six registries to use the shared `buildPURL` function which encodes per the PURL spec

## Test plan

- [x] Added test for npm scoped package PURL output (`@babel/core` -> `pkg:npm/%40babel/core`)
- [x] Full test suite passes (322 tests)