### PR TITLE
fix(packagist): filter dev-suffixed versions from latest resolution

### DIFF
--- a/src/registries/packagist.ts
+++ b/src/registries/packagist.ts
@@ -270,7 +270,7 @@ class PackagistRegistry implements Registry {
   /** Find the highest non-dev version. */
   private findLatestVersion(versions: string[]): string {
     // Filter out dev versions
-    const stable = versions.filter((v) => !v.startsWith("dev-"));
+    const stable = versions.filter((v) => !v.startsWith("dev-") && !v.endsWith("-dev"));
     if (stable.length === 0) {
       return versions[0] || "";
     }

--- a/test/unit/registries.test.ts
+++ b/test/unit/registries.test.ts
@@ -1090,6 +1090,93 @@ describe("Registry Modules", () => {
       expect(pkg.latestVersion).toBe("10.1.0");
     });
 
+    it("should skip dev-suffixed versions when resolving latest", async () => {
+      const client = new Client();
+      const mockResponse = {
+        package: {
+          name: "laravel/framework",
+          description: "The Laravel Framework.",
+          repository: "https://github.com/laravel/framework",
+          keywords: [],
+          versions: {
+            "v12.x-dev": {
+              name: "laravel/framework",
+              version: "v12.x-dev",
+              license: ["MIT"],
+              authors: [],
+              require: {},
+              "require-dev": {},
+              time: "2025-01-01T00:00:00Z",
+            },
+            "dev-master": {
+              name: "laravel/framework",
+              version: "dev-master",
+              license: ["MIT"],
+              authors: [],
+              require: {},
+              "require-dev": {},
+              time: "2025-01-01T00:00:00Z",
+            },
+            "11.5.1": {
+              name: "laravel/framework",
+              version: "11.5.1",
+              license: ["MIT"],
+              authors: [],
+              require: {},
+              "require-dev": {},
+              time: "2025-01-01T00:00:00Z",
+            },
+          },
+        },
+      };
+
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(mockResponse);
+
+      const registry = create("composer", undefined, client);
+      const pkg = await registry.fetchPackage("laravel/framework");
+
+      expect(pkg.latestVersion).toBe("11.5.1");
+    });
+
+    it("should fall back to first version when all versions are dev", async () => {
+      const client = new Client();
+      const mockResponse = {
+        package: {
+          name: "example/dev-only",
+          description: "A dev-only package",
+          repository: "",
+          keywords: [],
+          versions: {
+            "dev-master": {
+              name: "example/dev-only",
+              version: "dev-master",
+              license: ["MIT"],
+              authors: [],
+              require: {},
+              "require-dev": {},
+              time: "2025-01-01T00:00:00Z",
+            },
+            "1.x-dev": {
+              name: "example/dev-only",
+              version: "1.x-dev",
+              license: ["MIT"],
+              authors: [],
+              require: {},
+              "require-dev": {},
+              time: "2025-01-02T00:00:00Z",
+            },
+          },
+        },
+      };
+
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(mockResponse);
+
+      const registry = create("composer", undefined, client);
+      const pkg = await registry.fetchPackage("example/dev-only");
+
+      expect(["dev-master", "1.x-dev"]).toContain(pkg.latestVersion);
+    });
+
     it("should throw NotFoundError for missing packagist package", async () => {
       const client = new Client();
 


### PR DESCRIPTION
Composer dev versions come in two flavors: `dev-*` prefix (`dev-master`, `dev-main`) and `*-dev` suffix (`v12.x-dev`, `1.x-dev`). `findLatestVersion` only filtered the prefix form.

A package like `laravel/framework` with versions `["v12.x-dev", "v11.5.1", "v11.5.0"]` would pick `v12.x-dev` as latest because `parseInt("12")` sorts above `parseInt("11")` and the suffix variant passed the filter. `fetchPackage` then returns a dev branch as `latestVersion`.

One-line fix in the filter, two test cases covering both the mixed scenario and the all-dev fallback path.