### PR TITLE
fix(pypi): match project_urls keys case-insensitively

### DIFF
--- a/src/registries/pypi.ts
+++ b/src/registries/pypi.ts
@@ -237,7 +237,7 @@ class PyPIRegistry implements Registry {
       "GitHub",
       "Homepage",
     ]);
-    return url ? normalizeRepositoryURL(url) : "";
+    return normalizeRepositoryURL(url);
   }
 
   /** Find a project URL by key, case-insensitive. */

--- a/src/registries/pypi.ts
+++ b/src/registries/pypi.ts
@@ -83,8 +83,8 @@ class PyPIRegistry implements Registry {
       return {
         name: info.name,
         description: info.summary || info.description || "",
-        homepage: this.findProjectUrl(info.project_urls, ["Homepage"]) || "",
-        documentation: this.findProjectUrl(info.project_urls, ["Documentation"]) || "",
+        homepage: this.findProjectUrl(info.project_urls, ["Homepage"]),
+        documentation: this.findProjectUrl(info.project_urls, ["Documentation"]),
         repository,
         licenses,
         keywords,

--- a/src/registries/pypi.ts
+++ b/src/registries/pypi.ts
@@ -83,8 +83,8 @@ class PyPIRegistry implements Registry {
       return {
         name: info.name,
         description: info.summary || info.description || "",
-        homepage: info.project_urls?.["Homepage"] || "",
-        documentation: info.project_urls?.["Documentation"] || "",
+        homepage: this.findProjectUrl(info.project_urls, ["Homepage"]) || "",
+        documentation: this.findProjectUrl(info.project_urls, ["Documentation"]) || "",
         repository,
         licenses,
         keywords,
@@ -230,14 +230,31 @@ class PyPIRegistry implements Registry {
 
   /** Extract repository URL from project_urls. */
   private extractRepository(projectUrls: Record<string, string> | undefined): string {
+    const url = this.findProjectUrl(projectUrls, [
+      "Repository",
+      "Source",
+      "Source Code",
+      "GitHub",
+      "Homepage",
+    ]);
+    return url ? normalizeRepositoryURL(url) : "";
+  }
+
+  /** Find a project URL by key, case-insensitive. */
+  private findProjectUrl(
+    projectUrls: Record<string, string> | undefined,
+    keys: string[],
+  ): string {
     if (!projectUrls) return "";
 
-    const keys = ["Repository", "Source", "Source Code", "GitHub", "Homepage"];
+    const lowered = new Map<string, string>();
+    for (const [k, v] of Object.entries(projectUrls)) {
+      lowered.set(k.toLowerCase(), v);
+    }
+
     for (const key of keys) {
-      const url = projectUrls[key];
-      if (url) {
-        return normalizeRepositoryURL(url);
-      }
+      const value = lowered.get(key.toLowerCase());
+      if (value) return value;
     }
 
     return "";

--- a/test/unit/registries.test.ts
+++ b/test/unit/registries.test.ts
@@ -452,6 +452,39 @@ describe("Registry Modules", () => {
       await expect(registry.fetchPackage("nonexistent-package-xyz")).rejects.toThrow(NotFoundError);
     });
 
+    it("should match project_urls keys case-insensitively", async () => {
+      const client = new Client();
+      const mockResponse = {
+        info: {
+          name: "some-pkg",
+          version: "1.0.0",
+          summary: "A package",
+          description: "",
+          license: "MIT",
+          keywords: "",
+          author: "",
+          author_email: "",
+          project_urls: {
+            homepage: "https://example.com",
+            "source code": "https://github.com/foo/bar",
+            documentation: "https://docs.example.com",
+          },
+          requires_dist: null,
+        },
+        releases: {},
+        urls: [],
+      };
+
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(mockResponse);
+
+      const registry = create("pypi", undefined, client);
+      const pkg = await registry.fetchPackage("some-pkg");
+
+      expect(pkg.homepage).toBe("https://example.com");
+      expect(pkg.repository).toContain("github.com/foo/bar");
+      expect(pkg.documentation).toBe("https://docs.example.com");
+    });
+
     it("should parse PEP 508 dependencies with version specs", async () => {
       const client = new Client();
       const mockResponse = {


### PR DESCRIPTION
PyPI `project_urls` keys are freeform strings, and PEP 566 doesn't enforce casing. Packages use all kinds of variations: `"Source Code"` vs `"source code"`, `"Repository"` vs `"repository"`, `"homepage"` vs `"Homepage"`. The adapter was doing exact-match lookups, so anything with unexpected casing silently produced empty repository/homepage/documentation fields.

Added a `findProjectUrl` helper that lowercases both sides before matching. Applies to repository extraction, homepage, and documentation URL resolution.