### PR TITLE
fix(cache): revive Date objects after JSON round-trip in fetchVersions

### DIFF
--- a/src/cache/cached-registry.ts
+++ b/src/cache/cached-registry.ts
@@ -55,9 +55,15 @@ export class CachedRegistry implements Registry {
   }
 
   async fetchVersions(name: string, signal?: AbortSignal): Promise<Version[]> {
-    return this.cached<Version[]>(name, "versions", undefined, () =>
+    const versions = await this.cached<Version[]>(name, "versions", undefined, () =>
       this.inner.fetchVersions(name, signal),
     );
+    // JSON round-trip through storage turns Date objects into ISO strings.
+    // Revive them so consumers can safely call .getTime() / .toISOString().
+    return versions.map((v) => ({
+      ...v,
+      publishedAt: v.publishedAt ? new Date(v.publishedAt as unknown as string) : null,
+    }));
   }
 
   async fetchDependencies(

--- a/test/unit/cached-registry.test.ts
+++ b/test/unit/cached-registry.test.ts
@@ -338,6 +338,45 @@ describe("CachedRegistry", () => {
       await cached.fetchVersions("pkg");
       expect(fetchCount).toBe(2);
     });
+
+    it("revives publishedAt strings back to Date after cache round-trip", async () => {
+      let fetchCount = 0;
+      const inner = createMockRegistry("npm", {
+        fetchVersions: async () => {
+          fetchCount++;
+          return [
+            {
+              number: "1.0.0",
+              publishedAt: new Date("2024-06-15T12:00:00Z"),
+              licenses: "MIT",
+              integrity: "sha256-v1",
+              status: "",
+              metadata: {},
+            },
+          ];
+        },
+      });
+      const cached = new CachedRegistry(inner);
+
+      // First fetch populates cache
+      await cached.fetchVersions("pkg");
+      expect(fetchCount).toBe(1);
+
+      // Simulate JSON round-trip: replace cached Date with its ISO string
+      // (this is what the real fs driver does via JSON.stringify/parse)
+      const key = cacheKey("npm", "pkg", "versions");
+      const stored = await cached.storage.getItem(key) as Array<Record<string, unknown>>;
+      if (stored) {
+        stored[0]["publishedAt"] = "2024-06-15T12:00:00.000Z";
+        await cached.storage.setItem(key, stored as unknown as Record<string, unknown>);
+      }
+
+      // Second fetch reads from cache with string date
+      const versions = await cached.fetchVersions("pkg");
+      expect(fetchCount).toBe(1); // Still from cache
+      expect(versions[0].publishedAt).toBeInstanceOf(Date);
+      expect(versions[0].publishedAt!.toISOString()).toBe("2024-06-15T12:00:00.000Z");
+    });
   });
 
   describe("fetchDependencies", () => {


### PR DESCRIPTION
`Version.publishedAt` is typed as `Date | null`, but `unstorage` serializes through JSON under the hood. `JSON.parse` doesn't revive ISO date strings back to Date objects, so after a cache hit, `publishedAt` is silently a plain string. Any downstream code calling `.getTime()` or `.toISOString()` on it (like `selectVersion` in helpers.ts, or the `versions` CLI command) would blow up with a TypeError.

Added a revive step in `CachedRegistry.fetchVersions` that wraps `publishedAt` with `new Date()`. Safe for both paths - `new Date(date)` copies a Date, `new Date(isoString)` parses a string.