### PR TITLE
fix(pypi): handle missing releases key in version enumeration

### DIFF
--- a/src/registries/pypi.ts
+++ b/src/registries/pypi.ts
@@ -28,7 +28,7 @@ interface PyPIPackageResponse {
     project_urls: Record<string, string>;
     requires_dist: string[] | null;
   };
-  releases: Record<string, PyPIRelease[]>;
+  releases?: Record<string, PyPIRelease[]>;
   urls: PyPIFile[];
 }
 
@@ -108,7 +108,8 @@ class PyPIRegistry implements Registry {
       const data = await this.client.getJSON<PyPIPackageResponse>(url, signal);
       const versions: Version[] = [];
 
-      for (const [versionStr, releases] of Object.entries(data.releases)) {
+      const releaseMap = data.releases ?? {};
+      for (const [versionStr, releases] of Object.entries(releaseMap)) {
         if (releases.length === 0) continue;
 
         const release = releases[0]!;

--- a/src/registries/pypi.ts
+++ b/src/registries/pypi.ts
@@ -28,7 +28,7 @@ interface PyPIPackageResponse {
     project_urls: Record<string, string>;
     requires_dist: string[] | null;
   };
-  releases?: Record<string, PyPIRelease[]>;
+  releases?: Record<string, PyPIRelease[]> | null;
   urls: PyPIFile[];
 }
 

--- a/test/unit/registries.test.ts
+++ b/test/unit/registries.test.ts
@@ -669,6 +669,59 @@ describe("Registry Modules", () => {
       expect(versions[1].number).toBe("2.31.0");
       expect(versions[1].status).toBe("yanked");
     });
+
+    it("should return empty versions when releases key is missing", async () => {
+      const client = new Client();
+      const mockResponse = {
+        info: {
+          name: "requests",
+          version: "2.31.0",
+          summary: "Python HTTP for Humans.",
+          description: "",
+          license: "Apache 2.0",
+          keywords: "",
+          author: "Kenneth Reitz",
+          author_email: "me@kennethreitz.org",
+          project_urls: {},
+          requires_dist: null,
+        },
+        urls: [],
+      };
+
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(mockResponse);
+
+      const registry = create("pypi", undefined, client);
+      const versions = await registry.fetchVersions("requests");
+
+      expect(versions).toHaveLength(0);
+    });
+
+    it("should return empty versions when releases is null", async () => {
+      const client = new Client();
+      const mockResponse = {
+        info: {
+          name: "requests",
+          version: "2.31.0",
+          summary: "",
+          description: "",
+          license: "",
+          keywords: "",
+          author: "",
+          author_email: "",
+          project_urls: {},
+          requires_dist: null,
+        },
+        releases: null,
+        urls: [],
+      };
+
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(mockResponse);
+
+      const registry = create("pypi", undefined, client);
+      const versions = await registry.fetchVersions("requests");
+
+      expect(versions).toHaveLength(0);
+    });
   });
 
   describe("rubygems registry", () => {


### PR DESCRIPTION
`fetchVersions` calls `Object.entries(data.releases)` directly, which throws if PyPI omits the `releases` key from the JSON response. Some packages have this field stripped or set to null when using filtered endpoints.

Made `releases` optional in the response interface and fall back to an empty object before iterating. Tests cover both undefined and null cases.

Closes #32