### PR TITLE
perf(npm): fetch dependencies from per-version endpoint

### DIFF
--- a/src/registries/npm.ts
+++ b/src/registries/npm.ts
@@ -173,15 +173,10 @@ class NpmRegistry implements Registry {
     signal?: AbortSignal,
   ): Promise<Dependency[]> {
     const encodedName = this.encodeName(name);
-    const url = `${this.baseURL}/${encodedName}`;
+    const url = `${this.baseURL}/${encodedName}/${version}`;
 
     try {
-      const data = await this.client.getJSON<NpmPackageResponse>(url, signal);
-      const versionData = data.versions[version];
-
-      if (!versionData) {
-        throw new NotFoundError("npm", name, version);
-      }
+      const versionData = await this.client.getJSON<NpmVersion>(url, signal);
 
       const dependencies: Dependency[] = [];
 

--- a/test/unit/registries.test.ts
+++ b/test/unit/registries.test.ts
@@ -164,6 +164,60 @@ describe("Registry Modules", () => {
       expect(maintainers[2].role).toBe("contributor");
     });
 
+    it("should fetch dependencies from per-version endpoint", async () => {
+      const client = new Client();
+      const mockVersionResponse = {
+        name: "lodash",
+        version: "4.17.21",
+        dependencies: {
+          underscore: "^1.0.0",
+        },
+        devDependencies: {
+          mocha: "^10.0.0",
+        },
+        optionalDependencies: {
+          fsevents: "^2.3.0",
+        },
+        peerDependencies: {
+          webpack: "^5.0.0",
+        },
+      };
+
+      const spy = vi.spyOn(client, "getJSON").mockResolvedValueOnce(mockVersionResponse);
+
+      const registry = create("npm", undefined, client);
+      const deps = await registry.fetchDependencies("lodash", "4.17.21");
+
+      // Should call per-version endpoint, not full package doc
+      expect(spy).toHaveBeenCalledWith("https://registry.npmjs.org/lodash/4.17.21", undefined);
+
+      expect(deps).toHaveLength(4);
+      expect(deps[0]).toEqual({
+        name: "underscore",
+        requirements: "^1.0.0",
+        scope: "runtime",
+        optional: false,
+      });
+      expect(deps[1]).toEqual({
+        name: "mocha",
+        requirements: "^10.0.0",
+        scope: "development",
+        optional: false,
+      });
+      expect(deps[2]).toEqual({
+        name: "fsevents",
+        requirements: "^2.3.0",
+        scope: "runtime",
+        optional: true,
+      });
+      expect(deps[3]).toEqual({
+        name: "webpack",
+        requirements: "^5.0.0",
+        scope: "runtime",
+        optional: false,
+      });
+    });
+
     it("should produce valid PURL for scoped packages", () => {
       const registry = create("npm");
       const urls = registry.urls();


### PR DESCRIPTION
`fetchDependencies` was pulling the full package document to get deps for a single version. For something like lodash with 1700+ published versions, that's the entire version history in one JSON blob just to read four dependency maps from one of them.

npm registry has `/<name>/<version>` which returns exactly the version you asked for. Same dependency data, payload drops from MBs to KBs. The 404 handling still works because the per-version endpoint returns 404 for missing versions, which `Client` maps to `HTTPError` caught by the existing error handler.