### PR TITLE
fix(purl): handle literal @ in scoped package shorthand

### DIFF
--- a/src/core/purl.ts
+++ b/src/core/purl.ts
@@ -55,12 +55,15 @@ export function parsePURL(purlStr: string): ParsedPURL {
     }
   }
 
-  // Extract version
+  // Extract version — the version separator is the last '@' that appears
+  // after the last '/', so scoped names like 'npm/@vue/core' are not mistaken
+  // for having a version.
   let version = "";
-  const atIdx = remainder.indexOf("@");
-  if (atIdx !== -1) {
-    version = decodePURLComponent(purlStr, remainder.slice(atIdx + 1));
-    remainder = remainder.slice(0, atIdx);
+  const lastSlashBeforeVersion = remainder.lastIndexOf("/");
+  const lastAtIdx = remainder.lastIndexOf("@");
+  if (lastAtIdx !== -1 && lastAtIdx > lastSlashBeforeVersion) {
+    version = decodePURLComponent(purlStr, remainder.slice(lastAtIdx + 1));
+    remainder = remainder.slice(0, lastAtIdx);
   }
 
   // Extract type

--- a/test/unit/purl.test.ts
+++ b/test/unit/purl.test.ts
@@ -27,6 +27,30 @@ describe("purl", () => {
       });
     });
 
+    it("parses scoped package with literal @ in path", () => {
+      const result = parsePURL("pkg:npm/@vue/core");
+      expect(result).toEqual({
+        type: "npm",
+        namespace: "@vue",
+        name: "core",
+        version: "",
+        qualifiers: {},
+        subpath: "",
+      });
+    });
+
+    it("parses scoped package with literal @ and version", () => {
+      const result = parsePURL("pkg:npm/@vue/core@3.4.0");
+      expect(result).toEqual({
+        type: "npm",
+        namespace: "@vue",
+        name: "core",
+        version: "3.4.0",
+        qualifiers: {},
+        subpath: "",
+      });
+    });
+
     it("parses PURL with version", () => {
       const result = parsePURL("pkg:cargo/serde@1.0.0");
       expect(result).toEqual({


### PR DESCRIPTION
Version extraction in `parsePURL` used `indexOf("@")` on the full remainder, so `pkg:npm/@vue/core` hit the scope `@` first and treated `@vue/core` as the version string. Every CLI command (`info`, `versions`, `deps`, `maintainers`) threw `InvalidPURLError` on scoped shorthand that wasn't percent-encoded.

Switched to `lastIndexOf("@")` with a positional guard - the `@` only counts as a version separator if it sits after the last `/`. Scoped `@` always comes before a `/`, so it's left alone now.

Existing tests still pass (percent-encoded scopes were fine before). Two new tests cover the literal `@` path: `pkg:npm/@vue/core` without version and `pkg:npm/@vue/core@3.4.0` with one.

Closes #25