### PR TITLE
feat: add agent skills for package registry queries and AI tool integration

### DIFF
--- a/skills/regxa-ai-tool/SKILL.md
+++ b/skills/regxa-ai-tool/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: regxa-ai-tool
+description: Integrates regxa's packageTool into AI applications built with the Vercel AI SDK. Provides structured package registry queries (info, versions, dependencies, maintainers, bulk lookups) as a tool for LLM agents. Use when building AI apps that need to query npm, PyPI, crates.io, or other registries. Do not use for direct CLI usage or non-AI integrations.
+---
+
+# regxa AI Tool Integration
+
+regxa exports a ready-made `packageTool` compatible with the Vercel AI SDK. It gives AI agents structured access to package registry data across npm, PyPI, crates.io, RubyGems, Packagist, and Arch Linux.
+
+## Step 1: Install Dependencies
+
+```bash
+npm install regxa ai @ai-sdk/openai  # or any AI SDK provider
+```
+
+## Step 2: Register the Tool
+
+Import `packageTool` from `regxa/ai` and pass it to the AI SDK:
+
+```typescript
+import { generateText } from "ai";
+import { openai } from "@ai-sdk/openai";
+import { packageTool } from "regxa/ai";
+
+const result = await generateText({
+  model: openai("gpt-4o"),
+  tools: { package: packageTool },
+  prompt: "What are the dependencies of flask 3.1.1?",
+});
+```
+
+The tool handles PURL construction, API calls, normalization, and error handling internally.
+
+## Step 3: Understand the Operations
+
+The tool accepts a discriminated union input with these operations:
+
+### `package` - Fetch package metadata
+
+```json
+{ "operation": "package", "purl": "pkg:npm/lodash" }
+```
+
+Returns: name, description, licenses, repository, latest version, keywords.
+
+### `versions` - List all versions
+
+```json
+{ "operation": "versions", "purl": "pkg:cargo/serde" }
+```
+
+Returns: version numbers, publish dates, integrity hashes, status (yanked/deprecated).
+
+### `dependencies` - List dependencies for a version
+
+```json
+{ "operation": "dependencies", "purl": "pkg:pypi/flask@3.1.1" }
+```
+
+Returns: dependency names, version constraints, scope (runtime/dev/test/build), optional flag.
+
+**Note:** The PURL must include a version. Without it, the tool returns an error.
+
+### `maintainers` - List package maintainers
+
+```json
+{ "operation": "maintainers", "purl": "pkg:gem/rails" }
+```
+
+Returns: login, name, email, role for each maintainer.
+
+### `bulk-packages` - Fetch multiple packages at once
+
+```json
+{ "operation": "bulk-packages", "purls": ["pkg:npm/lodash", "pkg:cargo/serde"], "concurrency": 10 }
+```
+
+Returns: map of PURL to package metadata. Fetches up to 50 PURLs concurrently (default concurrency: 15). Failed lookups are silently omitted.
+
+## Step 4: Use with Streaming
+
+The tool works with `streamText` as well:
+
+```typescript
+import { streamText } from "ai";
+import { packageTool } from "regxa/ai";
+
+const result = streamText({
+  model: openai("gpt-4o"),
+  tools: { package: packageTool },
+  prompt: "Compare the latest versions of express and fastify",
+});
+
+for await (const chunk of result.textStream) {
+  process.stdout.write(chunk);
+}
+```
+
+## PURL Format Quick Reference
+
+Read `references/purl-cheatsheet.md` for the PURL format details and ecosystem-specific examples.
+
+## Error Handling
+
+The tool handles errors internally and returns them as structured error objects:
+
+- **Package not found**: Returns error with ecosystem and package name
+- **Invalid PURL**: Returns parse error with details
+- **Unknown ecosystem**: Returns list of supported ecosystems
+- **Rate limiting**: The HTTP client retries automatically with exponential backoff
+
+If the tool call fails at the AI SDK level, the agent receives the error message and can self-correct (e.g., fix PURL format, try a different ecosystem).

--- a/skills/regxa-ai-tool/SKILL.md
+++ b/skills/regxa-ai-tool/SKILL.md
@@ -113,4 +113,4 @@ The tool throws errors as exceptions (not structured return values). The AI SDK 
 - **`UnknownEcosystemError`**: Unsupported ecosystem type
 - **`RateLimitError`**: Registry rate limit hit (the HTTP client retries automatically first)
 
