### PR TITLE
fix(npm): use top-level maintainers instead of scanning all versions

### DIFF
--- a/src/registries/npm.ts
+++ b/src/registries/npm.ts
@@ -35,6 +35,11 @@ interface NpmPackageResponse {
     latest: string;
   };
   versions: Record<string, NpmVersion>;
+  maintainers?: Array<{
+    name?: string;
+    email?: string;
+    url?: string;
+  }>;
   time?: Record<string, string>;
 }
 
@@ -246,58 +251,54 @@ class NpmRegistry implements Registry {
       const maintainers: Maintainer[] = [];
       const seen = new Set<string>();
 
-      // Collect from maintainers field
-      if (data.versions) {
-        for (const versionData of Object.values(data.versions)) {
-          if (versionData.maintainers) {
-            for (const maintainer of versionData.maintainers) {
-              const key = `${maintainer.name}:${maintainer.email}`;
-              if (!seen.has(key)) {
-                seen.add(key);
-                maintainers.push({
-                  uuid: "",
-                  login: maintainer.email ? maintainer.email.split("@")[0] : "",
-                  name: maintainer.name || "",
-                  email: maintainer.email || "",
-                  url: maintainer.url || "",
-                  role: "",
-                });
-              }
-            }
-          }
+      // Use top-level maintainers (people with publish access)
+      if (data.maintainers) {
+        for (const maintainer of data.maintainers) {
+          const key = `${maintainer.name}:${maintainer.email}`;
+          seen.add(key);
+          maintainers.push({
+            uuid: "",
+            login: maintainer.email ? maintainer.email.split("@")[0] : "",
+            name: maintainer.name || "",
+            email: maintainer.email || "",
+            url: maintainer.url || "",
+            role: "",
+          });
+        }
+      }
 
-          // Collect from author field
-          if (versionData.author) {
-            const key = `${versionData.author.name}:${versionData.author.email}`;
-            if (!seen.has(key)) {
-              seen.add(key);
-              maintainers.push({
-                uuid: "",
-                login: versionData.author.email ? versionData.author.email.split("@")[0] : "",
-                name: versionData.author.name || "",
-                email: versionData.author.email || "",
-                url: versionData.author.url || "",
-                role: "author",
-              });
-            }
-          }
+      // Supplement with author and contributors from the latest version only
+      const latestTag = data["dist-tags"].latest;
+      const latestVersion = data.versions[latestTag];
 
-          // Collect from contributors field
-          if (versionData.contributors) {
-            for (const contributor of versionData.contributors) {
-              const key = `${contributor.name}:${contributor.email}`;
-              if (!seen.has(key)) {
-                seen.add(key);
-                maintainers.push({
-                  uuid: "",
-                  login: contributor.email ? contributor.email.split("@")[0] : "",
-                  name: contributor.name || "",
-                  email: contributor.email || "",
-                  url: contributor.url || "",
-                  role: "contributor",
-                });
-              }
-            }
+      if (latestVersion?.author) {
+        const key = `${latestVersion.author.name}:${latestVersion.author.email}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          maintainers.push({
+            uuid: "",
+            login: latestVersion.author.email ? latestVersion.author.email.split("@")[0] : "",
+            name: latestVersion.author.name || "",
+            email: latestVersion.author.email || "",
+            url: latestVersion.author.url || "",
+            role: "author",
+          });
+        }
+      }
+
+      if (latestVersion?.contributors) {
+        for (const contributor of latestVersion.contributors) {
+          const key = `${contributor.name}:${contributor.email}`;
+          if (!seen.has(key)) {
+            seen.add(key);
+            maintainers.push({
+              uuid: "",
+              login: contributor.email ? contributor.email.split("@")[0] : "",
+              name: contributor.name || "",
+              email: contributor.email || "",
+              url: contributor.url || "",
+              role: "contributor",
+            });
           }
         }
       }

--- a/src/registries/npm.ts
+++ b/src/registries/npm.ts
@@ -254,7 +254,8 @@ class NpmRegistry implements Registry {
       // Use top-level maintainers (people with publish access)
       if (data.maintainers) {
         for (const maintainer of data.maintainers) {
-          const key = `${maintainer.name}:${maintainer.email}`;
+          const key = this.maintainerKey(maintainer.name, maintainer.email);
+          if (!key || seen.has(key)) continue;
           seen.add(key);
           maintainers.push({
             uuid: "",
@@ -272,8 +273,8 @@ class NpmRegistry implements Registry {
       const latestVersion = data.versions[latestTag];
 
       if (latestVersion?.author) {
-        const key = `${latestVersion.author.name}:${latestVersion.author.email}`;
-        if (!seen.has(key)) {
+        const key = this.maintainerKey(latestVersion.author.name, latestVersion.author.email);
+        if (key && !seen.has(key)) {
           seen.add(key);
           maintainers.push({
             uuid: "",
@@ -288,8 +289,8 @@ class NpmRegistry implements Registry {
 
       if (latestVersion?.contributors) {
         for (const contributor of latestVersion.contributors) {
-          const key = `${contributor.name}:${contributor.email}`;
-          if (!seen.has(key)) {
+          const key = this.maintainerKey(contributor.name, contributor.email);
+          if (key && !seen.has(key)) {
             seen.add(key);
             maintainers.push({
               uuid: "",
@@ -336,6 +337,14 @@ class NpmRegistry implements Registry {
         return buildPURL({ type: "npm", namespace, name: bareName, version });
       },
     };
+  }
+
+  /** Build a stable dedup key from name+email. Returns empty string when both are missing. */
+  private maintainerKey(name: string | undefined, email: string | undefined): string {
+    const n = name || "";
+    const e = email || "";
+    if (!n && !e) return "";
+    return `${n}:${e}`;
   }
 
   /** Encode package name for URL (handle scoped packages). */

--- a/src/registries/npm.ts
+++ b/src/registries/npm.ts
@@ -339,12 +339,11 @@ class NpmRegistry implements Registry {
     };
   }
 
-  /** Build a stable dedup key from name+email. Returns empty string when both are missing. */
+  /** Build a stable dedup key. Prefers email (unique per account), falls back to name. */
   private maintainerKey(name: string | undefined, email: string | undefined): string {
-    const n = name || "";
-    const e = email || "";
-    if (!n && !e) return "";
-    return `${n}:${e}`;
+    if (email) return email;
+    if (name) return name;
+    return "";
   }
 
   /** Encode package name for URL (handle scoped packages). */

--- a/test/unit/registries.test.ts
+++ b/test/unit/registries.test.ts
@@ -119,6 +119,51 @@ describe("Registry Modules", () => {
       expect(versions[1].status).toBe("");
     });
 
+    it("should use top-level maintainers instead of scanning all versions", async () => {
+      const client = new Client();
+      const mockResponse = {
+        name: "lodash",
+        "dist-tags": { latest: "4.17.21" },
+        maintainers: [
+          { name: "jdalton", email: "john@davidclarkson.com" },
+          { name: "mathias", email: "mathias@example.com" },
+        ],
+        versions: {
+          "4.17.20": {
+            name: "lodash",
+            version: "4.17.20",
+            author: { name: "Old Author", email: "old@example.com" },
+            maintainers: [{ name: "jdalton", email: "john@davidclarkson.com" }],
+          },
+          "4.17.21": {
+            name: "lodash",
+            version: "4.17.21",
+            author: { name: "jdalton", email: "john@davidclarkson.com" },
+            contributors: [{ name: "Blaine Bublitz", email: "blaine@example.com" }],
+            maintainers: [
+              { name: "jdalton", email: "john@davidclarkson.com" },
+              { name: "mathias", email: "mathias@example.com" },
+            ],
+          },
+        },
+      };
+
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(mockResponse);
+
+      const registry = create("npm", undefined, client);
+      const maintainers = await registry.fetchMaintainers("lodash");
+
+      // Top-level maintainers (jdalton, mathias) + contributor from latest (Blaine)
+      // Author "jdalton" is deduplicated against top-level maintainer
+      // Old versions' author ("Old Author") is NOT included - only latest version
+      expect(maintainers).toHaveLength(3);
+      expect(maintainers[0].name).toBe("jdalton");
+      expect(maintainers[0].role).toBe("");
+      expect(maintainers[1].name).toBe("mathias");
+      expect(maintainers[2].name).toBe("Blaine Bublitz");
+      expect(maintainers[2].role).toBe("contributor");
+    });
+
     it("should produce valid PURL for scoped packages", () => {
       const registry = create("npm");
       const urls = registry.urls();


### PR DESCRIPTION
`fetchMaintainers` was iterating through every single version of a package to collect maintainers, authors, and contributors. For packages like lodash with hundreds of versions, that's a lot of wasted work producing stale results (old version authors who might not even be involved anymore).

The npm registry returns a top-level `maintainers` array on the package document - the people who actually have publish access. The code was ignoring it entirely.

Now uses the root-level `maintainers` as primary source and supplements with author/contributors from the latest version only. Same API call, same response shape, just reads the right field.