### PR TITLE
chore(test): remove redundant vitest imports

### DIFF
--- a/test/unit/ai-tool.test.ts
+++ b/test/unit/ai-tool.test.ts
@@ -1,5 +1,3 @@
-import { describe, expect, it, vi } from "vitest";
-
 const {
   mockFetchPackageFromPURL,
   mockFetchVersionsFromPURL,

--- a/test/unit/alpm.test.ts
+++ b/test/unit/alpm.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Client } from "../../src/core/client.ts";
 import { NotFoundError, HTTPError } from "../../src/core/errors.ts";
 import { create } from "../../src/core/registry.ts";

--- a/test/unit/cached-registry.test.ts
+++ b/test/unit/cached-registry.test.ts
@@ -1,7 +1,6 @@
 import { CachedRegistry } from "../../src/cache/cached-registry.ts";
 import { readLockfile, cacheKey, DEFAULT_TTL } from "../../src/cache/lockfile.ts";
 import { createHash } from "node:crypto";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Registry, URLBuilder } from "../../src/core/types.ts";
 import type { Lockfile } from "../../src/cache/lockfile.ts";
 
@@ -365,7 +364,7 @@ describe("CachedRegistry", () => {
       // Simulate JSON round-trip: replace cached Date with its ISO string
       // (this is what the real fs driver does via JSON.stringify/parse)
       const key = cacheKey("npm", "pkg", "versions");
-      const stored = await cached.storage.getItem(key) as Array<Record<string, unknown>>;
+      const stored = (await cached.storage.getItem(key)) as Array<Record<string, unknown>>;
       if (stored) {
         stored[0]["publishedAt"] = "2024-06-15T12:00:00.000Z";
         await cached.storage.setItem(key, stored as unknown as Record<string, unknown>);

--- a/test/unit/lockfile.test.ts
+++ b/test/unit/lockfile.test.ts
@@ -1,6 +1,5 @@
 import { createStorage } from "unstorage";
 import memoryDriver from "unstorage/drivers/memory";
-import { describe, expect, it } from "vitest";
 import {
   DEFAULT_TTL,
   cacheKey,

--- a/test/unit/registries.test.ts
+++ b/test/unit/registries.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Client } from "../../src/core/client.ts";
 import { NotFoundError, HTTPError } from "../../src/core/errors.ts";
 import { create } from "../../src/core/registry.ts";


### PR DESCRIPTION
Five test files were explicitly importing from `vitest` while the other eight relied on globals. \`vitest.config.ts\` has \`globals: true\` for both unit and e2e projects, so \`describe\`/\`it\`/\`expect\`/\`vi\`/\`beforeEach\`/\`afterEach\` are all available without imports.

Partially addresses #18 (the remaining actionable item after items 1-3 were fixed in prior work).