### PR TITLE
fix(helpers): check abort signal in bulk fetch worker loop

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -57,13 +57,18 @@ export async function bulkFetchPackages(
   const results = new Map<string, Package>();
   const queue = [...purls];
 
+  const signal = options?.signal;
+
   const workers = Array.from({ length: Math.min(concurrency, queue.length) }, async () => {
     while (queue.length > 0) {
+      if (signal?.aborted) break;
+
       const purl = queue.shift()!;
       try {
-        const pkg = await fetchPackageFromPURL(purl, options?.signal, options?.client);
+        const pkg = await fetchPackageFromPURL(purl, signal, options?.client);
         results.set(purl, pkg);
       } catch {
+        if (signal?.aborted) break;
         // Silently skip failed lookups — absent from results map
       }
     }

--- a/test/unit/helpers.test.ts
+++ b/test/unit/helpers.test.ts
@@ -181,6 +181,10 @@ describe("fetchDependenciesFromPURL", () => {
 });
 
 describe("bulkFetchPackages", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   function makeMockRegistry(
     fetchPackage: (name: string, signal?: AbortSignal) => Promise<Package>,
   ) {
@@ -218,8 +222,6 @@ describe("bulkFetchPackages", () => {
 
     expect(results.size).toBe(0);
     expect(fetchPackage).not.toHaveBeenCalled();
-
-    vi.restoreAllMocks();
   });
 
   it("stops workers when signal is aborted mid-flight", async () => {
@@ -248,8 +250,6 @@ describe("bulkFetchPackages", () => {
 
     expect(results.size).toBeLessThanOrEqual(1);
     expect(fetchCount).toBeLessThanOrEqual(2);
-
-    vi.restoreAllMocks();
   });
 });
 

--- a/test/unit/helpers.test.ts
+++ b/test/unit/helpers.test.ts
@@ -4,6 +4,7 @@ import {
   resolveDocsUrl,
   resolveReadmeUrl,
   fetchDependenciesFromPURL,
+  bulkFetchPackages,
 } from "../../src/helpers.ts";
 import { InvalidPURLError } from "../../src/core/errors.ts";
 import "../../src/registries/index.ts";
@@ -176,6 +177,79 @@ describe("fetchDependenciesFromPURL", () => {
   it("includes PURL string in InvalidPURLError", async () => {
     const purl = "pkg:npm/lodash";
     await expect(fetchDependenciesFromPURL(purl)).rejects.toThrow(purl);
+  });
+});
+
+describe("bulkFetchPackages", () => {
+  function makeMockRegistry(
+    fetchPackage: (name: string, signal?: AbortSignal) => Promise<Package>,
+  ) {
+    return {
+      ecosystem: () => "npm",
+      fetchPackage,
+      fetchVersions: async () => [],
+      fetchDependencies: async () => [],
+      fetchMaintainers: async () => [],
+      urls: () => ({
+        registry: () => "",
+        download: () => "",
+        documentation: () => "",
+        readme: () => "",
+        purl: () => "",
+      }),
+    };
+  }
+
+  it("stops fetching when signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const fetchPackage = vi.fn().mockResolvedValue(pkg());
+    const registry = makeMockRegistry(fetchPackage);
+    vi.spyOn(await import("../../src/core/purl.ts"), "createFromPURL").mockReturnValue([
+      registry,
+      "test",
+      "",
+    ]);
+
+    const results = await bulkFetchPackages(["pkg:npm/a", "pkg:npm/b", "pkg:npm/c"], {
+      signal: controller.signal,
+    });
+
+    expect(results.size).toBe(0);
+    expect(fetchPackage).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+
+  it("stops workers when signal is aborted mid-flight", async () => {
+    const controller = new AbortController();
+    let fetchCount = 0;
+
+    const fetchPackage = vi.fn().mockImplementation(async (name: string, signal?: AbortSignal) => {
+      fetchCount++;
+      if (fetchCount >= 2) controller.abort();
+      if (signal?.aborted) throw new DOMException("Aborted", "AbortError");
+      return pkg({ name });
+    });
+
+    vi.spyOn(await import("../../src/core/purl.ts"), "createFromPURL").mockImplementation(
+      (purl: string) => {
+        const name = purl.replace("pkg:npm/", "");
+        return [makeMockRegistry(fetchPackage), name, ""];
+      },
+    );
+
+    const purls = Array.from({ length: 20 }, (_, i) => `pkg:npm/pkg-${i}`);
+    const results = await bulkFetchPackages(purls, {
+      signal: controller.signal,
+      concurrency: 1,
+    });
+
+    expect(results.size).toBeLessThanOrEqual(2);
+    expect(fetchCount).toBeLessThanOrEqual(3);
+
+    vi.restoreAllMocks();
   });
 });
 

--- a/test/unit/helpers.test.ts
+++ b/test/unit/helpers.test.ts
@@ -246,8 +246,8 @@ describe("bulkFetchPackages", () => {
       concurrency: 1,
     });
 
-    expect(results.size).toBeLessThanOrEqual(2);
-    expect(fetchCount).toBeLessThanOrEqual(3);
+    expect(results.size).toBeLessThanOrEqual(1);
+    expect(fetchCount).toBeLessThanOrEqual(2);
 
     vi.restoreAllMocks();
   });


### PR DESCRIPTION
`bulkFetchPackages` workers kept draining the queue after the signal was aborted - the loop never checked `signal.aborted`, and the unconditional `catch` swallowed abort errors just like any other failure. So a canceled AI tool call would still fire off every remaining registry lookup until the queue ran dry.

Two changes in the worker loop: break before dequeuing when the signal is already aborted, and break after a failed fetch if the signal got aborted in the meantime. The signal reference is hoisted out of the options bag to avoid repeated property access.

Tests cover both pre-aborted signals (zero fetches expected) and mid-flight abort (workers stop within one iteration).

Closes #31