-When using `maxSteps` or a tool loop, the agent receives the error message and can self-correct (e.g., fix PURL format, try a different ecosystem). For single-step calls, errors propagate to the caller. If you need custom error handling, wrap the tool's `execute` function.
+With multi-step tool use, failed calls appear as `tool-error` parts and the agent can self-correct (e.g., fix PURL format, try a different ecosystem). If you need custom error handling, wrap the tool's `execute` function.

--- a/skills/regxa-ai-tool/SKILL.md
+++ b/skills/regxa-ai-tool/SKILL.md
@@ -60,7 +60,7 @@ Returns: version numbers, publish dates, integrity hashes, status (yanked/deprec
 { "operation": "dependencies", "purl": "pkg:pypi/flask@3.1.1" }
 ```
 
-Returns: dependency names, version constraints, scope (runtime/dev/test/build), optional flag.
+Returns: dependency names, version constraints, scope (runtime/development/test/build/optional), optional flag.
 
 **Note:** The PURL must include a version. Without it, the tool returns an error.
 
@@ -86,6 +86,7 @@ The tool works with `streamText` as well:
 
 ```typescript
 import { streamText } from "ai";
+import { openai } from "@ai-sdk/openai";
 import { packageTool } from "regxa/ai";
 
 const result = streamText({
@@ -112,4 +113,4 @@ The tool throws errors as exceptions (not structured return values). The AI SDK 
 - **`UnknownEcosystemError`**: Unsupported ecosystem type
 - **`RateLimitError`**: Registry rate limit hit (the HTTP client retries automatically first)
 
-The agent receives the error message and can self-correct (e.g., fix PURL format, try a different ecosystem). If you need custom error handling, wrap the tool's `execute` function.
+When using `maxSteps` or a tool loop, the agent receives the error message and can self-correct (e.g., fix PURL format, try a different ecosystem). For single-step calls, errors propagate to the caller. If you need custom error handling, wrap the tool's `execute` function.

--- a/skills/regxa-ai-tool/SKILL.md
+++ b/skills/regxa-ai-tool/SKILL.md
@@ -105,11 +105,11 @@ Read `references/purl-cheatsheet.md` for the PURL format details and ecosystem-s
 
 ## Error Handling
 
-The tool handles errors internally and returns them as structured error objects:
+The tool throws errors as exceptions (not structured return values). The AI SDK catches these and surfaces them to the agent as tool call failures:
 
-- **Package not found**: Returns error with ecosystem and package name
-- **Invalid PURL**: Returns parse error with details
-- **Unknown ecosystem**: Returns list of supported ecosystems
-- **Rate limiting**: The HTTP client retries automatically with exponential backoff
+- **`NotFoundError`**: Package or version does not exist
+- **`InvalidPURLError`**: Malformed PURL string (missing `pkg:` prefix, bad encoding)
+- **`UnknownEcosystemError`**: Unsupported ecosystem type
+- **`RateLimitError`**: Registry rate limit hit (the HTTP client retries automatically first)
 
-If the tool call fails at the AI SDK level, the agent receives the error message and can self-correct (e.g., fix PURL format, try a different ecosystem).
+The agent receives the error message and can self-correct (e.g., fix PURL format, try a different ecosystem). If you need custom error handling, wrap the tool's `execute` function.

--- a/skills/regxa-ai-tool/SKILL.md
+++ b/skills/regxa-ai-tool/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: regxa-ai-tool
 description: Integrates regxa's packageTool into AI applications built with the Vercel AI SDK. Provides structured package registry queries (info, versions, dependencies, maintainers, bulk lookups) as a tool for LLM agents. Use when building AI apps that need to query npm, PyPI, crates.io, or other registries. Do not use for direct CLI usage or non-AI integrations.
+metadata:
+  author: oritwoen
+  version: "0.1.5"
 ---
 
 # regxa AI Tool Integration

--- a/skills/regxa-ai-tool/agents/openai.yaml
+++ b/skills/regxa-ai-tool/agents/openai.yaml
@@ -1,0 +1,12 @@
+interface:
+  display_name: regxa AI Tool
+  short_description: Integrate regxa packageTool into Vercel AI SDK apps for structured registry queries
+  brand_color: "#3b82f6"
+  default_prompt: Set up packageTool for an AI agent that needs to query package registries
+
+policy:
+  allow_implicit_invocation: false
+
+dependencies:
+  tools:
+    - regxa

--- a/skills/regxa-ai-tool/references/purl-cheatsheet.md
+++ b/skills/regxa-ai-tool/references/purl-cheatsheet.md
@@ -1,0 +1,52 @@
+# PURL Cheatsheet
+
+Quick reference for constructing PURLs to pass to the regxa AI tool.
+
+## Format
+
+```
+pkg:<type>/<name>@<version>
+```
+
+## Examples by Ecosystem
+
+| Package | PURL |
+|---------|------|
+| lodash (npm) | `pkg:npm/lodash` |
+| lodash v4.17.21 | `pkg:npm/lodash@4.17.21` |
+| @babel/core (npm scoped) | `pkg:npm/%40babel/core@7.0.0` |
+| flask (PyPI) | `pkg:pypi/flask@3.1.1` |
+| Django REST Framework | `pkg:pypi/django-rest-framework` |
+| serde (Rust) | `pkg:cargo/serde@1.0.0` |
+| rails (Ruby) | `pkg:gem/rails@7.1.0` |
+| laravel/framework (PHP) | `pkg:composer/laravel/framework@11.0.0` |
+| linux (Arch official) | `pkg:alpm/arch/linux` |
+| yay (AUR) | `pkg:alpm/aur/yay` |
+
+## Scoped Packages
+
+npm scopes: encode `@` as `%40`:
+- `@vue/core` -> `pkg:npm/%40vue/core`
+- `@types/node` -> `pkg:npm/%40types/node`
+
+Composer vendors: use path separator:
+- `symfony/console` -> `pkg:composer/symfony/console`
+
+## Common Mistakes
+
+| Wrong | Correct | Why |
+|-------|---------|-----|
+| `pkg:npm/@babel/core` | `pkg:npm/%40babel/core` | `@` must be percent-encoded |
+| `pkg:pip/flask` | `pkg:pypi/flask` | Type is `pypi`, not `pip` |
+| `pkg:crate/serde` | `pkg:cargo/serde` | Type is `cargo`, not `crate` |
+| `pkg:rubygems/rails` | `pkg:gem/rails` | Type is `gem`, not `rubygems` |
+| `pkg:packagist/laravel/framework` | `pkg:composer/laravel/framework` | Type is `composer` |
+| `pkg:pypi/Django_REST_Framework` | `pkg:pypi/django-rest-framework` | PyPI names are normalized |
+
+## Operations That Require a Version
+
+The `dependencies` operation requires a version in the PURL:
+- `pkg:npm/lodash@4.17.21` (works)
+- `pkg:npm/lodash` (fails for dependencies)
+
+All other operations work with or without a version.

--- a/skills/regxa/SKILL.md
+++ b/skills/regxa/SKILL.md
@@ -27,7 +27,7 @@ pkg:<type>/<name>@<version>
 | Packagist | `composer` | `pkg:composer/laravel/framework@11.0.0` |
 | Arch Linux | `alpm` | `pkg:alpm/arch/linux`, `pkg:alpm/aur/yay` |
 
-The CLI accepts shorthand without the `pkg:` prefix (e.g., `npm/lodash@4.17.21`). The library API requires the full `pkg:` prefix.
+The CLI accepts shorthand without the `pkg:` prefix (e.g., `npm/lodash@4.17.21`). The PURL helpers (`fetchPackageFromPURL`, etc.) require the full `pkg:` prefix. The lower-level registry API takes bare package names directly.
 
 Read `references/purl-guide.md` for scoped packages, namespaces, and special characters.
 
@@ -67,7 +67,7 @@ regxa maintainers pkg:composer/laravel/framework
 regxa cache clear          # Clear all cached data
 ```
 
-All commands accept `--json` for machine-readable output and `--no-cache` to bypass the cache.
+Query commands (`info`, `versions`, `deps`, `maintainers`) accept `--json` for machine-readable output and `--no-cache` to bypass the cache.
 
 ## Using the Library API
 
@@ -103,7 +103,7 @@ const deps = await fetchDependenciesFromPURL("pkg:pypi/flask@3.1.1");
 // Maintainers
 const maintainers = await fetchMaintainersFromPURL("pkg:gem/rails");
 
-// Bulk fetch (up to 50, concurrent)
+// Bulk fetch (concurrent)
 const packages = await bulkFetchPackages([
   "pkg:npm/lodash",
   "pkg:cargo/serde",
@@ -152,7 +152,7 @@ import { selectVersion, resolveDocsUrl } from "regxa";
 const best = selectVersion(versions, { requested: "4.17.21" });
 
 // Resolve documentation URL with fallback chain
-const docsUrl = resolveDocsUrl(pkg, registry.urls(), "4.17.21");
+const docsUrl = resolveDocsUrl(pkg, npm.urls(), "4.17.21");
 ```
 
 Read `references/api-reference.md` for the full type definitions and return shapes.

--- a/skills/regxa/SKILL.md
+++ b/skills/regxa/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: regxa
+description: Query package metadata from npm, PyPI, crates.io, RubyGems, Packagist, and Arch Linux using regxa. Supports looking up package info, versions, dependencies, and maintainers via PURL-native API or CLI. Use when the user needs package registry data across ecosystems. Do not use for building or publishing packages, managing lockfiles, or installing dependencies.
+---
+
+# Query Package Registries with regxa
+
+regxa is a universal package registry client. It queries npm, PyPI, crates.io, RubyGems, Packagist, and Arch Linux with a single API. Packages are addressed using PURLs (Package URLs).
+
+## PURL Format
+
+All queries use PURLs to identify packages:
+
+```
+pkg:<type>/<name>@<version>
+```
+
+| Ecosystem | PURL type | Example |
+|-----------|-----------|---------|
+| npm | `npm` | `pkg:npm/lodash`, `pkg:npm/%40babel/core@7.0.0` |
+| PyPI | `pypi` | `pkg:pypi/flask@3.1.1` |
+| crates.io | `cargo` | `pkg:cargo/serde@1.0.0` |
+| RubyGems | `gem` | `pkg:gem/rails@7.1.0` |
+| Packagist | `composer` | `pkg:composer/laravel/framework@11.0.0` |
+| Arch Linux | `alpm` | `pkg:alpm/arch/linux`, `pkg:alpm/aur/yay` |
+
+Shorthand without `pkg:` prefix also works: `npm/lodash@4.17.21`.
+
+Read `references/purl-guide.md` for scoped packages, namespaces, and special characters.
+
+## Using the CLI
+
+### Package info
+
+```bash
+regxa info npm/lodash
+regxa info pkg:cargo/serde --json
+```
+
+### Version listing
+
+```bash
+regxa versions pypi/flask
+regxa versions pkg:npm/%40vue/core --json
+```
+
+### Dependencies (requires version)
+
+```bash
+regxa deps npm/lodash@4.17.21
+regxa deps pkg:pypi/flask@3.1.1 --json
+```
+
+### Maintainers
+
+```bash
+regxa maintainers gem/rails
+regxa maintainers pkg:composer/laravel/framework
+```
+
+### Cache management
+
+```bash
+regxa cache clear          # Clear all cached data
+regxa cache clear npm      # Clear cache for one ecosystem
+```
+
+All commands accept `--json` for machine-readable output and `--no-cache` to bypass the cache.
+
+## Using the Library API
+
+### Install
+
+```bash
+npm install regxa
+```
+
+### One-shot PURL helpers
+
+The simplest way to query. Pass a PURL string, get normalized data:
+
+```typescript
+import {
+  fetchPackageFromPURL,
+  fetchVersionsFromPURL,
+  fetchDependenciesFromPURL,
+  fetchMaintainersFromPURL,
+  bulkFetchPackages,
+} from "regxa";
+
+// Single package
+const pkg = await fetchPackageFromPURL("pkg:npm/lodash");
+console.log(pkg.name, pkg.licenses, pkg.latestVersion);
+
+// All versions
+const versions = await fetchVersionsFromPURL("pkg:cargo/serde");
+
+// Dependencies for a specific version
+const deps = await fetchDependenciesFromPURL("pkg:pypi/flask@3.1.1");
+
+// Maintainers
+const maintainers = await fetchMaintainersFromPURL("pkg:gem/rails");
+
+// Bulk fetch (up to 50, concurrent)
+const packages = await bulkFetchPackages([
+  "pkg:npm/lodash",
+  "pkg:cargo/serde",
+  "pkg:pypi/flask",
+]);
+```
+
+### Registry API (lower level)
+
+For more control, create a registry instance directly:
+
+```typescript
+import { create } from "regxa";
+
+const npm = create("npm");
+
+const pkg = await npm.fetchPackage("lodash");
+const versions = await npm.fetchVersions("@babel/core");
+const deps = await npm.fetchDependencies("lodash", "4.17.21");
+const urls = npm.urls();
+console.log(urls.registry("lodash"));       // npmjs.com URL
+console.log(urls.documentation("lodash"));  // docs URL
+console.log(urls.purl("lodash", "4.17.21")); // PURL string
+```
+
+### Cached queries
+
+Wrap any registry with caching:
+
+```typescript
+import { create, CachedRegistry } from "regxa";
+
+const npm = create("npm");
+const cached = new CachedRegistry(npm);
+
+// First call fetches from network, subsequent calls use disk cache
+const pkg = await cached.fetchPackage("lodash");
+```
+
+### Helper utilities
+
+```typescript
+import { selectVersion, resolveDocsUrl } from "regxa";
+
+// Pick the best version from a list
+const best = selectVersion(versions, { requested: "4.17.21" });
+
+// Resolve documentation URL with fallback chain
+const docsUrl = resolveDocsUrl(pkg, registry.urls(), "4.17.21");
+```
+
+Read `references/api-reference.md` for the full type definitions and return shapes.
+
+## Error Handling
+
+| Error | When | What to do |
+|-------|------|------------|
+| `NotFoundError` | Package or version does not exist | Check the PURL spelling and ecosystem |
+| `InvalidPURLError` | Malformed PURL string | Fix the format (see PURL table above) |
+| `UnknownEcosystemError` | Unsupported ecosystem type | Use one of: npm, cargo, pypi, gem, composer, alpm |
+| `RateLimitError` | Registry rate limit hit | The client retries automatically; wait if persistent |

--- a/skills/regxa/SKILL.md
+++ b/skills/regxa/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: regxa
 description: Query package metadata from npm, PyPI, crates.io, RubyGems, Packagist, and Arch Linux using regxa. Supports looking up package info, versions, dependencies, and maintainers via PURL-native API or CLI. Use when the user needs package registry data across ecosystems. Do not use for building or publishing packages, managing lockfiles, or installing dependencies.
+metadata:
+  author: oritwoen
+  version: "0.1.5"
 ---
 
 # Query Package Registries with regxa

--- a/skills/regxa/SKILL.md
+++ b/skills/regxa/SKILL.md
@@ -14,7 +14,7 @@ regxa is a universal package registry client. It queries npm, PyPI, crates.io, R
 
 All queries use PURLs to identify packages:
 
-```
+```text
 pkg:<type>/<name>@<version>
 ```
 
@@ -146,12 +146,13 @@ const pkg = await cached.fetchPackage("lodash");
 ### Helper utilities
 
 ```typescript
-import { selectVersion, resolveDocsUrl } from "regxa";
+import { create, selectVersion, resolveDocsUrl } from "regxa";
 
 // Pick the best version from a list
 const best = selectVersion(versions, { requested: "4.17.21" });
 
 // Resolve documentation URL with fallback chain
+const npm = create("npm");
 const docsUrl = resolveDocsUrl(pkg, npm.urls(), "4.17.21");
 ```
 

--- a/skills/regxa/SKILL.md
+++ b/skills/regxa/SKILL.md
@@ -27,7 +27,7 @@ pkg:<type>/<name>@<version>
 | Packagist | `composer` | `pkg:composer/laravel/framework@11.0.0` |
 | Arch Linux | `alpm` | `pkg:alpm/arch/linux`, `pkg:alpm/aur/yay` |
 
-Shorthand without `pkg:` prefix also works: `npm/lodash@4.17.21`.
+The CLI accepts shorthand without the `pkg:` prefix (e.g., `npm/lodash@4.17.21`). The library API requires the full `pkg:` prefix.
 
 Read `references/purl-guide.md` for scoped packages, namespaces, and special characters.
 
@@ -65,7 +65,6 @@ regxa maintainers pkg:composer/laravel/framework
 
 ```bash
 regxa cache clear          # Clear all cached data
-regxa cache clear npm      # Clear cache for one ecosystem
 ```
 
 All commands accept `--json` for machine-readable output and `--no-cache` to bypass the cache.

--- a/skills/regxa/agents/openai.yaml
+++ b/skills/regxa/agents/openai.yaml
@@ -1,0 +1,8 @@
+interface:
+  display_name: regxa
+  short_description: Query package registries (npm, PyPI, crates.io, RubyGems, Packagist, Arch Linux) using PURLs
+  brand_color: "#3b82f6"
+  default_prompt: Look up package info, versions, dependencies, or maintainers across ecosystems
+
+policy:
+  allow_implicit_invocation: true

--- a/skills/regxa/references/api-reference.md
+++ b/skills/regxa/references/api-reference.md
@@ -1,0 +1,104 @@
+# API Reference
+
+## Return Types
+
+### Package
+
+Returned by `fetchPackageFromPURL()` and `registry.fetchPackage()`:
+
+```typescript
+interface Package {
+  name: string;           // "lodash", "@babel/core", "flask"
+  description: string;    // Short summary
+  homepage: string;       // Project homepage URL
+  documentation: string;  // Docs URL
+  repository: string;     // Normalized git repository URL
+  licenses: string;       // SPDX expression: "MIT", "Apache-2.0 OR MIT"
+  keywords: string[];     // Tags
+  namespace: string;      // "@babel" for npm, "laravel" for composer, "" if none
+  latestVersion: string;  // Latest stable version
+  metadata: Record<string, unknown>; // Ecosystem-specific extras
+}
+```
+
+### Version
+
+Returned by `fetchVersionsFromPURL()` and `registry.fetchVersions()`:
+
+```typescript
+interface Version {
+  number: string;           // "4.17.21", "1.0.0"
+  publishedAt: Date | null; // Publish timestamp
+  licenses: string;         // SPDX for this version
+  integrity: string;        // "sha256-<hex>" or "sha1-<hex>"
+  status: "" | "yanked" | "deprecated" | "retracted";
+  metadata: Record<string, unknown>;
+}
+```
+
+### Dependency
+
+Returned by `fetchDependenciesFromPURL()` and `registry.fetchDependencies()`:
+
+```typescript
+interface Dependency {
+  name: string;        // "express", "tokio"
+  requirements: string; // "^1.0.0", ">=2,<4"
+  scope: "runtime" | "development" | "test" | "build" | "optional";
+  optional: boolean;
+}
+```
+
+### Maintainer
+
+Returned by `fetchMaintainersFromPURL()` and `registry.fetchMaintainers()`:
+
+```typescript
+interface Maintainer {
+  uuid: string;  // Registry-specific ID
+  login: string; // Username
+  name: string;  // Display name
+  email: string; // Email address
+  url: string;   // Profile URL
+  role: string;  // "author", "contributor", "owner", ""
+}
+```
+
+## Helper Functions
+
+### selectVersion(versions, options?)
+
+Pick the best version from a list. Resolution order:
+1. Exact match for `options.requested` (non-yanked)
+2. Exact match for `options.latest` (non-yanked)
+3. Newest available version with no negative status
+
+Returns `null` if no usable version exists.
+
+### bulkFetchPackages(purls, options?)
+
+Fetch metadata for up to 50 packages concurrently. Failed lookups are silently omitted from the result map.
+
+Options:
+- `concurrency`: Max concurrent fetches (default: 15)
+- `signal`: AbortSignal for cancellation
+- `client`: Custom HTTP client
+
+### resolveDocsUrl(pkg, urls, version?)
+
+Resolve the best documentation URL. Fallback chain: `pkg.documentation` -> `pkg.homepage` -> `urls.documentation()`.
+
+### resolveReadmeUrl(pkg, urls, version?)
+
+Get the ecosystem-specific README URL.
+
+## Supported Ecosystems
+
+| Ecosystem | Type | Default Registry |
+|-----------|------|-----------------|
+| npm | `npm` | registry.npmjs.org |
+| PyPI | `pypi` | pypi.org |
+| crates.io | `cargo` | crates.io |
+| RubyGems | `gem` | rubygems.org |
+| Packagist | `composer` | packagist.org |
+| Arch Linux | `alpm` | archlinux.org + aur.archlinux.org |

--- a/skills/regxa/references/purl-guide.md
+++ b/skills/regxa/references/purl-guide.md
@@ -53,15 +53,17 @@ Characters that need percent-encoding in PURLs:
 | `+` | `%2B` | `1.0.0%2Bbuild.123` |
 | space | `%20` | `my%20package` |
 
-## Shorthand
+## Shorthand (CLI only)
 
-regxa accepts shorthand without the `pkg:` prefix:
+The CLI accepts shorthand without the `pkg:` prefix:
 
 ```
 npm/lodash@4.17.21          -> pkg:npm/lodash@4.17.21
 cargo/serde                 -> pkg:cargo/serde
 pypi/flask@3.1.1            -> pkg:pypi/flask@3.1.1
 ```
+
+The library API (`fetchPackageFromPURL`, `parsePURL`, etc.) requires the full `pkg:` prefix. Shorthand will throw `InvalidPURLError`.
 
 ## Name Normalization
 

--- a/skills/regxa/references/purl-guide.md
+++ b/skills/regxa/references/purl-guide.md
@@ -1,0 +1,99 @@
+# PURL Guide
+
+Package URLs (PURLs) identify packages across ecosystems. Full spec: [github.com/package-url/purl-spec](https://github.com/package-url/purl-spec).
+
+## Format
+
+```
+pkg:<type>/<namespace>/<name>@<version>?<qualifiers>#<subpath>
+```
+
+Only `type` and `name` are required. Everything else is optional.
+
+## Scoped and Namespaced Packages
+
+### npm scoped packages
+
+The `@` in npm scopes must be percent-encoded as `%40`:
+
+```
+pkg:npm/%40babel/core@7.0.0    # @babel/core
+pkg:npm/%40vue/core             # @vue/core
+pkg:npm/lodash                  # unscoped, no namespace
+```
+
+### Packagist (Composer)
+
+Vendor is the namespace:
+
+```
+pkg:composer/laravel/framework@11.0.0
+pkg:composer/symfony/console
+```
+
+### Arch Linux (ALPM)
+
+Repository is the namespace (`arch` for official, `aur` for AUR):
+
+```
+pkg:alpm/arch/linux
+pkg:alpm/aur/yay
+```
+
+If no namespace is given, `arch` is assumed.
+
+## Special Characters
+
+Characters that need percent-encoding in PURLs:
+
+| Character | Encoded | Example |
+|-----------|---------|---------|
+| `@` | `%40` | `%40babel/core` |
+| `/` | `%2F` | (in name only, not as separator) |
+| `+` | `%2B` | `1.0.0%2Bbuild.123` |
+| space | `%20` | `my%20package` |
+
+## Shorthand
+
+regxa accepts shorthand without the `pkg:` prefix:
+
+```
+npm/lodash@4.17.21          -> pkg:npm/lodash@4.17.21
+cargo/serde                 -> pkg:cargo/serde
+pypi/flask@3.1.1            -> pkg:pypi/flask@3.1.1
+```
+
+## Name Normalization
+
+Some ecosystems normalize package names during PURL parsing:
+
+- **PyPI**: Lowercased, runs of `-`, `_`, `.` collapsed to single `-`. `Django_REST_Framework` becomes `django-rest-framework`.
+- **ALPM**: Lowercased.
+- **npm, cargo, gem, composer**: No normalization (case-sensitive).
+
+## Qualifiers
+
+Optional key-value pairs after `?`:
+
+```
+pkg:npm/lodash?repository_url=https://custom.registry.com
+```
+
+The `repository_url` qualifier overrides the default registry base URL.
+
+## Building PURLs Programmatically
+
+```typescript
+import { buildPURL, parsePURL } from "regxa";
+
+const purl = buildPURL({
+  type: "npm",
+  namespace: "@babel",
+  name: "core",
+  version: "7.0.0",
+});
+// -> "pkg:npm/%40babel/core@7.0.0"
+
+const parsed = parsePURL("pkg:npm/%40babel/core@7.0.0");
+// -> { type: "npm", namespace: "@babel", name: "core", version: "7.0.0", qualifiers: {}, subpath: "" }
+```


### PR DESCRIPTION
## Summary

Two agent skills following the [agentskills.io spec](https://github.com/mgechev/skills-best-practices) for [skills.sh](https://skills.sh/):

- **regxa** - teaches agents how to query package registries using regxa's CLI and library API. Covers all 6 ecosystems, PURL format, caching, helpers.
- **regxa-ai-tool** - teaches agents how to integrate regxa's `packageTool` into Vercel AI SDK applications. Covers all 5 operations (package, versions, dependencies, maintainers, bulk).

Both skills use progressive disclosure - lean SKILL.md files with JiT-loaded references for detailed type contracts, PURL encoding rules, and common mistakes.

## Test plan

- [x] Skill directory names match frontmatter `name` fields
- [x] SKILL.md files under 500 lines (main skill: ~120, ai-tool: ~100)
- [x] References are flat (one level deep)
- [x] Instructions use third-person imperative
- [x] No human-centric files (README, CHANGELOG)
- [x] Code examples match current regxa API