### PR TITLE
refactor!: replace registry factories with classes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,13 +48,13 @@ test/
 
 ### Where to put new code
 
-| What | Where |
-|------|-------|
+| What                  | Where                                                            |
+| --------------------- | ---------------------------------------------------------------- |
 | New ecosystem adapter | `src/registries/<name>.ts` + import in `src/registries/index.ts` |
-| New CLI command | `src/commands/<name>.ts` + wire in `src/cli.ts` |
-| Public API addition | export from `src/index.ts` |
-| Shared type/contract | `src/core/types.ts` |
-| New unit test | `test/unit/<module>.test.ts` |
+| New CLI command       | `src/commands/<name>.ts` + wire in `src/cli.ts`                  |
+| Public API addition   | export from `src/index.ts`                                       |
+| Shared type/contract  | `src/core/types.ts`                                              |
+| New unit test         | `test/unit/<module>.test.ts`                                     |
 
 ## Code Conventions
 
@@ -84,7 +84,7 @@ test/
 
 ### Registries
 
-- Plugin-based via `register()`/`create()` factory. No hardcoded switch logic.
+- Plugin-based via abstract `Registry` subclasses registered with `register()` and resolved by `create()`. No hardcoded switch logic.
 - Side-effect registration is intentional: `import 'regxa/registries'`.
 - Each adapter normalizes upstream payloads into core types before returning.
 - No adapter-to-adapter imports.
@@ -103,13 +103,14 @@ test/
 
 ## Key Symbols
 
-| Symbol | Location | Role |
-|--------|----------|------|
-| `create` | `src/core/registry.ts` | Registry factory from ecosystem key |
-| `createCached` | `src/cache/index.ts` | Decorates registry with cache + lockfile |
-| `parsePURL` | `src/core/purl.ts` | Canonical PURL parser — single source of truth |
-| `Client` | `src/core/client.ts` | Central HTTP: retry, timeout, rate limiting |
-| `DEFAULT_TTL` | `src/cache/lockfile.ts` | Project-wide cache freshness policy |
+| Symbol         | Location                | Role                                                  |
+| -------------- | ----------------------- | ----------------------------------------------------- |
+| `Registry`     | `src/core/registry.ts`  | Abstract contract shared by adapters and decorators   |
+| `create`       | `src/core/registry.ts`  | Instantiates a registered class from an ecosystem key |
+| `createCached` | `src/cache/index.ts`    | Decorates registry with cache + lockfile              |
+| `parsePURL`    | `src/core/purl.ts`      | Canonical PURL parser — single source of truth        |
+| `Client`       | `src/core/client.ts`    | Central HTTP: retry, timeout, rate limiting           |
+| `DEFAULT_TTL`  | `src/cache/lockfile.ts` | Project-wide cache freshness policy                   |
 
 ## Banned Patterns
 

