### PR TITLE
refactor(pypi): migrate fetchVersions to Simple API (PEP 691)

### DIFF
--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -71,13 +71,17 @@ export class Client {
   }
 
   /** Fetch JSON from a URL with retry and rate limiting. */
-  async getJSON<T>(url: string, signal?: AbortSignal): Promise<T> {
+  async getJSON<T>(
+    url: string,
+    signal?: AbortSignal,
+    headers?: Record<string, string>,
+  ): Promise<T> {
     if (this.rateLimiter) {
       await this.rateLimiter.wait(signal);
     }
 
     try {
-      return await this.fetch<T>(url, { signal });
+      return await this.fetch<T>(url, { signal, headers });
     } catch (error) {
       if (error instanceof FetchError) {
         if (error.statusCode === 429) {

--- a/src/registries/pypi.ts
+++ b/src/registries/pypi.ts
@@ -28,19 +28,7 @@ interface PyPIPackageResponse {
     project_urls: Record<string, string>;
     requires_dist: string[] | null;
   };
-  releases?: Record<string, PyPIRelease[]> | null;
   urls: PyPIFile[];
-}
-
-/** PyPI release file information. */
-interface PyPIRelease {
-  filename: string;
-  url: string;
-  upload_time_iso_8601: string;
-  yanked: boolean;
-  digests: {
-    sha256: string;
-  };
 }
 
 /** PyPI file information. */
@@ -52,6 +40,24 @@ interface PyPIFile {
   digests: {
     sha256: string;
   };
+}
+
+/** PyPI Simple API (PEP 691) response for a project. */
+interface PyPISimpleResponse {
+  meta: { "api-version": string };
+  name: string;
+  versions: string[];
+  files: PyPISimpleFile[];
+}
+
+/** A single file entry in the Simple API response. */
+interface PyPISimpleFile {
+  filename: string;
+  url: string;
+  hashes: { sha256?: string };
+  "requires-python"?: string;
+  yanked?: string | false;
+  "upload-time"?: string;
 }
 
 /** PyPI registry client. */
@@ -103,25 +109,46 @@ class PyPIRegistry implements Registry {
 
   async fetchVersions(name: string, signal?: AbortSignal): Promise<Version[]> {
     const normalized = this.normalizeName(name);
-    const url = `${this.baseURL}/pypi/${normalized}/json`;
+    const url = `${this.baseURL}/simple/${normalized}/`;
 
     try {
-      const data = await this.client.getJSON<PyPIPackageResponse>(url, signal);
+      const data = await this.client.getJSON<PyPISimpleResponse>(url, signal, {
+        Accept: "application/vnd.pypi.simple.v1+json",
+      });
+
+      const filesByVersion = new Map<string, PyPISimpleFile[]>();
+      for (const version of data.versions) {
+        filesByVersion.set(version, []);
+      }
+
+      for (const file of data.files) {
+        const version = this.matchFileVersion(file.filename, normalized, data.versions);
+        if (version) {
+          filesByVersion.get(version)!.push(file);
+        }
+      }
+
       const versions: Version[] = [];
+      for (const [versionStr, files] of filesByVersion) {
+        if (files.length === 0) {
+          versions.push({
+            number: versionStr,
+            publishedAt: null,
+            licenses: "",
+            integrity: "",
+            status: "",
+            metadata: {},
+          });
+          continue;
+        }
 
-      const releaseMap = data.releases ?? {};
-      for (const [versionStr, releases] of Object.entries(releaseMap)) {
-        if (releases.length === 0) continue;
+        const sdist = files.find((f) => f.filename.endsWith(".tar.gz"));
+        const file = sdist ?? files[0]!;
+        const publishedAt = file["upload-time"] ? new Date(file["upload-time"]) : null;
+        const integrity = file.hashes?.sha256 ? `sha256-${file.hashes.sha256}` : "";
+        const status = file.yanked !== false && file.yanked !== undefined ? "yanked" : "";
 
-        const sdist = releases.find((r) => r.filename.endsWith(".tar.gz"));
-        const release = sdist ?? releases[0]!;
-        const publishedAt = release.upload_time_iso_8601
-          ? new Date(release.upload_time_iso_8601)
-          : null;
-        const integrity = release.digests?.sha256 ? `sha256-${release.digests.sha256}` : "";
-        const status = release.yanked ? "yanked" : "";
-
-        this.downloadUrls.set(`${normalized}@${versionStr}`, release.url);
+        this.downloadUrls.set(`${normalized}@${versionStr}`, file.url);
 
         versions.push({
           number: versionStr,
@@ -228,6 +255,35 @@ class PyPIRegistry implements Registry {
         return buildPURL({ type: "pypi", name: this.normalizeName(name), version });
       },
     };
+  }
+
+  /** Match a filename to a version from the known versions list. */
+  private matchFileVersion(
+    filename: string,
+    normalizedName: string,
+    versions: string[],
+  ): string | undefined {
+    // Wheel/sdist filenames normalize the name to underscores
+    const prefix = normalizedName.replace(/-/g, "_") + "-";
+    const lower = filename.toLowerCase();
+
+    if (!lower.startsWith(prefix)) return undefined;
+
+    const afterPrefix = filename.slice(prefix.length);
+
+    // Wheel: {name}-{version}-{python}-{abi}-{platform}.whl
+    // Version is before the first dash after the prefix
+    const dashIdx = afterPrefix.indexOf("-");
+    if (dashIdx !== -1) {
+      const candidate = afterPrefix.slice(0, dashIdx);
+      if (versions.includes(candidate)) return candidate;
+    }
+
+    // Sdist: {name}-{version}.tar.gz / .zip / .tar.bz2
+    const stripped = afterPrefix.replace(/\.(tar\.(gz|bz2|xz)|zip)$/i, "");
+    if (versions.includes(stripped)) return stripped;
+
+    return undefined;
   }
 
   /** Normalize package name per PEP 503. */

--- a/src/registries/pypi.ts
+++ b/src/registries/pypi.ts
@@ -146,7 +146,7 @@ class PyPIRegistry implements Registry {
         const file = sdist ?? files[0]!;
         const publishedAt = file["upload-time"] ? new Date(file["upload-time"]) : null;
         const integrity = file.hashes?.sha256 ? `sha256-${file.hashes.sha256}` : "";
-        const status = file.yanked !== false && file.yanked !== undefined ? "yanked" : "";
+        const status = file.yanked ? "yanked" : "";
 
         this.downloadUrls.set(`${normalized}@${versionStr}`, file.url);
 

--- a/test/unit/registries.test.ts
+++ b/test/unit/registries.test.ts
@@ -747,45 +747,25 @@ describe("Registry Modules", () => {
     it("should fetch pypi versions with yanked status", async () => {
       const client = new Client();
       const mockResponse = {
-        info: {
-          name: "requests",
-          version: "2.31.0",
-          summary: "Python HTTP for Humans.",
-          description: "Requests is a simple, yet elegant, HTTP library.",
-          license: "Apache 2.0",
-          keywords: "requests, urllib, httplib",
-          author: "Kenneth Reitz",
-          author_email: "me@kennethreitz.org",
-          project_urls: {
-            Homepage: "https://requests.readthedocs.io",
+        meta: { "api-version": "1.1" },
+        name: "requests",
+        versions: ["2.30.0", "2.31.0"],
+        files: [
+          {
+            filename: "requests-2.30.0-py3-none-any.whl",
+            url: "https://files.pythonhosted.org/packages/requests-2.30.0-py3-none-any.whl",
+            hashes: { sha256: "abc123def456" },
+            yanked: false,
+            "upload-time": "2023-05-15T10:00:00Z",
           },
-          requires_dist: null,
-        },
-        releases: {
-          "2.30.0": [
-            {
-              filename: "requests-2.30.0-py3-none-any.whl",
-              url: "https://files.pythonhosted.org/packages/requests-2.30.0-py3-none-any.whl",
-              upload_time_iso_8601: "2023-05-15T10:00:00Z",
-              yanked: false,
-              digests: {
-                sha256: "abc123def456",
-              },
-            },
-          ],
-          "2.31.0": [
-            {
-              filename: "requests-2.31.0-py3-none-any.whl",
-              url: "https://files.pythonhosted.org/packages/requests-2.31.0-py3-none-any.whl",
-              upload_time_iso_8601: "2023-10-15T10:00:00Z",
-              yanked: true,
-              digests: {
-                sha256: "def456ghi789",
-              },
-            },
-          ],
-        },
-        urls: [],
+          {
+            filename: "requests-2.31.0-py3-none-any.whl",
+            url: "https://files.pythonhosted.org/packages/requests-2.31.0-py3-none-any.whl",
+            hashes: { sha256: "def456ghi789" },
+            yanked: "security vulnerability",
+            "upload-time": "2023-10-15T10:00:00Z",
+          },
+        ],
       };
 
       vi.spyOn(client, "getJSON").mockResolvedValueOnce(mockResponse);
@@ -801,22 +781,13 @@ describe("Registry Modules", () => {
       expect(versions[1].status).toBe("yanked");
     });
 
-    it("should return empty versions when releases key is missing", async () => {
+    it("should return empty versions when Simple API returns no versions", async () => {
       const client = new Client();
       const mockResponse = {
-        info: {
-          name: "requests",
-          version: "2.31.0",
-          summary: "Python HTTP for Humans.",
-          description: "",
-          license: "Apache 2.0",
-          keywords: "",
-          author: "Kenneth Reitz",
-          author_email: "me@kennethreitz.org",
-          project_urls: {},
-          requires_dist: null,
-        },
-        urls: [],
+        meta: { "api-version": "1.1" },
+        name: "requests",
+        versions: [],
+        files: [],
       };
 
       vi.spyOn(client, "getJSON").mockResolvedValueOnce(mockResponse);
@@ -827,23 +798,21 @@ describe("Registry Modules", () => {
       expect(versions).toHaveLength(0);
     });
 
-    it("should return empty versions when releases is null", async () => {
+    it("should include versions with no matching files", async () => {
       const client = new Client();
       const mockResponse = {
-        info: {
-          name: "requests",
-          version: "2.31.0",
-          summary: "",
-          description: "",
-          license: "",
-          keywords: "",
-          author: "",
-          author_email: "",
-          project_urls: {},
-          requires_dist: null,
-        },
-        releases: null,
-        urls: [],
+        meta: { "api-version": "1.1" },
+        name: "requests",
+        versions: ["1.0.0", "2.0.0"],
+        files: [
+          {
+            filename: "requests-2.0.0.tar.gz",
+            url: "https://files.pythonhosted.org/packages/requests-2.0.0.tar.gz",
+            hashes: { sha256: "abc123" },
+            yanked: false,
+            "upload-time": "2023-01-01T00:00:00Z",
+          },
+        ],
       };
 
       vi.spyOn(client, "getJSON").mockResolvedValueOnce(mockResponse);
@@ -851,7 +820,12 @@ describe("Registry Modules", () => {
       const registry = create("pypi", undefined, client);
       const versions = await registry.fetchVersions("requests");
 
-      expect(versions).toHaveLength(0);
+      expect(versions).toHaveLength(2);
+      expect(versions[0].number).toBe("1.0.0");
+      expect(versions[0].publishedAt).toBeNull();
+      expect(versions[0].integrity).toBe("");
+      expect(versions[1].number).toBe("2.0.0");
+      expect(versions[1].integrity).toContain("sha256");
     });
   });
 


### PR DESCRIPTION
## Summary
PyPI's `/pypi/<project>/json` endpoint still works but the `releases` field is deprecated - the Simple API (`/simple/<project>/`, PEP 691) is the intended way to enumerate versions now. `fetchVersions` was the only method touching `releases`, so only that one moved.

`Client.getJSON()` picked up an optional `headers` parameter to support content negotiation (`application/vnd.pypi.simple.v1+json`). The other PyPI methods (`fetchPackage`, `fetchDependencies`, `fetchMaintainers`) stay on the project JSON endpoint since they only need package metadata, not version lists.

Files in the Simple API response aren't grouped by version, so there's a `matchFileVersion` helper that maps filenames back to their versions. Not the prettiest API design on PyPI's part, but it works.

## Test plan
- [x] All 349 unit tests pass
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [ ] Verify against live PyPI (e2e smoke tests)