### PR TITLE
fix(cache): re-read lockfile before writing to prevent lost entries

### DIFF
--- a/src/cache/cached-registry.ts
+++ b/src/cache/cached-registry.ts
@@ -131,8 +131,11 @@ export class CachedRegistry implements Registry {
     };
     try {
       await this.storage.setItem(storageKey, value as Record<string, unknown>);
-      setEntry(lockfile, newEntry);
-      await writeLockfile(lockfile, this.lockfileStorage);
+      // Re-read lockfile before writing to avoid overwriting entries
+      // added by concurrent calls for different keys.
+      const freshLockfile = await readLockfile(this.lockfileStorage);
+      setEntry(freshLockfile, newEntry);
+      await writeLockfile(freshLockfile, this.lockfileStorage);
     } catch {
       // Storage I/O failed (disk full, permissions, remote driver timeout, etc.).
       // The data was already fetched successfully — return it anyway.

--- a/test/unit/cached-registry.test.ts
+++ b/test/unit/cached-registry.test.ts
@@ -596,6 +596,34 @@ describe("CachedRegistry", () => {
       expect(entry?.integrity).toMatch(/^sha256-[a-f0-9]{64}$/);
     });
 
+    it("should not lose lockfile entries when concurrent fetches write different keys", async () => {
+      const inner = createMockRegistry("npm", {
+        fetchPackage: async (name) => {
+          await new Promise((r) => setTimeout(r, 50));
+          return {
+            name,
+            description: "",
+            homepage: "",
+            repository: "",
+            licenses: "MIT",
+            keywords: [],
+            namespace: "",
+            latestVersion: "1.0.0",
+            metadata: {},
+          };
+        },
+      });
+      const cached = new CachedRegistry(inner);
+
+      // Concurrent fetches for different packages
+      await Promise.all([cached.fetchPackage("alpha"), cached.fetchPackage("beta")]);
+
+      const alphaKey = cacheKey("npm", "alpha", "package");
+      const betaKey = cacheKey("npm", "beta", "package");
+      expect(mockLockfile.entries[alphaKey]).toBeDefined();
+      expect(mockLockfile.entries[betaKey]).toBeDefined();
+    });
+
     it("uses correct TTL for each entry type", async () => {
       const inner = createMockRegistry("npm");
       const cached = new CachedRegistry(inner);


### PR DESCRIPTION
Concurrent cache writes for different keys were racing on the lockfile. Both callers read the same snapshot, then each wrote back their entry, so the second write silently dropped the first's entry. The lost entry just meant a redundant upstream fetch later, but it's still wrong.

Re-reading the lockfile right before writing narrows the window significantly. Full elimination would need atomic file ops which is overkill for a cache freshness file.

Closes #53

## Test plan
- [x] New test: concurrent fetchPackage for two different packages, both entries present after
- [x] 344 tests passing