### PR TITLE
fix(pypi): match non-compliant filename separators

### DIFF
--- a/src/registries/pypi.ts
+++ b/src/registries/pypi.ts
@@ -14,6 +14,8 @@ import { normalizeLicense } from "../core/license.ts";
 import { normalizeRepositoryURL } from "../core/repository.ts";
 import { buildPURL } from "../core/purl.ts";
 
+const PYPI_FILENAME_SEPARATORS = ["_", "-", "."] as const;
+
 /** PyPI JSON API response for a package. */
 interface PyPIPackageResponse {
   info: {
@@ -263,11 +265,18 @@ class PyPIRegistry implements Registry {
     normalizedName: string,
     versions: string[],
   ): string | undefined {
-    // Wheel/sdist filenames normalize the name to underscores
-    const prefix = normalizedName.replace(/-/g, "_") + "-";
     const lower = filename.toLowerCase();
+    let prefix: string | undefined;
 
-    if (!lower.startsWith(prefix)) return undefined;
+    for (const separator of PYPI_FILENAME_SEPARATORS) {
+      const candidate = normalizedName.replaceAll("-", separator) + "-";
+      if (lower.startsWith(candidate)) {
+        prefix = candidate;
+        break;
+      }
+    }
+
+    if (!prefix) return undefined;
 
     const afterPrefix = filename.slice(prefix.length);
 

--- a/test/unit/registries.test.ts
+++ b/test/unit/registries.test.ts
@@ -781,6 +781,41 @@ describe("Registry Modules", () => {
       expect(versions[1].status).toBe("yanked");
     });
 
+    it("should match non-compliant pypi filenames with dashes or dots", async () => {
+      const client = new Client();
+      const mockResponse = {
+        meta: { "api-version": "1.1" },
+        name: "example-package-name",
+        versions: ["1.0.0", "2.0.0"],
+        files: [
+          {
+            filename: "example-package-name-1.0.0-py3-none-any.whl",
+            url: "https://files.pythonhosted.org/packages/example-package-name-1.0.0.whl",
+            hashes: { sha256: "dash123" },
+            yanked: false,
+            "upload-time": "2024-01-01T00:00:00Z",
+          },
+          {
+            filename: "example.package.name-2.0.0.tar.gz",
+            url: "https://files.pythonhosted.org/packages/example.package.name-2.0.0.tar.gz",
+            hashes: { sha256: "dot456" },
+            yanked: false,
+            "upload-time": "2024-02-01T00:00:00Z",
+          },
+        ],
+      };
+
+      vi.spyOn(client, "getJSON").mockResolvedValueOnce(mockResponse);
+
+      const registry = create("pypi", undefined, client);
+      const versions = await registry.fetchVersions("example-package-name");
+
+      expect(versions[0].publishedAt).toEqual(new Date("2024-01-01T00:00:00Z"));
+      expect(versions[0].integrity).toBe("sha256-dash123");
+      expect(versions[1].publishedAt).toEqual(new Date("2024-02-01T00:00:00Z"));
+      expect(versions[1].integrity).toBe("sha256-dot456");
+    });
+
     it("should return empty versions when Simple API returns no versions", async () => {
       const client = new Client();
       const mockResponse = {


### PR DESCRIPTION
`fetchVersions()` silently drops files when PyPI filename keeps dashes or dots instead of normalized underscores, then returns empty metadata for version that actually has files. That's just wrong. Accept all three separator forms, with compliant underscore form still first.

Closes #57

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oritwoen/regxa/pull/58?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

