### PR TITLE
fix(license): use OR instead of AND when combining multiple licenses

### DIFF
--- a/src/core/license.ts
+++ b/src/core/license.ts
@@ -57,11 +57,17 @@ const LICENSE_MAP = new Map<string, string>([
 
 /**
  * Combine multiple license strings into a single SPDX expression.
+ *
+ * Default operator is OR (disjunctive, user picks one).
+ * Pass "AND" for ecosystems where multiple licenses mean all apply (e.g. Arch Linux).
  */
-export function combineLicenses(licenses: (string | null | undefined)[]): string {
+export function combineLicenses(
+  licenses: (string | null | undefined)[],
+  operator: "OR" | "AND" = "OR",
+): string {
   const normalized = licenses.map((l) => normalizeLicense(l)).filter(Boolean);
 
   if (normalized.length === 0) return "";
   if (normalized.length === 1) return normalized[0]!;
-  return normalized.join(" OR ");
+  return normalized.join(` ${operator} `);
 }

--- a/src/core/license.ts
+++ b/src/core/license.ts
@@ -63,5 +63,5 @@ export function combineLicenses(licenses: (string | null | undefined)[]): string
 
   if (normalized.length === 0) return "";
   if (normalized.length === 1) return normalized[0]!;
-  return normalized.join(" AND ");
+  return normalized.join(" OR ");
 }

--- a/src/registries/alpm.ts
+++ b/src/registries/alpm.ts
@@ -189,7 +189,7 @@ class AlpmRegistry implements Registry {
       homepage: result.url || "",
       documentation: "",
       repository: "",
-      licenses: combineLicenses(result.licenses, "AND"),
+      licenses: combineLicenses(result.licenses),
       keywords: result.groups,
       namespace: "arch",
       latestVersion: this.formatVersion(result),
@@ -217,7 +217,7 @@ class AlpmRegistry implements Registry {
       {
         number: this.formatVersion(result),
         publishedAt: result.last_update ? new Date(result.last_update) : null,
-        licenses: combineLicenses(result.licenses, "AND"),
+        licenses: combineLicenses(result.licenses),
         integrity: "",
         status: result.flag_date ? "deprecated" : "",
         metadata: {
@@ -294,7 +294,7 @@ class AlpmRegistry implements Registry {
       homepage: result.URL || "",
       documentation: "",
       repository: "",
-      licenses: combineLicenses(result.License || [], "AND"),
+      licenses: combineLicenses(result.License || []),
       keywords: result.Keywords || [],
       namespace: "aur",
       latestVersion: result.Version,
@@ -316,7 +316,7 @@ class AlpmRegistry implements Registry {
       {
         number: result.Version,
         publishedAt: result.LastModified ? new Date(result.LastModified * 1000) : null,
-        licenses: combineLicenses(result.License || [], "AND"),
+        licenses: combineLicenses(result.License || []),
         integrity: "",
         status: result.OutOfDate ? "deprecated" : "",
         metadata: {

--- a/src/registries/alpm.ts
+++ b/src/registries/alpm.ts
@@ -189,7 +189,7 @@ class AlpmRegistry implements Registry {
       homepage: result.url || "",
       documentation: "",
       repository: "",
-      licenses: combineLicenses(result.licenses),
+      licenses: combineLicenses(result.licenses, "AND"),
       keywords: result.groups,
       namespace: "arch",
       latestVersion: this.formatVersion(result),
@@ -217,7 +217,7 @@ class AlpmRegistry implements Registry {
       {
         number: this.formatVersion(result),
         publishedAt: result.last_update ? new Date(result.last_update) : null,
-        licenses: combineLicenses(result.licenses),
+        licenses: combineLicenses(result.licenses, "AND"),
         integrity: "",
         status: result.flag_date ? "deprecated" : "",
         metadata: {
@@ -294,7 +294,7 @@ class AlpmRegistry implements Registry {
       homepage: result.URL || "",
       documentation: "",
       repository: "",
-      licenses: combineLicenses(result.License || []),
+      licenses: combineLicenses(result.License || [], "AND"),
       keywords: result.Keywords || [],
       namespace: "aur",
       latestVersion: result.Version,
@@ -316,7 +316,7 @@ class AlpmRegistry implements Registry {
       {
         number: result.Version,
         publishedAt: result.LastModified ? new Date(result.LastModified * 1000) : null,
-        licenses: combineLicenses(result.License || []),
+        licenses: combineLicenses(result.License || [], "AND"),
         integrity: "",
         status: result.OutOfDate ? "deprecated" : "",
         metadata: {

--- a/test/unit/license.test.ts
+++ b/test/unit/license.test.ts
@@ -144,28 +144,28 @@ describe("license", () => {
       expect(combineLicenses(["MIT License"])).toBe("MIT");
     });
 
-    it("combines two licenses with AND", () => {
-      expect(combineLicenses(["MIT", "Apache-2.0"])).toBe("MIT AND Apache-2.0");
+    it("combines two licenses with OR", () => {
+      expect(combineLicenses(["MIT", "Apache-2.0"])).toBe("MIT OR Apache-2.0");
     });
 
-    it("combines multiple licenses with AND", () => {
-      expect(combineLicenses(["MIT", "Apache-2.0", "ISC"])).toBe("MIT AND Apache-2.0 AND ISC");
+    it("combines multiple licenses with OR", () => {
+      expect(combineLicenses(["MIT", "Apache-2.0", "ISC"])).toBe("MIT OR Apache-2.0 OR ISC");
     });
 
     it("normalizes licenses before combining", () => {
-      expect(combineLicenses(["MIT License", "Apache 2.0"])).toBe("MIT AND Apache-2.0");
+      expect(combineLicenses(["MIT License", "Apache 2.0"])).toBe("MIT OR Apache-2.0");
     });
 
     it("filters out null/undefined values", () => {
-      expect(combineLicenses(["MIT", null, "Apache-2.0", undefined])).toBe("MIT AND Apache-2.0");
+      expect(combineLicenses(["MIT", null, "Apache-2.0", undefined])).toBe("MIT OR Apache-2.0");
     });
 
     it("filters out empty strings", () => {
-      expect(combineLicenses(["MIT", "", "Apache-2.0"])).toBe("MIT AND Apache-2.0");
+      expect(combineLicenses(["MIT", "", "Apache-2.0"])).toBe("MIT OR Apache-2.0");
     });
 
     it("filters out whitespace-only strings", () => {
-      expect(combineLicenses(["MIT", "   ", "Apache-2.0"])).toBe("MIT AND Apache-2.0");
+      expect(combineLicenses(["MIT", "   ", "Apache-2.0"])).toBe("MIT OR Apache-2.0");
     });
 
     it("handles all nulls/undefined/empty", () => {
@@ -174,7 +174,7 @@ describe("license", () => {
 
     it("combines with normalization and filtering", () => {
       expect(combineLicenses(["MIT License", null, "Apache 2.0", undefined, ""])).toBe(
-        "MIT AND Apache-2.0",
+        "MIT OR Apache-2.0",
       );
     });
   });


### PR DESCRIPTION
`combineLicenses` was joining multiple licenses with `" AND "`, which in SPDX means "you must comply with all of them". When a registry returns an array of licenses (RubyGems `licenses: ["MIT", "Apache-2.0"]`, Packagist `license: ["MIT", "Apache-2.0"]`), the semantics are disjunctive - the user picks one. Composer docs say this explicitly: "array = disjunctive license".

So `["MIT", "Apache-2.0"]` should produce `"MIT OR Apache-2.0"`, not `"MIT AND Apache-2.0"`. One-word fix, but gets the SPDX expression right for every multi-licensed package coming through RubyGems and Packagist adapters.