--- a/README.md
+++ b/README.md
@@ -141,16 +141,19 @@ const packages = await bulkFetchPackages(["pkg:npm/lodash", "pkg:cargo/serde", "
 
 ### Direct registry access
 
-For more control, create a registry instance directly:
+For more control, instantiate a concrete registry class:
 
 ```ts
-import { create } from "regxa";
+import { Client } from "regxa";
+import { NpmRegistry } from "regxa/registries";
 
-const npm = create("npm");
+const npm = new NpmRegistry("https://registry.npmjs.org", new Client());
 const pkg = await npm.fetchPackage("lodash");
 const versions = await npm.fetchVersions("lodash");
 const deps = await npm.fetchDependencies("lodash", "4.17.21");
 ```
+
+Use `create("npm")` when you prefer lookup through the registered ecosystem classes.
 
 ### Cached registry
 

--- a/skills/regxa/SKILL.md
+++ b/skills/regxa/SKILL.md
@@ -18,14 +18,14 @@ All queries use PURLs to identify packages:
 pkg:<type>/<name>@<version>
 ```
 
-| Ecosystem | PURL type | Example |
-|-----------|-----------|---------|
-| npm | `npm` | `pkg:npm/lodash`, `pkg:npm/%40babel/core@7.0.0` |
-| PyPI | `pypi` | `pkg:pypi/flask@3.1.1` |
-| crates.io | `cargo` | `pkg:cargo/serde@1.0.0` |
-| RubyGems | `gem` | `pkg:gem/rails@7.1.0` |
-| Packagist | `composer` | `pkg:composer/laravel/framework@11.0.0` |
-| Arch Linux | `alpm` | `pkg:alpm/arch/linux`, `pkg:alpm/aur/yay` |
+| Ecosystem  | PURL type  | Example                                         |
+| ---------- | ---------- | ----------------------------------------------- |
+| npm        | `npm`      | `pkg:npm/lodash`, `pkg:npm/%40babel/core@7.0.0` |
+| PyPI       | `pypi`     | `pkg:pypi/flask@3.1.1`                          |
+| crates.io  | `cargo`    | `pkg:cargo/serde@1.0.0`                         |
+| RubyGems   | `gem`      | `pkg:gem/rails@7.1.0`                           |
+| Packagist  | `composer` | `pkg:composer/laravel/framework@11.0.0`         |
+| Arch Linux | `alpm`     | `pkg:alpm/arch/linux`, `pkg:alpm/aur/yay`       |
 
 The CLI accepts shorthand without the `pkg:` prefix (e.g., `npm/lodash@4.17.21`). The PURL helpers (`fetchPackageFromPURL`, etc.) require the full `pkg:` prefix. The lower-level registry API takes bare package names directly.
 
@@ -104,30 +104,29 @@ const deps = await fetchDependenciesFromPURL("pkg:pypi/flask@3.1.1");
 const maintainers = await fetchMaintainersFromPURL("pkg:gem/rails");
 
 // Bulk fetch (concurrent)
-const packages = await bulkFetchPackages([
-  "pkg:npm/lodash",
-  "pkg:cargo/serde",
-  "pkg:pypi/flask",
-]);
+const packages = await bulkFetchPackages(["pkg:npm/lodash", "pkg:cargo/serde", "pkg:pypi/flask"]);
 ```
 
 ### Registry API (lower level)
 
-For more control, create a registry instance directly:
+For direct construction, import a concrete class from the registries subpath:
 
 ```typescript
-import { create } from "regxa";
+import { Client } from "regxa";
+import { NpmRegistry } from "regxa/registries";
 
-const npm = create("npm");
+const npm = new NpmRegistry("https://registry.npmjs.org", new Client());
 
 const pkg = await npm.fetchPackage("lodash");
 const versions = await npm.fetchVersions("@babel/core");
 const deps = await npm.fetchDependencies("lodash", "4.17.21");
 const urls = npm.urls();
-console.log(urls.registry("lodash"));       // npmjs.com URL
-console.log(urls.documentation("lodash"));  // docs URL
+console.log(urls.registry("lodash")); // npmjs.com URL
+console.log(urls.documentation("lodash")); // docs URL
 console.log(urls.purl("lodash", "4.17.21")); // PURL string
 ```
+
+Use `create("npm")` for lookup through the registered ecosystem classes.
 
 ### Cached queries
 
@@ -160,9 +159,9 @@ Read `references/api-reference.md` for the full type definitions and return shap
 
 ## Error Handling
 
-| Error | When | What to do |
-|-------|------|------------|
-| `NotFoundError` | Package or version does not exist | Check the PURL spelling and ecosystem |
-| `InvalidPURLError` | Malformed PURL string | Fix the format (see PURL table above) |
-| `UnknownEcosystemError` | Unsupported ecosystem type | Use one of: npm, cargo, pypi, gem, composer, alpm |
-| `RateLimitError` | Registry rate limit hit | The client retries automatically; wait if persistent |
+| Error                   | When                              | What to do                                           |
+| ----------------------- | --------------------------------- | ---------------------------------------------------- |
+| `NotFoundError`         | Package or version does not exist | Check the PURL spelling and ecosystem                |
+| `InvalidPURLError`      | Malformed PURL string             | Fix the format (see PURL table above)                |
+| `UnknownEcosystemError` | Unsupported ecosystem type        | Use one of: npm, cargo, pypi, gem, composer, alpm    |
+| `RateLimitError`        | Registry rate limit hit           | The client retries automatically; wait if persistent |

--- a/src/cache/cached-registry.ts
+++ b/src/cache/cached-registry.ts
@@ -1,11 +1,5 @@
-import type {
-  Dependency,
-  Maintainer,
-  Package,
-  Registry,
-  URLBuilder,
-  Version,
-} from "../core/types.ts";
+import type { Dependency, Maintainer, Package, URLBuilder, Version } from "../core/types.ts";
+import { Registry } from "../core/registry.ts";
 import { getStorage, computeIntegrity } from "./storage.ts";
 import {
   readLockfile,
@@ -25,13 +19,14 @@ import type { Storage } from "unstorage";
  * Pass a custom `storage` to use a non-default driver (e.g. Cloudflare KV).
  * If omitted, uses the globally configured storage (see `configureStorage()`).
  */
-export class CachedRegistry implements Registry {
+export class CachedRegistry extends Registry {
   readonly inner: Registry;
   readonly storage: Storage;
   private readonly lockfileStorage: Storage;
   private readonly inflight = new Map<string, Promise<unknown>>();
 
   constructor(inner: Registry, storage?: Storage) {
+    super();
     this.inner = inner;
     this.storage = storage ?? getStorage();
     this.lockfileStorage = storage ?? getStorage();

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -24,9 +24,8 @@ export type { Lockfile, LockfileEntry, EntryType } from "./lockfile.ts";
 
 // Convenience
 import type { Storage } from "unstorage";
-import type { Registry } from "../core/types.ts";
 import type { Client } from "../core/client.ts";
-import { create } from "../core/registry.ts";
+import { create, type Registry } from "../core/registry.ts";
 import { CachedRegistry } from "./cached-registry.ts";
 
 /** Options for creating a cached registry. */

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -1,4 +1,5 @@
-import type { Package, Registry } from "../core/types.ts";
+import type { Package } from "../core/types.ts";
+import type { Registry } from "../core/registry.ts";
 import { defineCommand } from "citty";
 import consola from "consola";
 import { resolveDocsUrl } from "../helpers.ts";

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -1,7 +1,6 @@
 import consola from "consola";
-import type { Registry } from "../core/types.ts";
 import { createFromPURL, parsePURL, fullName } from "../core/purl.ts";
-import { create, ecosystems } from "../core/registry.ts";
+import { create, ecosystems, type Registry } from "../core/registry.ts";
 import {
   HTTPError,
   NotFoundError,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,6 +1,6 @@
 // Core
 export { Client, defaultClient } from "./client.ts";
-export { register, create, ecosystems, has } from "./registry.ts";
+export { Registry, register, create, ecosystems, has } from "./registry.ts";
 export { parsePURL, fullName, createFromPURL, buildPURL } from "./purl.ts";
 export { normalizeLicense, combineLicenses } from "./license.ts";
 export { normalizeRepositoryURL } from "./repository.ts";
@@ -24,8 +24,6 @@ export type {
   VersionStatus,
   Scope,
   URLBuilder,
-  Registry,
-  RegistryFactory,
   ClientOptions,
   RateLimiter,
   ParsedPURL,

--- a/src/core/purl.ts
+++ b/src/core/purl.ts
@@ -1,6 +1,6 @@
-import type { ParsedPURL, Registry } from "./types.ts";
+import type { ParsedPURL } from "./types.ts";
 import type { Client } from "./client.ts";
-import { create } from "./registry.ts";
+import { create, type Registry } from "./registry.ts";
 import { InvalidPURLError } from "./errors.ts";
 
 /** Decode a percent-encoded PURL component, throwing InvalidPURLError on malformed sequences. */

--- a/src/core/registry.ts
+++ b/src/core/registry.ts
@@ -1,33 +1,50 @@
-import type { Registry, RegistryFactory } from "./types.ts";
 import type { Client } from "./client.ts";
 import { defaultClient } from "./client.ts";
 import { UnknownEcosystemError } from "./errors.ts";
+import type { Dependency, Maintainer, Package, URLBuilder, Version } from "./types.ts";
 
-const factories = new Map<string, RegistryFactory>();
+/** Common base for package registries and registry decorators. */
+export abstract class Registry {
+  abstract ecosystem(): string;
+  abstract fetchPackage(name: string, signal?: AbortSignal): Promise<Package>;
+  abstract fetchVersions(name: string, signal?: AbortSignal): Promise<Version[]>;
+  abstract fetchDependencies(
+    name: string,
+    version: string,
+    signal?: AbortSignal,
+  ): Promise<Dependency[]>;
+  abstract fetchMaintainers(name: string, signal?: AbortSignal): Promise<Maintainer[]>;
+  abstract urls(): URLBuilder;
+}
+
+const constructors = new Map<string, new (baseURL: string, client: Client) => Registry>();
 const defaults = new Map<string, string>();
 
-/** Register an ecosystem factory. Called by each registry module on import (side-effect). */
-export function register(ecosystem: string, defaultURL: string, factory: RegistryFactory): void {
-  factories.set(ecosystem, factory);
+/** Register an ecosystem class. Called by each registry module on import. */
+export function register(
+  ecosystem: string,
+  defaultURL: string,
+  RegistryClass: new (baseURL: string, client: Client) => Registry,
+): void {
+  constructors.set(ecosystem, RegistryClass);
   defaults.set(ecosystem, defaultURL);
 }
 
 /** Create a registry instance for the given ecosystem. */
 export function create(ecosystem: string, baseURL?: string, client?: Client): Registry {
-  const factory = factories.get(ecosystem);
-  if (!factory) {
+  const RegistryClass = constructors.get(ecosystem);
+  if (!RegistryClass) {
     throw new UnknownEcosystemError(ecosystem);
   }
-  const url = baseURL || defaults.get(ecosystem)!;
-  return factory(url, client ?? defaultClient());
+  return new RegistryClass(baseURL || defaults.get(ecosystem)!, client ?? defaultClient());
 }
 
 /** List all registered ecosystem names. */
 export function ecosystems(): string[] {
-  return [...factories.keys()];
+  return [...constructors.keys()];
 }
 
 /** Check if an ecosystem is registered. */
 export function has(ecosystem: string): boolean {
-  return factories.has(ecosystem);
+  return constructors.has(ecosystem);
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,5 +1,3 @@
-import type { Client } from "./client.ts";
-
 /** Normalized package metadata returned by any registry. */
 export interface Package {
   name: string;
@@ -53,19 +51,6 @@ export interface URLBuilder {
   readme(name: string, version?: string): string;
   purl(name: string, version?: string): string;
 }
-
-/** Common interface every registry must implement. */
-export interface Registry {
-  ecosystem(): string;
-  fetchPackage(name: string, signal?: AbortSignal): Promise<Package>;
-  fetchVersions(name: string, signal?: AbortSignal): Promise<Version[]>;
-  fetchDependencies(name: string, version: string, signal?: AbortSignal): Promise<Dependency[]>;
-  fetchMaintainers(name: string, signal?: AbortSignal): Promise<Maintainer[]>;
-  urls(): URLBuilder;
-}
-
-/** Factory function signature for creating registry instances. */
-export type RegistryFactory = (baseURL: string, client: Client) => Registry;
 
 /** Options for the HTTP client. */
 export interface ClientOptions {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import "./registries/index.ts";
 
 // Core API
 export { Client, defaultClient } from "./core/client.ts";
-export { register, create, ecosystems, has } from "./core/registry.ts";
+export { Registry, register, create, ecosystems, has } from "./core/registry.ts";
 export { parsePURL, fullName, createFromPURL, buildPURL } from "./core/purl.ts";
 export { normalizeLicense, combineLicenses } from "./core/license.ts";
 export { normalizeRepositoryURL } from "./core/repository.ts";
@@ -38,8 +38,6 @@ export type {
   VersionStatus,
   Scope,
   URLBuilder,
-  Registry,
-  RegistryFactory,
   ClientOptions,
   RateLimiter,
   ParsedPURL,

--- a/src/registries/alpm.ts
+++ b/src/registries/alpm.ts
@@ -1,14 +1,6 @@
 import type { Client } from "../core/client.ts";
-import type {
-  Dependency,
-  Maintainer,
-  Package,
-  Registry,
-  RegistryFactory,
-  URLBuilder,
-  Version,
-} from "../core/types.ts";
-import { register } from "../core/registry.ts";
+import type { Dependency, Maintainer, Package, URLBuilder, Version } from "../core/types.ts";
+import { Registry, register } from "../core/registry.ts";
 import { HTTPError, NotFoundError } from "../core/errors.ts";
 import { combineLicenses } from "../core/license.ts";
 import { buildPURL } from "../core/purl.ts";
@@ -83,8 +75,9 @@ interface AurPackageResult {
 }
 
 /** ALPM registry client — routes to Arch Linux official repos or AUR based on namespace. */
-class AlpmRegistry implements Registry {
+export class AlpmRegistry extends Registry {
   constructor(baseURL: string, client: Client) {
+    super();
     this.baseURL = baseURL;
     this.client = client;
   }
@@ -493,10 +486,4 @@ class AlpmRegistry implements Registry {
   }
 }
 
-/** Factory function for creating ALPM registry instances. */
-const factory: RegistryFactory = (baseURL: string, client: Client): Registry => {
-  return new AlpmRegistry(baseURL, client);
-};
-
-// Self-register on import
-register("alpm", "https://archlinux.org", factory);
+register("alpm", "https://archlinux.org", AlpmRegistry);

--- a/src/registries/cargo.ts
+++ b/src/registries/cargo.ts
@@ -1,14 +1,6 @@
 import type { Client } from "../core/client.ts";
-import type {
-  Dependency,
-  Maintainer,
-  Package,
-  Registry,
-  RegistryFactory,
-  URLBuilder,
-  Version,
-} from "../core/types.ts";
-import { register } from "../core/registry.ts";
+import type { Dependency, Maintainer, Package, URLBuilder, Version } from "../core/types.ts";
+import { Registry, register } from "../core/registry.ts";
 import { HTTPError, NotFoundError } from "../core/errors.ts";
 import { normalizeLicense } from "../core/license.ts";
 import { normalizeRepositoryURL } from "../core/repository.ts";
@@ -103,8 +95,9 @@ interface CratesMaintainer {
 }
 
 /** Crates.io registry client. */
-class CargoRegistry implements Registry {
+export class CargoRegistry extends Registry {
   constructor(baseURL: string, client: Client) {
+    super();
     this.baseURL = baseURL;
     this.client = client;
   }
@@ -279,10 +272,4 @@ class CargoRegistry implements Registry {
   }
 }
 
-/** Factory function for creating Cargo registry instances. */
-const factory: RegistryFactory = (baseURL: string, client: Client): Registry => {
-  return new CargoRegistry(baseURL, client);
-};
-
-// Self-register on import
-register("cargo", "https://crates.io", factory);
+register("cargo", "https://crates.io", CargoRegistry);

--- a/src/registries/index.ts
+++ b/src/registries/index.ts
@@ -1,7 +1,6 @@
-// Side-effect imports — each registers itself on import
-import "./npm.ts";
-import "./cargo.ts";
-import "./pypi.ts";
-import "./rubygems.ts";
-import "./packagist.ts";
-import "./alpm.ts";
+export { NpmRegistry } from "./npm.ts";
+export { CargoRegistry } from "./cargo.ts";
+export { PyPIRegistry } from "./pypi.ts";
+export { RubyGemsRegistry } from "./rubygems.ts";
+export { PackagistRegistry } from "./packagist.ts";
+export { AlpmRegistry } from "./alpm.ts";

--- a/src/registries/npm.ts
+++ b/src/registries/npm.ts
@@ -1,14 +1,6 @@
 import type { Client } from "../core/client.ts";
-import type {
-  Dependency,
-  Maintainer,
-  Package,
-  Registry,
-  RegistryFactory,
-  URLBuilder,
-  Version,
-} from "../core/types.ts";
-import { register } from "../core/registry.ts";
+import type { Dependency, Maintainer, Package, URLBuilder, Version } from "../core/types.ts";
+import { Registry, register } from "../core/registry.ts";
 import { HTTPError, NotFoundError } from "../core/errors.ts";
 import { normalizeLicense } from "../core/license.ts";
 import { normalizeRepositoryURL } from "../core/repository.ts";
@@ -82,8 +74,9 @@ interface NpmVersion {
 }
 
 /** npm registry client. */
-class NpmRegistry implements Registry {
+export class NpmRegistry extends Registry {
   constructor(baseURL: string, client: Client) {
+    super();
     this.baseURL = baseURL;
     this.client = client;
   }
@@ -377,10 +370,4 @@ class NpmRegistry implements Registry {
   }
 }
 
-/** Factory function for creating npm registry instances. */
-const factory: RegistryFactory = (baseURL: string, client: Client): Registry => {
-  return new NpmRegistry(baseURL, client);
-};
-
-// Self-register on import
-register("npm", "https://registry.npmjs.org", factory);
+register("npm", "https://registry.npmjs.org", NpmRegistry);

--- a/src/registries/packagist.ts
+++ b/src/registries/packagist.ts
@@ -1,14 +1,6 @@
 import type { Client } from "../core/client.ts";
-import type {
-  Dependency,
-  Maintainer,
-  Package,
-  Registry,
-  RegistryFactory,
-  URLBuilder,
-  Version,
-} from "../core/types.ts";
-import { register } from "../core/registry.ts";
+import type { Dependency, Maintainer, Package, URLBuilder, Version } from "../core/types.ts";
+import { Registry, register } from "../core/registry.ts";
 import { HTTPError, NotFoundError, InvalidPURLError } from "../core/errors.ts";
 import { combineLicenses } from "../core/license.ts";
 import { normalizeRepositoryURL } from "../core/repository.ts";
@@ -54,8 +46,9 @@ interface PackagistVersion {
 }
 
 /** Packagist registry client. */
-class PackagistRegistry implements Registry {
+export class PackagistRegistry extends Registry {
   constructor(baseURL: string, client: Client) {
+    super();
     this.baseURL = baseURL;
     this.client = client;
   }
@@ -315,10 +308,4 @@ class PackagistRegistry implements Registry {
   }
 }
 
-/** Factory function for creating Packagist registry instances. */
-const factory: RegistryFactory = (baseURL: string, client: Client): Registry => {
-  return new PackagistRegistry(baseURL, client);
-};
-
-// Self-register on import
-register("composer", "https://packagist.org", factory);
+register("composer", "https://packagist.org", PackagistRegistry);

--- a/src/registries/pypi.ts
+++ b/src/registries/pypi.ts
@@ -1,14 +1,6 @@
 import type { Client } from "../core/client.ts";
-import type {
-  Dependency,
-  Maintainer,
-  Package,
-  Registry,
-  RegistryFactory,
-  URLBuilder,
-  Version,
-} from "../core/types.ts";
-import { register } from "../core/registry.ts";
+import type { Dependency, Maintainer, Package, URLBuilder, Version } from "../core/types.ts";
+import { Registry, register } from "../core/registry.ts";
 import { HTTPError, NotFoundError } from "../core/errors.ts";
 import { normalizeLicense } from "../core/license.ts";
 import { normalizeRepositoryURL } from "../core/repository.ts";
@@ -63,14 +55,16 @@ interface PyPISimpleFile {
 }
 
 /** PyPI registry client. */
-class PyPIRegistry implements Registry {
+export class PyPIRegistry extends Registry {
   constructor(baseURL: string, client: Client) {
+    super();
     this.baseURL = baseURL;
     this.client = client;
   }
 
   readonly baseURL: string;
   readonly client: Client;
+
   private readonly downloadUrls = new Map<string, string>();
 
   ecosystem(): string {
@@ -383,10 +377,4 @@ class PyPIRegistry implements Registry {
   }
 }
 
-/** Factory function for creating PyPI registry instances. */
-const factory: RegistryFactory = (baseURL: string, client: Client): Registry => {
-  return new PyPIRegistry(baseURL, client);
-};
-
-// Self-register on import
-register("pypi", "https://pypi.org", factory);
+register("pypi", "https://pypi.org", PyPIRegistry);

--- a/src/registries/rubygems.ts
+++ b/src/registries/rubygems.ts
@@ -1,14 +1,6 @@
 import type { Client } from "../core/client.ts";
-import type {
-  Dependency,
-  Maintainer,
-  Package,
-  Registry,
-  RegistryFactory,
-  URLBuilder,
-  Version,
-} from "../core/types.ts";
-import { register } from "../core/registry.ts";
+import type { Dependency, Maintainer, Package, URLBuilder, Version } from "../core/types.ts";
+import { Registry, register } from "../core/registry.ts";
 import { HTTPError, NotFoundError } from "../core/errors.ts";
 import { combineLicenses, normalizeLicense } from "../core/license.ts";
 import { normalizeRepositoryURL } from "../core/repository.ts";
@@ -51,8 +43,9 @@ interface RubyGemsOwnerResponse {
 }
 
 /** RubyGems registry client. */
-class RubyGemsRegistry implements Registry {
+export class RubyGemsRegistry extends Registry {
   constructor(baseURL: string, client: Client) {
+    super();
     this.baseURL = baseURL;
     this.client = client;
   }
@@ -228,10 +221,4 @@ class RubyGemsRegistry implements Registry {
   }
 }
 
-/** Factory function for creating RubyGems registry instances. */
-const factory: RegistryFactory = (baseURL: string, client: Client): Registry => {
-  return new RubyGemsRegistry(baseURL, client);
-};
-
-// Self-register on import
-register("gem", "https://rubygems.org", factory);
+register("gem", "https://rubygems.org", RubyGemsRegistry);

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,9 +7,8 @@ export type {
   VersionStatus,
   Scope,
   URLBuilder,
-  Registry,
-  RegistryFactory,
   ClientOptions,
   RateLimiter,
   ParsedPURL,
 } from "./core/types.ts";
+export type { Registry } from "./core/registry.ts";

--- a/test/unit/cached-registry.test.ts
+++ b/test/unit/cached-registry.test.ts
@@ -1,7 +1,8 @@
 import { CachedRegistry } from "../../src/cache/cached-registry.ts";
 import { readLockfile, cacheKey, DEFAULT_TTL } from "../../src/cache/lockfile.ts";
 import { createHash } from "node:crypto";
-import type { Registry, URLBuilder } from "../../src/core/types.ts";
+import type { URLBuilder } from "../../src/core/types.ts";
+import { Registry } from "../../src/core/registry.ts";
 import type { Lockfile } from "../../src/cache/lockfile.ts";
 
 // Mock storage to avoid real file I/O
@@ -109,6 +110,7 @@ describe("CachedRegistry", () => {
       const inner = createMockRegistry("npm");
       const cached = new CachedRegistry(inner);
       expect(cached.inner).toBe(inner);
+      expect(cached).toBeInstanceOf(Registry);
     });
 
     it("initializes storage for ecosystem", () => {

--- a/test/unit/info-command.test.ts
+++ b/test/unit/info-command.test.ts
@@ -1,5 +1,6 @@
 import consola from "consola";
-import type { Package, Registry } from "../../src/core/types.ts";
+import type { Package } from "../../src/core/types.ts";
+import type { Registry } from "../../src/core/registry.ts";
 import { outputPackageInfo } from "../../src/commands/info.ts";
 
 function createPackage(overrides: Partial<Package> = {}): Package {

--- a/test/unit/registries.test.ts
+++ b/test/unit/registries.test.ts
@@ -1,7 +1,14 @@
 import { Client } from "../../src/core/client.ts";
 import { NotFoundError, HTTPError } from "../../src/core/errors.ts";
 import { create } from "../../src/core/registry.ts";
-import "../../src/registries/index.ts";
+import {
+  AlpmRegistry,
+  CargoRegistry,
+  NpmRegistry,
+  PackagistRegistry,
+  PyPIRegistry,
+  RubyGemsRegistry,
+} from "../../src/registries/index.ts";
 
 describe("Registry Modules", () => {
   beforeEach(() => {
@@ -10,6 +17,23 @@ describe("Registry Modules", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it("should align registry classes with their ecosystem keys", () => {
+    const registries = [
+      ["npm", NpmRegistry],
+      ["cargo", CargoRegistry],
+      ["pypi", PyPIRegistry],
+      ["gem", RubyGemsRegistry],
+      ["composer", PackagistRegistry],
+      ["alpm", AlpmRegistry],
+    ] as const;
+
+    for (const [ecosystem, RegistryClass] of registries) {
+      const registry = create(ecosystem);
+      expect(registry).toBeInstanceOf(RegistryClass);
+      expect(registry.ecosystem()).toBe(ecosystem);
+    }
   });
 
   describe("npm registry", () => {

--- a/test/unit/registry.test.ts
+++ b/test/unit/registry.test.ts
@@ -1,335 +1,115 @@
-import { register, create, ecosystems, has } from "../../src/core/registry.ts";
+import { Client } from "../../src/core/client.ts";
 import { UnknownEcosystemError } from "../../src/core/errors.ts";
-import type { Registry } from "../../src/core/types.ts";
-import type { Client } from "../../src/core/client.ts";
+import { Registry, create, ecosystems, has, register } from "../../src/core/registry.ts";
+
+class TestRegistry extends Registry {
+  constructor(baseURL: string, client: Client) {
+    super();
+    this.baseURL = baseURL;
+    this.client = client;
+  }
+
+  readonly baseURL: string;
+  readonly client: Client;
+
+  ecosystem(): string {
+    return "test";
+  }
+
+  async fetchPackage() {
+    return {
+      name: "",
+      description: "",
+      homepage: "",
+      documentation: "",
+      repository: "",
+      licenses: "",
+      keywords: [],
+      namespace: "",
+      latestVersion: "",
+      metadata: {},
+    };
+  }
+
+  async fetchVersions() {
+    return [];
+  }
+
+  async fetchDependencies() {
+    return [];
+  }
+
+  async fetchMaintainers() {
+    return [];
+  }
+
+  urls() {
+    return {
+      registry: () => this.baseURL,
+      download: () => "",
+      documentation: () => "",
+      readme: () => "",
+      purl: () => "",
+    };
+  }
+}
 
 describe("registry", () => {
-  describe("register", () => {
-    it("registers an ecosystem", () => {
-      const mockFactory = (_baseURL: string, _client: Client): Registry => ({
-        ecosystem: () => "test-eco",
-        fetchPackage: async () => ({
-          name: "",
-          description: "",
-          homepage: "",
-          repository: "",
-          licenses: "",
-          keywords: [],
-          namespace: "",
-          latestVersion: "",
-          metadata: {},
-        }),
-        fetchVersions: async () => [],
-        fetchDependencies: async () => [],
-        fetchMaintainers: async () => [],
-        urls: () => ({
-          registry: () => "",
-          download: () => "",
-          documentation: () => "",
-          readme: () => "",
-          purl: () => "",
-        }),
-      });
+  it("should register a registry class", () => {
+    register("test", "https://register.example.com", TestRegistry);
 
-      register("test-eco", "https://test.example.com", mockFactory);
-      expect(has("test-eco")).toBe(true);
-    });
-
-    it("allows creating registry after registration", () => {
-      const mockFactory = (_baseURL: string, _client: Client): Registry => ({
-        ecosystem: () => "test-eco-2",
-        fetchPackage: async () => ({
-          name: "",
-          description: "",
-          homepage: "",
-          repository: "",
-          licenses: "",
-          keywords: [],
-          namespace: "",
-          latestVersion: "",
-          metadata: {},
-        }),
-        fetchVersions: async () => [],
-        fetchDependencies: async () => [],
-        fetchMaintainers: async () => [],
-        urls: () => ({
-          registry: () => "",
-          download: () => "",
-          documentation: () => "",
-          readme: () => "",
-          purl: () => "",
-        }),
-      });
-
-      register("test-eco-2", "https://test2.example.com", mockFactory);
-      const registry = create("test-eco-2");
-      expect(registry.ecosystem()).toBe("test-eco-2");
-    });
+    expect(has("test")).toBe(true);
   });
 
-  describe("create", () => {
-    it("creates registry for registered ecosystem", () => {
-      const mockFactory = (_baseURL: string, _client: Client): Registry => ({
-        ecosystem: () => "test-eco-3",
-        fetchPackage: async () => ({
-          name: "",
-          description: "",
-          homepage: "",
-          repository: "",
-          licenses: "",
-          keywords: [],
-          namespace: "",
-          latestVersion: "",
-          metadata: {},
-        }),
-        fetchVersions: async () => [],
-        fetchDependencies: async () => [],
-        fetchMaintainers: async () => [],
-        urls: () => ({
-          registry: () => "",
-          download: () => "",
-          documentation: () => "",
-          readme: () => "",
-          purl: () => "",
-        }),
-      });
+  it("should instantiate the registered class", () => {
+    register("test", "https://create.example.com", TestRegistry);
 
-      register("test-eco-3", "https://test3.example.com", mockFactory);
-      const registry = create("test-eco-3");
-      expect(registry).toBeDefined();
-      expect(registry.ecosystem()).toBe("test-eco-3");
-    });
-
-    it("throws UnknownEcosystemError for unregistered ecosystem", () => {
-      expect(() => create("nonexistent-ecosystem")).toThrow(UnknownEcosystemError);
-    });
-
-    it("throws UnknownEcosystemError with correct ecosystem name", () => {
-      try {
-        create("unknown-eco");
-        expect.fail("Should have thrown");
-      } catch (error) {
-        expect(error).toBeInstanceOf(UnknownEcosystemError);
-        if (error instanceof UnknownEcosystemError) {
-          expect(error.ecosystem).toBe("unknown-eco");
-        }
-      }
-    });
-
-    it("uses custom baseURL when provided", () => {
-      const mockFactory = (baseURL: string, _client: Client): Registry => ({
-        ecosystem: () => "test-eco-4",
-        fetchPackage: async () => ({
-          name: "",
-          description: "",
-          homepage: "",
-          repository: "",
-          licenses: "",
-          keywords: [],
-          namespace: "",
-          latestVersion: "",
-          metadata: {},
-        }),
-        fetchVersions: async () => [],
-        fetchDependencies: async () => [],
-        fetchMaintainers: async () => [],
-        urls: () => ({
-          registry: () => baseURL,
-          download: () => "",
-          documentation: () => "",
-          readme: () => "",
-          purl: () => "",
-        }),
-      });
-
-      register("test-eco-4", "https://default.example.com", mockFactory);
-      const registry = create("test-eco-4", "https://custom.example.com");
-      expect(registry.urls().registry()).toBe("https://custom.example.com");
-    });
-
-    it("uses default baseURL when not provided", () => {
-      const mockFactory = (baseURL: string, _client: Client): Registry => ({
-        ecosystem: () => "test-eco-5",
-        fetchPackage: async () => ({
-          name: "",
-          description: "",
-          homepage: "",
-          repository: "",
-          licenses: "",
-          keywords: [],
-          namespace: "",
-          latestVersion: "",
-          metadata: {},
-        }),
-        fetchVersions: async () => [],
-        fetchDependencies: async () => [],
-        fetchMaintainers: async () => [],
-        urls: () => ({
-          registry: () => baseURL,
-          download: () => "",
-          documentation: () => "",
-          readme: () => "",
-          purl: () => "",
-        }),
-      });
-
-      register("test-eco-5", "https://default.example.com", mockFactory);
-      const registry = create("test-eco-5");
-      expect(registry.urls().registry()).toBe("https://default.example.com");
-    });
+    const registry = create("test");
+    expect(registry).toBeInstanceOf(TestRegistry);
+    expect(registry.ecosystem()).toBe("test");
   });
 
-  describe("ecosystems", () => {
-    it("returns array of registered ecosystem names", () => {
-      const mockFactory = (_baseURL: string, _client: Client): Registry => ({
-        ecosystem: () => "test-eco-6",
-        fetchPackage: async () => ({
-          name: "",
-          description: "",
-          homepage: "",
-          repository: "",
-          licenses: "",
-          keywords: [],
-          namespace: "",
-          latestVersion: "",
-          metadata: {},
-        }),
-        fetchVersions: async () => [],
-        fetchDependencies: async () => [],
-        fetchMaintainers: async () => [],
-        urls: () => ({
-          registry: () => "",
-          download: () => "",
-          documentation: () => "",
-          readme: () => "",
-          purl: () => "",
-        }),
-      });
+  it("should use the default base URL", () => {
+    register("test", "https://default.example.com", TestRegistry);
 
-      register("test-eco-6", "https://test6.example.com", mockFactory);
-      const ecos = ecosystems();
-      expect(Array.isArray(ecos)).toBe(true);
-      expect(ecos).toContain("test-eco-6");
-    });
-
-    it("returns empty array when no ecosystems registered", () => {
-      // Note: This test may fail if other tests have registered ecosystems
-      // In a real test suite, you'd want to reset the registry between tests
-      const ecos = ecosystems();
-      expect(Array.isArray(ecos)).toBe(true);
-    });
+    expect(create("test").urls().registry("package")).toBe("https://default.example.com");
   });
 
-  describe("has", () => {
-    it("returns true for registered ecosystem", () => {
-      const mockFactory = (_baseURL: string, _client: Client): Registry => ({
-        ecosystem: () => "test-eco-7",
-        fetchPackage: async () => ({
-          name: "",
-          description: "",
-          homepage: "",
-          repository: "",
-          licenses: "",
-          keywords: [],
-          namespace: "",
-          latestVersion: "",
-          metadata: {},
-        }),
-        fetchVersions: async () => [],
-        fetchDependencies: async () => [],
-        fetchMaintainers: async () => [],
-        urls: () => ({
-          registry: () => "",
-          download: () => "",
-          documentation: () => "",
-          readme: () => "",
-          purl: () => "",
-        }),
-      });
+  it("should use a custom base URL", () => {
+    register("test", "https://default.example.com", TestRegistry);
 
-      register("test-eco-7", "https://test7.example.com", mockFactory);
-      expect(has("test-eco-7")).toBe(true);
-    });
-
-    it("returns false for unregistered ecosystem", () => {
-      expect(has("definitely-not-registered-ecosystem")).toBe(false);
-    });
-
-    it("is case-sensitive", () => {
-      const mockFactory = (_baseURL: string, _client: Client): Registry => ({
-        ecosystem: () => "test-eco-8",
-        fetchPackage: async () => ({
-          name: "",
-          description: "",
-          homepage: "",
-          repository: "",
-          licenses: "",
-          keywords: [],
-          namespace: "",
-          latestVersion: "",
-          metadata: {},
-        }),
-        fetchVersions: async () => [],
-        fetchDependencies: async () => [],
-        fetchMaintainers: async () => [],
-        urls: () => ({
-          registry: () => "",
-          download: () => "",
-          documentation: () => "",
-          readme: () => "",
-          purl: () => "",
-        }),
-      });
-
-      register("test-eco-8", "https://test8.example.com", mockFactory);
-      expect(has("test-eco-8")).toBe(true);
-      expect(has("TEST-ECO-8")).toBe(false);
-      expect(has("Test-Eco-8")).toBe(false);
-    });
+    expect(create("test", "https://custom.example.com").urls().registry("package")).toBe(
+      "https://custom.example.com",
+    );
   });
 
-  describe("integration", () => {
-    it("register, create, and has work together", () => {
-      const mockFactory = (_baseURL: string, _client: Client): Registry => ({
-        ecosystem: () => "integration-test-eco",
-        fetchPackage: async () => ({
-          name: "",
-          description: "",
-          homepage: "",
-          repository: "",
-          licenses: "",
-          keywords: [],
-          namespace: "",
-          latestVersion: "",
-          metadata: {},
-        }),
-        fetchVersions: async () => [],
-        fetchDependencies: async () => [],
-        fetchMaintainers: async () => [],
-        urls: () => ({
-          registry: () => "",
-          download: () => "",
-          documentation: () => "",
-          readme: () => "",
-          purl: () => "",
-        }),
-      });
+  it("should pass a custom client to the class", () => {
+    register("test", "https://client.example.com", TestRegistry);
+    const client = new Client();
 
-      // Before registration
-      expect(has("integration-test-eco")).toBe(false);
+    expect(create("test", undefined, client)).toMatchObject({ client });
+  });
 
-      // Register
-      register("integration-test-eco", "https://integration.example.com", mockFactory);
+  it("should list registered ecosystems", () => {
+    register("test", "https://ecosystems.example.com", TestRegistry);
 
-      // After registration
-      expect(has("integration-test-eco")).toBe(true);
+    expect(ecosystems()).toEqual(expect.arrayContaining(["test"]));
+  });
 
-      // Create
-      const registry = create("integration-test-eco");
-      expect(registry.ecosystem()).toBe("integration-test-eco");
+  it("should treat ecosystem names as case-sensitive", () => {
+    register("test", "https://case.example.com", TestRegistry);
 
-      // Verify in ecosystems list
-      expect(ecosystems()).toContain("integration-test-eco");
-    });
+    expect(has("test")).toBe(true);
+    expect(has("TEST")).toBe(false);
+  });
+
+  it("should throw for an unregistered ecosystem", () => {
+    expect(() => create("nonexistent-ecosystem")).toThrow(UnknownEcosystemError);
+  });
+
+  it("should include the ecosystem in an unknown-ecosystem error", () => {
+    expect(() => create("unknown-eco")).toThrow(
+      expect.objectContaining({ ecosystem: "unknown-eco" }),
+    );
   });
 });


### PR DESCRIPTION
One `Registry` base is enough. This replaces registry factory closures with concrete subclasses and keeps `create()` as the lookup path, with `CachedRegistry` on the same contract. It is intentionally breaking for custom registrations: `register()` now takes a class and `RegistryFactory` is gone.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oritwoen/regxa/pull/59?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

